### PR TITLE
Remote loggings fixes

### DIFF
--- a/src/CHANGELOG
+++ b/src/CHANGELOG
@@ -3,6 +3,10 @@ Legend:
   + new feature
   - bugfix
 --------------------
+2.2.0 (2017-01-27)
+  - all remote loggings keep "qso_dxcc" boolean false
+  - wsjtx logging take start and stop times to log (before just stop time)
+  - fldigi remote socket checking fixed
 
 2.2.0 (2017-30-12)
   + wsjt remote mode improvements (Saku, OH1KH)

--- a/src/fXfldigi.lfm
+++ b/src/fXfldigi.lfm
@@ -1,7 +1,7 @@
 object frmxfldigi: Tfrmxfldigi
-  Left = 435
+  Left = 39
   Height = 193
-  Top = 58
+  Top = 15
   Width = 347
   Caption = 'frmxfldigi'
   ClientHeight = 193


### PR DESCRIPTION

- all remote loggings (fldigi, fldigi-xmlrpc, wsjt-x) keep "qso_dxcc" boolean false by setting old_call:="" and old_adif:=adif before save.
- wsjtx logging take start and stop times to log (before just stop time. UDP format changed since cqrlog 1.9.0)
- fldigi remote socket checking fixed (checked status after freeing socket, not ok)