### PR TITLE
fixed: bug in ADIF export

### DIFF
--- a/src/fExportProgress.pas
+++ b/src/fExportProgress.pas
@@ -323,7 +323,7 @@ var
     begin
       if Length(QSLS) > 0 then
       begin
-        if Pos('S',QSLS) > 1 then
+        if Pos('S',QSLS) > 0 then
           tmp := '<QSL_SENT' + dmUtils.StringToADIF('R')
         else
           tmp := '<QSL_SENT' + dmUtils.StringToADIF('Y')


### PR DESCRIPTION
If a QSL sent status with "S" was selected, the ADIF-export has produced
<QSL_SENT:1>N instead of <QSL_SENT:1>R