### PR TITLE
Bugfix: CWtype/letter mode: a .. z double keying (while A .. Z were ok)

### DIFF
--- a/src/CHANGELOG
+++ b/src/CHANGELOG
@@ -4,6 +4,7 @@ Legend:
   - bugfix
 --------------------
 2.3.0
+  - CWtype/letter mode: doubling a .. z removed (Saku, OH1KH)
   + Cq-monitor: Overtimed entries turn silvergray in Follow and "no history" (Saku, OH1KH)
   + Band selector to Filter windows added (Saku, OH1KH)
   + CQ-monitor Delta Freqyency instead of Time when "no history" checked (Saku, OH1KH)

--- a/src/fCWType.pas
+++ b/src/fCWType.pas
@@ -88,22 +88,24 @@ var
   tmp   : String = '';
   i     : Integer = 0;
   mess  : String = '';
+  CWkey : char;
 begin
-  if key <> '' then
-    key := UpperCase(key)[1];
-  if (key in ['A'..'Z']) or (key in ['0'..'9']) or (key = '=') or
-   (key = '?') or (key = ',') or (key='.') or (key='/') or (key = ' ') or
-   (key = '<') or (key = '>') or (key = ':') or (key = ')') or (key = '(') or
-   (key = ';') or (key = '@') or (key = 'ß') or (key ='Ü') or (key ='Ö') or
-   (key = 'Ä') then
+  CWkey :=key;
+  if CWkey <> '' then
+    CWkey := UpperCase(CWkey)[1];
+  if (CWkey in ['A'..'Z']) or (CWkey in ['0'..'9']) or (CWkey = '=') or
+   (CWkey = '?') or (CWkey = ',') or (CWkey='.') or (CWkey='/') or (CWkey = ' ') or
+   (CWkey = '<') or (CWkey = '>') or (CWkey = ':') or (CWkey = ')') or (CWkey = '(') or
+   (CWkey = ';') or (CWkey = '@') or (CWkey = 'ß') or (CWkey ='Ü') or (CWkey ='Ö') or
+   (CWkey = 'Ä') then
   begin
     if rgMode.ItemIndex = 0 then //letter mode
-      frmNewQSO.CWint.SendText(key)
+      frmNewQSO.CWint.SendText(CWkey)
     else begin                   //word mode
       if (Pos(' ',m.Text) = 0) and (rgMode.ItemIndex=1) then  //fist word is send character by character
-        frmNewQSO.CWint.SendText(key)
+        frmNewQSO.CWint.SendText(CWkey)
       else begin
-        if (key = ' ') then
+        if (CWkey = ' ') then
         begin
           tmp := '';
           mess := m.Text;


### PR DESCRIPTION
Simple, but test it before release.
It should not break anything even if it was working for you with previous code, too.
Works here now ok.