### PR TITLE
Do not use a hardcoded icon name in the desktop file

### DIFF
--- a/tools/cqrlog.desktop
+++ b/tools/cqrlog.desktop
@@ -4,7 +4,7 @@ Comment=Advanced logging program for hamradio operators
 Exec=cqrlog
 Terminal=false
 Type=Application
-Icon=cqrlog.png
+Icon=cqrlog
 Categories=Utility;Database;HamRadio
 Keywords=Ham;Radio;Log;
 


### PR DESCRIPTION
This allows use of custom icons and fixes some other issues.