### PR TITLE
close rigs even if fTRXControl is not showing.

### DIFF
--- a/src/fNewQSO.pas
+++ b/src/fNewQSO.pas
@@ -1304,8 +1304,10 @@ begin
       frmTRXControl.Close;
       cqrini.WriteBool('Window','TRX',True)
     end
-    else
+    else begin
+      frmTRXControl.CloseRigs;
       cqrini.WriteBool('Window','TRX',False);
+    end;
 
     if frmRotControl.Showing then
     begin

--- a/src/fTRXControl.pas
+++ b/src/fTRXControl.pas
@@ -1043,7 +1043,11 @@ end;
 
 procedure TfrmTRXControl.CloseRigs;
 begin
+     if dmData.DebugLevel > 0  then
+        System.WriteLn('Closing rigs .. ');
 
+     if Assigned(radio) then
+        FreeAndNil(radio);
 end;
 
 procedure TfrmTRXControl.UpdateModeButtons(mode : String);


### PR DESCRIPTION
Filled in the CloseRigs function in fTRXControl.pas so that it will FreeAndNil the radio object.

This triggers the rig control destructor, which ensures that rigctld will be properly shut down, even if the TRXControl form is never opened by the user.

Added a call to CloseRigs when closing the windows manually in fNewQSO.pas to tie it all to the program's exit point.