### PR TITLE
DXChat now defaulting invisible

### DIFF
--- a/src/fDXCluster.lfm
+++ b/src/fDXCluster.lfm
@@ -1,13 +1,13 @@
 object frmDXCluster: TfrmDXCluster
-  Left = 702
-  Height = 367
-  Top = 436
+  Left = 129
+  Height = 445
+  Top = 116
   Width = 709
   HelpType = htKeyword
   HelpKeyword = 'help/h21.html#ah19'
   ActiveControl = pgDXCluster
   Caption = 'DXCluster'
-  ClientHeight = 367
+  ClientHeight = 445
   ClientWidth = 709
   Icon.Data = {
     BE0C00000000010001002020000001001800A80C000016000000280000002000
@@ -124,7 +124,7 @@ object frmDXCluster: TfrmDXCluster
   LCLVersion = '1.6.4.0'
   object pgDXCluster: TPageControl
     Left = 0
-    Height = 367
+    Height = 445
     Top = 0
     Width = 709
     ActivePage = tabTelnet
@@ -133,16 +133,16 @@ object frmDXCluster: TfrmDXCluster
     TabOrder = 0
     object tabWeb: TTabSheet
       Caption = 'Web'
-      ClientHeight = 336
-      ClientWidth = 705
+      ClientHeight = 416
+      ClientWidth = 699
       object Panel4: TPanel
         Left = 0
         Height = 36
-        Top = 152
-        Width = 560
+        Top = 365
+        Width = 699
         Align = alBottom
         ClientHeight = 36
-        ClientWidth = 560
+        ClientWidth = 699
         TabOrder = 0
         object lblInfo: TLabel
           Left = 10
@@ -152,9 +152,9 @@ object frmDXCluster: TfrmDXCluster
           ParentColor = False
         end
         object btnWebConnect: TButton
-          Left = 471
+          Left = 610
           Height = 25
-          Top = 6
+          Top = 8
           Width = 84
           Anchors = [akTop, akRight]
           BorderSpacing.InnerBorder = 4
@@ -163,7 +163,7 @@ object frmDXCluster: TfrmDXCluster
           TabOrder = 0
         end
         object btnClear: TButton
-          Left = 389
+          Left = 528
           Height = 25
           Top = 6
           Width = 75
@@ -185,7 +185,7 @@ object frmDXCluster: TfrmDXCluster
           Visible = False
         end
         object btnFont: TButton
-          Left = 309
+          Left = 448
           Height = 25
           Top = 6
           Width = 75
@@ -197,9 +197,9 @@ object frmDXCluster: TfrmDXCluster
       end
       object pnlWeb: TPanel
         Left = 0
-        Height = 152
+        Height = 365
         Top = 0
-        Width = 560
+        Width = 699
         Align = alClient
         Alignment = taLeftJustify
         BevelInner = bvLowered
@@ -215,31 +215,31 @@ object frmDXCluster: TfrmDXCluster
     end
     object tabTelnet: TTabSheet
       Caption = 'Telnet'
-      ClientHeight = 336
-      ClientWidth = 705
+      ClientHeight = 416
+      ClientWidth = 699
       object Panel1: TPanel
         Left = 0
         Height = 34
-        Top = 302
-        Width = 705
+        Top = 382
+        Width = 699
         Align = alBottom
         BevelOuter = bvNone
         ClientHeight = 34
-        ClientWidth = 705
+        ClientWidth = 699
         TabOrder = 0
         object Label1: TLabel
           Left = 6
-          Height = 17
+          Height = 15
           Top = 11
-          Width = 74
+          Width = 71
           Caption = 'Command:'
           ParentColor = False
         end
         object edtCommand: TEdit
           AnchorSideLeft.Control = Label1
           AnchorSideLeft.Side = asrBottom
-          Left = 82
-          Height = 27
+          Left = 79
+          Height = 32
           Top = 3
           Width = 266
           BorderSpacing.Left = 2
@@ -248,7 +248,7 @@ object frmDXCluster: TfrmDXCluster
         end
         object Button1: TButton
           AnchorSideLeft.Side = asrBottom
-          Left = 616
+          Left = 610
           Height = 25
           Top = 3
           Width = 85
@@ -259,7 +259,7 @@ object frmDXCluster: TfrmDXCluster
           TabOrder = 1
         end
         object Button2: TButton
-          Left = 328
+          Left = 528
           Height = 25
           Top = -8
           Width = 75
@@ -268,20 +268,38 @@ object frmDXCluster: TfrmDXCluster
           TabOrder = 2
           Visible = False
         end
+        object trChatSize: TTrackBar
+          AnchorSideLeft.Control = edtCommand
+          AnchorSideTop.Control = Panel1
+          AnchorSideTop.Side = asrCenter
+          AnchorSideBottom.Side = asrBottom
+          Left = 79
+          Height = 52
+          Top = -9
+          Width = 263
+          Max = 100
+          Min = 2
+          OnChange = trChatSizeChange
+          Position = 20
+          ScalePos = trLeft
+          OnClick = trChatSizeClick
+          TabOrder = 3
+          Visible = False
+        end
       end
       object Panel2: TPanel
         Left = 0
         Height = 30
         Top = 0
-        Width = 705
+        Width = 699
         Align = alTop
         BevelOuter = bvNone
         ClientHeight = 30
-        ClientWidth = 705
+        ClientWidth = 699
         TabOrder = 1
         object edtTelAddress: TEdit
           Left = 8
-          Height = 27
+          Height = 32
           Top = 1
           Width = 189
           TabOrder = 0
@@ -318,14 +336,27 @@ object frmDXCluster: TfrmDXCluster
       end
       object pnlTelnet: TPanel
         Left = 0
-        Height = 272
+        Height = 352
         Top = 30
-        Width = 705
+        Width = 699
         Align = alClient
         BevelOuter = bvNone
+        ClientHeight = 352
+        ClientWidth = 699
         Color = clWhite
         ParentColor = False
         TabOrder = 2
+        object pnlChat: TPanel
+          Left = 0
+          Height = 2
+          Top = 0
+          Width = 699
+          Align = alTop
+          BevelOuter = bvNone
+          Color = 13890552
+          ParentColor = False
+          TabOrder = 0
+        end
       end
     end
   end
@@ -364,6 +395,10 @@ object frmDXCluster: TfrmDXCluster
     object MenuItem2: TMenuItem
       Caption = '-'
     end
+    object MenuItem6: TMenuItem
+      Action = acChatSize
+      Caption = 'Chat Size'
+    end
     object MenuItem3: TMenuItem
       Action = acFont
     end
@@ -388,6 +423,10 @@ object frmDXCluster: TfrmDXCluster
     object acProgPref: TAction
       Caption = 'Preferences'
       OnExecute = acProgPrefExecute
+    end
+    object acChatSize: TAction
+      Caption = 'acChatSize'
+      OnExecute = acChatSizeExecute
     end
   end
 end

--- a/src/fDXCluster.pas
+++ b/src/fDXCluster.pas
@@ -18,7 +18,7 @@ interface
 uses
   Classes, SysUtils, LResources, Forms, Controls, Graphics, Dialogs, inifiles,
   ExtCtrls, ComCtrls, StdCtrls, Buttons, httpsend, uColorMemo,
-  db, lcltype, Menus, ActnList, dynlibs, lNetComponents, lnet;
+  db, lcltype, Menus, ActnList, Spin, dynlibs, lNetComponents, lnet;
 
 type
   { TfrmDXCluster }
@@ -28,6 +28,7 @@ type
     acFont : TAction;
     acCallAlert : TAction;
     acProgPref : TAction;
+    acChatSize: TAction;
     btnClear: TButton;
     btnFont: TButton;
     btnHelp: TButton;
@@ -47,9 +48,11 @@ type
     MenuItem3 : TMenuItem;
     MenuItem4 : TMenuItem;
     MenuItem5 : TMenuItem;
+    MenuItem6: TMenuItem;
     mnuCallalert : TMenuItem;
     Panel1: TPanel;
     Panel2: TPanel;
+    pnlChat: TPanel;
     Panel4: TPanel;
     pgDXCluster: TPageControl;
     pnlTelnet: TPanel;
@@ -59,7 +62,9 @@ type
     tabWeb: TTabSheet;
     tmrAutoConnect: TTimer;
     tmrSpots: TTimer;
+    trChatSize: TTrackBar;
     procedure acCallAlertExecute(Sender : TObject);
+    procedure acChatSizeExecute(Sender: TObject);
     procedure acFontExecute(Sender : TObject);
     procedure acProgPrefExecute(Sender : TObject);
     procedure Button2Click(Sender: TObject);
@@ -79,6 +84,8 @@ type
     procedure mnuCallalertClick(Sender : TObject);
    procedure tmrAutoConnectTimer(Sender: TObject);
     procedure tmrSpotsTimer(Sender: TObject);
+    procedure trChatSizeChange(Sender: TObject);
+    procedure trChatSizeClick(Sender: TObject);
   private
     telDesc    : String;
     telAddr    : String;
@@ -134,6 +141,7 @@ type
     procedure ConnectToTelnet;
     procedure SynWeb;
     procedure SynTelnet;
+    procedure SynChat;
     procedure lConnect(aSocket: TLSocket);
     procedure lDisconnect(aSocket: TLSocket);
     procedure lReceive(aSocket: TLSocket);
@@ -171,13 +179,17 @@ type
 var
   frmDXCluster : TfrmDXCluster;
   Spots        : TStringList;
+  Chats        : TStringList;
   WebSpots     : TColorMemo;
   TelSpots     : TColorMemo;
+  ChatSpots    : TColorMemo;
   mindex       : Integer;
   ThInfo       : String;
   ThSpot       : String;
   ThColor      : Integer;
   ThBckColor   : Integer;
+  ThChat       : String;
+  ChBckColor   : Integer;
   TelThread    : TTelThread;
 
 implementation
@@ -357,13 +369,25 @@ begin
     cqrini.WriteString('DXCluster','Font',dlgDXfnt.Font.Name);
     cqrini.WriteInteger('DXCluster','FontSize',dlgDXfnt.Font.Size);
     WebSpots.SetFont(dlgDXfnt.Font);
-    TelSpots.SetFont(dlgDXfnt.Font)
+    TelSpots.SetFont(dlgDXfnt.Font);
+    ChatSpots.SetFont(dlgDXfnt.Font)
   end
 end;
 
 procedure TfrmDXCluster.acCallAlertExecute(Sender : TObject);
 begin
   frmPreferences.btnAlertCallsignsClick(nil)
+end;
+
+procedure TfrmDXCluster.acChatSizeExecute(Sender: TObject);
+begin
+       trChatSize.Max :=   pnlTelnet.Height -20;
+       trChatSize.Position := pnlChat.Height;
+       trChatSize.Visible :=true;
+       trChatSize.Cursor := crSizeWE;
+       edtCommand.Visible := false;
+       label1.Caption := 'ChatSize';
+       if dmData.DebugLevel >=1 then Writeln('Chat sizing AC');
 end;
 
 procedure TfrmDXCluster.FormCreate(Sender: TObject);
@@ -395,8 +419,19 @@ begin
   TelSpots.Align       := alClient;
   TelSpots.setLanguage(1);
 
+  ChBckColor  := $00D3F3F8;
+  pnlChat.Color := ChBckColor;
+  ChatSpots             := TColorMemo.Create(pnlChat);
+  ChatSpots.parent      := pnlChat;
+  ChatSpots.autoscroll  := True;
+  ChatSpots.Align       := alClient;
+  ChatSpots.setLanguage(1);
+
   Spots := TStringList.Create;
   Spots.Clear;
+  Chats := TStringList.Create;
+  Chats.Clear;
+
   Running := False;
   mindex  := 1;
 
@@ -502,7 +537,8 @@ begin
     f.Name    := cqrini.ReadString('DXCluster','Font','DejaVu Sans Mono');
     f.Size    := cqrini.ReadInteger('DXCluster','FontSize',12);
     WebSpots.SetFont(f);
-    TelSpots.SetFont(f)
+    TelSpots.SetFont(f) ;
+    ChatSpots.SetFont(f)
   finally
     f.Free
   end;
@@ -521,7 +557,8 @@ begin
   ChangeCallAlertCaption;
 
   if cqrini.ReadBool('DXCluster', 'ConAfterRun', False) then
-    tmrAutoConnect.Enabled := True
+    tmrAutoConnect.Enabled := True;
+  pnlChat.Height := cqrini.ReadInteger('DXCluster','ChatSize',2);  //default now 2 = invisible
 end;
 
 procedure TfrmDXCluster.btnClearClick(Sender: TObject);
@@ -653,7 +690,7 @@ const
   LF = #10;
 var
   sStart, sStop: Integer;
-  tmp : String;
+  tmp, Chline: String;
   itmp : Integer;
   buffer : String;
   f : Double;
@@ -669,13 +706,40 @@ begin
     tmp  := Copy(Buffer, sStart, sStop - sStart);
     tmp  := trim(tmp);
     if dmData.DebugLevel >=1 then Writeln(tmp);
+
+    if Pos(UpperCase(telUser) + ' DE', UpperCase(tmp)) > 0 then
+      Begin
+        ChLine := tmp;
+        if dmData.DebugLevel>=1 then Writeln('pos: ', pos('>',Chline) ,' len:', length(Chline));
+        if pos('>',Chline) < length(Chline) then //if not dxcluster prompt
+         Begin //remove "mycall de" add local timestamp from PC
+           itmp := length(telUser)+4; //4 = ' DE '
+           ChLine := FormatDateTime('hh:nn',Now)+'_'+copy(Chline,itmp+1,length(Chline)-itmp);
+           if dmData.DebugLevel>=1 then Writeln('Chat :',ChLine);
+           EnterCriticalsection(frmDXCluster.csTelnet);
+           if dmData.DebugLevel>=1 then Writeln('Enter critical section On Receive Chat');
+           try
+            Chats.Add(Chline);
+           finally
+            LeaveCriticalsection(csTelnet);
+            if dmData.DebugLevel>=1 then Writeln('Leave critical section On Receive Chat')
+           end
+         end
+        else
+        Begin
+          Chline := '';
+          if dmData.DebugLevel>=1 then Writeln('Chat : line is cluster prompt!');
+        end;
+      end;
+
     itmp := Pos('DX DE',UpperCase(tmp));
     if (itmp > 0) or TryStrToFloat(copy(tmp,1,Pos(' ',tmp)-1),f)  then
     begin
       EnterCriticalsection(frmDXCluster.csTelnet);
       if dmData.DebugLevel>=1 then Writeln('Enter critical section On Receive');
       try
-        Spots.Add(tmp)
+        Spots.Add(tmp);
+        if Chline <> '' then Chats.Add(Chline);
       finally
         LeaveCriticalsection(csTelnet);
         if dmData.DebugLevel>=1 then Writeln('Leave critical section On Receive')
@@ -715,6 +779,22 @@ procedure TfrmDXCluster.tmrSpotsTimer(Sender: TObject);
 begin
   if pgDXCluster.ActivePageIndex = 0 then
     ConnectToWeb;
+end;
+
+procedure TfrmDXCluster.trChatSizeChange(Sender: TObject);
+begin
+     pnlChat.Height := trChatSize.Position;
+end;
+
+procedure TfrmDXCluster.trChatSizeClick(Sender: TObject);
+begin
+      trChatSize.Visible := false;
+      trChatSize.Cursor :=  crDefault;
+      edtCommand.Visible := true;
+      label1.Caption := 'Command:';
+      cqrini.WriteInteger('DXCluster','ChatSize',trChatSize.Position);
+      pnlChat.Height := trChatSize.Position;
+      if dmData.DebugLevel >=1 then Writeln('Chat sizing Click');
 end;
 
 function TfrmDXCluster.GetFreq(spot : String) : String;
@@ -1202,6 +1282,24 @@ begin
         if dmData.DebugLevel>=1 then Writeln('TelThread.Execute - after Synchronize(@frmDXCluster.SynTelnet)')
       end
     end;
+
+    while Chats.Count > 0 do
+    begin
+      if dmData.DebugLevel>=2 then Writeln('TelThread.Execute - enter critical section Chat ');
+      EnterCriticalsection(frmDXCluster.csTelnet);
+      try
+        ThChat := Trim(Chats.Strings[0]);
+        Chats.Delete(0)
+      finally
+        LeaveCriticalsection(frmDXCluster.csTelnet);
+        if dmData.DebugLevel>=2 then Writeln('TelThread.Execute - leave critical section Chat ');
+      end;
+      if dmData.DebugLevel >= 2 then Writeln('Chat: ',ThChat);
+      if dmData.DebugLevel>=1 then Writeln('TelThread.Execute - before Synchronize(@frmDXCluster.SynChat)');
+      Synchronize(@frmDXCluster.SynChat);
+      if dmData.DebugLevel>=1 then Writeln('TelThread.Execute - after Synchronize(@frmDXCluster.SynChat)')
+    end;
+
     sleep(500)
   end
 end;
@@ -1398,6 +1496,19 @@ begin
   //if dmData.DebugLevel>=1 then Writeln('TfrmDXCluster.SynTelnet - before PridejVetu ');
   //if dmData.DebugLevel>=1 then Writeln('TfrmDXCluster.SynTelnet - after zakaz_kresleni');
   //Sleep(200)
+end;
+procedure TfrmDXCluster.SynChat;
+begin
+
+  if ThChat = '' then
+    exit;
+
+  if ConTelnet then
+  begin
+    ChatSpots.DisableAutoRepaint(true);
+    ChatSpots.AddLine(ThChat,clBlack,ChBckColor,0);
+    ChatSpots.DisableAutoRepaint(false)
+  end;
 end;
 
 procedure TfrmDXCluster.ReloadSettings;


### PR DESCRIPTION
Shall we try this again once more?

Default height is 2px, so you never know it is there if you do not change height. (test compile and run as test user is done)
It is now long time tested and works ok. And it is handy if you use chatting when connected to telnet dxcluster. Otherwise it has no use, but does not do any harm either.

I have saved old .lfm and .pas files. 

If you say NO, I'll push them back (they will show up as new files on  next pull request, but there is no other way to roll back once done pull request, I have understood...)
----------------------------------
I have still queued:
-Wsjtx-CQ-monitor alert changes (needs some testing more before pull)
-Edited help-folder. I have moved chapters from my PDF to html for help-folder.
The folder content is little confusing, done with some kind of non WySiWyg help tool, maybe? 
Perhaps complete redesign with LibreOffice5 and then conversion to PDF, that most browsers can read "out of box", could give nice format and leftside catalog. But it is a bigger job.