### PR TITLE
Fixed connection refused error on hamlib cw

### DIFF
--- a/src/uCWKeying.pas
+++ b/src/uCWKeying.pas
@@ -664,7 +664,7 @@ end;
 constructor TCWHamLib.Create;
 begin
   fActive       := False;
-  fDebugMode    := True;
+  fDebugMode    := False;
   tcp           := TLTCPComponent.Create(nil);
   tcp.ReuseAddress:= True;
   tcp.OnReceive := @OnReceived;


### PR DESCRIPTION
Basically the TCWHamLib object must not go active until the OnConnect event fires. I have added the handling of this event as well as the OnError event in case something else goes wrong.

You may wish to handle similar handling of connection to the uRigControl and whatever else you have that uses TLTcpComponent. I think with the other things, you were just getting lucky that nothing was being sent until after the connection completed.

This PR, I hope you can use :+1: 