### PR TITLE
Changes to CQ-monitor:See README.OH1KH

### DIFF
--- a/README.OH1KH
+++ b/README.OH1KH
@@ -264,4 +264,38 @@
      - Faster wsjtx-decode (fNewQso.pas) Better now for FT8 cq-monitoring.
      - New SQL routines for CQ-monitor information fetch (fWorkedGrids.pas)    
                                                                                  (2.0.5.041)
+08.09.2017
+
+   - CQ-monitor now remembers showing state. I.E if closed while last wsjtxremote use will be closed on next
+     program start and wsjtxremote initiate.
+								(2.1.0(116))
+
+11.09.2017
+   - more study with richmemo slowness when on for long time. This does not solve the original problem that
+     exists (now 99% sure) at richmemo/lazarus code.
+     Now CQ-monitor form is created at the time it is needed (opened), not at program start.
+     When wsjt-remote is closed it will also distroy CQ-monitor form.(releases memory used by richmemo, too)
+     Closing CQ-monitor while wsjt-remote stays still on does not distroy form.
+     This way slowness (CPU load while richmemo printing) can be resolved without closing wsjtx & cqrlog.
+
+     Just drop wsjt-remote off and start it again! Slowness (and CPUload) has gone !
+
+     With this change richmemo slow printing changed so that lines are not slowly dropping. They appear fast,
+     but time between wsjt-x decode end and lines appearing to CQ-monitor increases. It is harder to notice,
+     but opening a terimal with "top -H -p $(pidof cqrlog) -d 0,2" you can easily find out when CPU load
+     starts to stay >90% while decoding
+								(2.1.0(117))
+20.09.2017
+   - CQ-monitor:  Country names (cut to length 15) are now displayed instead of callsign prefixes.
+     Extended CQs (CQ DX, CQ AS, CQ AF .. etc) are now compared against own continent. If "CQ DX" caller
+     callsign is from same continent as your call a "*" is added in front of country name and it is printed
+     with "CQ ext" color defined.
+     Same if "CQ AS" is called and your continent is not AS, and so on.
+     If continent cannot be compaired (CQ extension is something special) same "*" and "CQ ext" color is used.
+     This is to notify you to consider if answering follows good working practise and ham spirit rules.
+   - "My Alert" is now compared oppsite way: First word of decoded line is compared against your cqrlog/
+     preferences/station callsign. This should fit now also when you are using extended callsign XX/YOURCALL or
+     YOURCALL/XX in your log as wsjt-x traffic uses always plain callsigns during qsos.
+								(2.1.0(118))
+
                                                                                  

--- a/src/cqrlog.lpr
+++ b/src/cqrlog.lpr
@@ -68,7 +68,7 @@ begin
   Application.CreateForm(TfrmReminder, frmReminder);
   Application.CreateForm(TfrmContest, frmContest);
   Application.CreateForm(Tfrmxfldigi, frmxfldigi);
-  Application.CreateForm(TfrmMonWsjtx, frmMonWsjtx);
+
 
   Splash.Update;
   application.ProcessMessages;


### PR DESCRIPTION
This (2.1.0-118 in my version count) has been running ok here and I have not received any bugreports from elsewhere either.
Still this does not completely resolve CPU load caused by richmemo when monitor has been on for several hours. There must be something in the units code itself.

Question1: Why we create so many forms at program start?
Some of them must be created, but some could be created only when/if needed. ( to decrease memory usage)

Question2: You use "InitCriticalSection" on several places. If I understood its function description right it should be initiated only once at main form. After that all critical sections should use that initilalization to completely halt any other parts of program running while code is in critical section. Am I wrong?
