### PR TITLE
CQ-monitor:  More informative colors. Fixed missing 'All' checkbox. 

### DIFF
--- a/README.OH1KH
+++ b/README.OH1KH
@@ -240,3 +240,12 @@
        Found out that double click on CQ-monitor line now initiates qso when FT8 is in use.
        Assume that it happens also with MSK144 as this fix is happened because new wsjtx version has 
        corrected UDP message.								(2.0.5.039)
+
+27.07.2017
+
+     - More informative CQ-monitor by colours of callsign.
+       Red lowcase   = worked this band and mode
+       Fuchsia upcase = worked this band, but not this mode
+       Maroon upcase = worked on any other band and mode
+       Green upcase  = never worked before on any band       
+                                                                              (2.0.5.(040))

--- a/src/fMonWsjtx.lfm
+++ b/src/fMonWsjtx.lfm
@@ -139,4 +139,15 @@ object frmMonWsjtx: TfrmMonWsjtx
     BorderSpacing.Top = 2
     TabOrder = 4
   end
+  object chkmyAll: TCheckBox
+    AnchorSideLeft.Control = chkmyAlert
+    AnchorSideLeft.Side = asrBottom
+    AnchorSideTop.Control = chkmyAlert
+    Left = 87
+    Height = 23
+    Top = 292
+    Width = 43
+    Caption = 'All'
+    TabOrder = 5
+  end
 end


### PR DESCRIPTION
Missing "All" checkbox.   See README.OH1KH at 08.06.2017 for details.

Added more colors to callsigns to tell about worked before status. See README.OH1KH (the end of it) 
