### PR TITLE
Improvements to wsjtx

### DIFF
--- a/help/wsjt.html
+++ b/help/wsjt.html
@@ -90,6 +90,7 @@ Checking <b>“flw”</b> new part of monitor opens. This will make easier to fo
  </br>Alerts are not connected  to this line. Follow and flw states and callsing are saved over program restart.
  </br>Line color turns silver gray from default color (black) when corresponding response period is over.
  </br>This will make easier to follow a DX who does not stay same frequency and jumps around answering to callers.
+ </br>Double click on followed line loads Std messages to wsjt-x (but does not fire TX). This works with Wsjt-x 1.9.0-rc3 and up. 
  </br>
  </br>CQ-monitor has known problem of color printing (richmemo unit) that causes CPU load to grow slowly during online hours. For so far solution for this  has not been found.
  </br>

--- a/src/fMonWsjtx.lfm
+++ b/src/fMonWsjtx.lfm
@@ -10,7 +10,7 @@ object frmMonWsjtx: TfrmMonWsjtx
   OnCreate = FormCreate
   OnHide = FormHide
   OnShow = FormShow
-  LCLVersion = '1.8.0.6'
+  LCLVersion = '1.8.2.0'
   object lblBand: TLabel
     AnchorSideLeft.Control = Owner
     AnchorSideTop.Control = Owner
@@ -247,6 +247,7 @@ object frmMonWsjtx: TfrmMonWsjtx
       Anchors = [akTop, akLeft, akRight]
       BorderSpacing.Left = 3
       BorderSpacing.Right = 3
+      OnDblClick = edtFollowDblClick
       ReadOnly = True
       TabOrder = 1
     end

--- a/src/fMonWsjtx.pas
+++ b/src/fMonWsjtx.pas
@@ -54,6 +54,7 @@ type
     procedure EditAlertExit(Sender: TObject);
     procedure edtFollowCallEnter(Sender: TObject);
     procedure edtFollowCallExit(Sender: TObject);
+    procedure edtFollowDblClick(Sender: TObject);
     procedure FormClose(Sender: TObject; var CloseAction: TCloseAction);
     procedure FormCreate(Sender: TObject);
     procedure FormHide(Sender: TObject);
@@ -107,6 +108,7 @@ var
   EditedText         : string;                  //holds editAlert after finished (loose focus)
   Ssearch,Sfull      : String;
   Spos               : integer;
+  RepFlw             : String [255];            //reply in case of follow line double click
 
 
 implementation
@@ -257,7 +259,20 @@ begin
   cqrini.WriteString('MonWsjtx','FollowCall',edtFollowCall.Text);
 end;
 
+procedure TfrmMonWsjtx.edtFollowDblClick(Sender: TObject);
+var
+   reply : string;
+begin
+  if dmData.DebugLevel>=1 then Writeln('Clicked follow line gives: ',RepFlw);
+  reply := RepFlw;
 
+  if (length(reply) > 11 ) and (reply[12] = #$02) then //we should have proper reply
+               Begin
+                reply[12] := #$04;    //quick hack: change message type from 2 to 4
+                if dmData.DebugLevel>=1 then Writeln('Changed message type from 2 to 4. Sending...');
+                frmNewQSO.Wsjtxsock.SendString(reply);
+               end;
+end;
 
 procedure TfrmMonWsjtx.cmBandClick(Sender: TObject);
 begin
@@ -431,6 +446,7 @@ begin
                   edtFollow.Font.Color := clSilver;
   end;
 
+
 procedure TfrmMonWsjtx.cmCqDxClick(Sender: TObject);
 begin
        popColorDlg.Color:=extCqCall;
@@ -572,6 +588,7 @@ Begin
   tmrFollow.Enabled:=false;
   edtFollow.Font.Color := clDefault;
   edtFollow.Text := Message;
+  RepFlw := Reply;
    if ((lblMode.Caption ='FT8') or (lblMode.Caption ='MSK144')) then
     tmrFollow.Interval:= 15500
    else

--- a/src/fNewQSO.lfm
+++ b/src/fNewQSO.lfm
@@ -1,12 +1,12 @@
 object frmNewQSO: TfrmNewQSO
-  Left = 469
+  Left = 65
   Height = 659
-  Top = 116
+  Top = 114
   Width = 807
   HelpType = htKeyword
   HelpKeyword = 'help/index.html'
   Caption = 'New QSO ... (CQRLOG for Linux)'
-  ClientHeight = 659
+  ClientHeight = 636
   ClientWidth = 807
   Icon.Data = {
     3E08010000000100010080800000010020002808010016000000280000008000
@@ -2134,7 +2134,7 @@ object frmNewQSO: TfrmNewQSO
   OnKeyPress = FormKeyPress
   OnShow = FormShow
   OnWindowStateChange = FormWindowStateChange
-  LCLVersion = '1.8.0.6'
+  LCLVersion = '1.8.2.0'
   object sbNewQSO: TStatusBar
     Left = 0
     Height = 17
@@ -3178,7 +3178,7 @@ object frmNewQSO: TfrmNewQSO
           TabOrder = 28
           object tabDXCCStat: TTabSheet
             Caption = 'DXCC statistic'
-            ClientHeight = 111
+            ClientHeight = 114
             ClientWidth = 538
             object sgrdStatistic: TStringGrid
               Left = 0
@@ -3200,7 +3200,7 @@ object frmNewQSO: TfrmNewQSO
           end
           object tabSatellite: TTabSheet
             Caption = 'Satellite'
-            ClientHeight = 111
+            ClientHeight = 114
             ClientWidth = 538
             object cmbPropagation: TComboBox
               Left = 8
@@ -3826,15 +3826,15 @@ object frmNewQSO: TfrmNewQSO
     Interval = 2000
     OnTimer = tmrStartTimer
     OnStartTimer = tmrStartStartTimer
-    left = 728
-    top = 480
+    left = 712
+    top = 440
   end
   object tmrEnd: TTimer
     Enabled = False
     OnTimer = tmrEndTimer
     OnStartTimer = tmrEndStartTimer
-    left = 656
-    top = 480
+    left = 640
+    top = 440
   end
   object tmrRadio: TTimer
     Enabled = False
@@ -6030,7 +6030,14 @@ object frmNewQSO: TfrmNewQSO
   object tmrWsjtx: TTimer
     Enabled = False
     OnTimer = tmrWsjtxTimer
-    left = 584
-    top = 480
+    left = 576
+    top = 440
+  end
+  object tmrWsjtSpd: TTimer
+    Enabled = False
+    Interval = 490
+    OnTimer = tmrWsjtSpdTimer
+    left = 576
+    top = 512
   end
 end


### PR DESCRIPTION
New timer to switch higher polling rate for decoding near decode time starts. In FT8 mode there is just few seconds time to answer cq and almost all of that is needed for operator reactions. So decoding should happen as fast as can.
Best solution would be OnReceive event to fire decoding when something has arrived from UDP.
How ever this is not possible with Synaptic sockets (unfortunately) so only way is to poll by timer.
Other Wsmodes than FT8 do not need so fast reacts to UDP messages.

CQmonitor: "follow" line can be double clicked now and it loads Std messages but does not fire TX on Wsjt-x. Is is done with new UDP reply that exist in 1.9.0-rc3 version (and up).
