### PR TITLE
Add AppStream appdata file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,7 @@ install:
 	install -d -v         $(sharedir)/pixmaps/cqrlog
 	install -d -v         $(sharedir)/icons/cqrlog
 	install -d -v         $(sharedir)/applications
+	install -d -v         $(sharedir)/appdata
 	install -d -v         $(sharedir)/man/man1
 	install    -v -m 0755 src/cqrlog $(bindir)
 	install    -v -m 0755 tools/cqrlog-apparmor-fix $(datadir)/cqrlog-apparmor-fix
@@ -59,6 +60,7 @@ install:
 #	install    -v -m 0644 images/icon/256x256/*   $(datadir)/images/icon/256x256/
 #	install    -v -m 0644 images/*   $(datadir)/images/
 	install    -v -m 0644 tools/cqrlog.desktop $(sharedir)/applications/cqrlog.desktop
+	install    -v -m 0644 tools/cqrlog.appdata.xml $(sharedir)/appdata/cqrlog.appdata.xml
 	install    -v -m 0644 images/icon/32x32/cqrlog.png $(sharedir)/pixmaps/cqrlog/cqrlog.png
 	install    -v -m 0644 images/icon/128x128/cqrlog.png $(sharedir)/icons/cqrlog.png
 	install    -v -m 0644 src/changelog.html $(datadir)/changelog.html

--- a/tools/cqrlog.appdata.xml
+++ b/tools/cqrlog.appdata.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2017 Daniel Rusek <mail@asciiwolf.com> -->
+<component type="desktop">
+  <id>cqrlog.desktop</id>
+  <project_license>GPL-2.0</project_license>
+  <metadata_license>CC0-1.0</metadata_license>
+  <name>CQRLOG</name>
+  <summary>Advanced logging program for hamradio operators</summary>
+  <description>
+    <p>
+    CQRLOG is an advanced ham radio logger based on MySQL embedded database. Provides radio control based on hamlib libraries
+    (currently support of 140+ radio types and models), DX cluster connection, HamQTH/QRZ callbook (XML access), a grayliner,
+    internal QSL manager database support and a most accurate country resolution algorithm based on country tables developed
+    by OK1RR. CQRLOG is intended for daily general logging of HF, CW &amp; SSB contacts and strongly focused on easy operation
+    and maintenance.
+    </p>
+  </description>
+  <url type="homepage">https://www.cqrlog.com/</url>
+  <update_contact>mail@asciiwolf.com</update_contact>
+</component>


### PR DESCRIPTION
AppStream is a cross-distro XML format to provide metadata for software components and to assign unique identifiers to software. The metadata can for example be used by software centers like GNOME Software or KDE Discover to display a user-friendly application-centric way on the package archive.

This PR adds an AppStream AppData file.