### PR TITLE
Bugfix: Worked grids map: load user digital modes to mode selector

### DIFF
--- a/src/CHANGELOG
+++ b/src/CHANGELOG
@@ -4,6 +4,7 @@ Legend:
   - bugfix
 --------------------
 2.3.0
+  - Worked grids map: Mode selector did not load user's additions (digimodes) (Saku, OH1KH)
   - CWtype/letter mode: doubling a .. z removed (Saku, OH1KH)
   + Cq-monitor: Overtimed entries turn silvergray in Follow and "no history" (Saku, OH1KH)
   + Band selector to Filter windows added (Saku, OH1KH)

--- a/src/fWorkedGrids.lfm
+++ b/src/fWorkedGrids.lfm
@@ -15,7 +15,7 @@ object frmWorkedGrids: TfrmWorkedGrids
   OnCreate = FormCreate
   OnShow = FormShow
   Position = poDefault
-  LCLVersion = '1.6.4.0'
+  LCLVersion = '1.8.2.0'
   object LocMap: TImage
     Left = 16
     Height = 361

--- a/src/fWorkedGrids.pas
+++ b/src/fWorkedGrids.pas
@@ -430,10 +430,7 @@ begin
   LogBand := ' ';
   LogTable := 'cqrlog_main';  //assume table name is this always
 
-  dmUtils.InsertModes(WsMode);
-  WsMode.Items.Insert(0, 'any');
-  WsMode.Items.Insert(1, 'JT9+JT65');
-  WsMode.ItemIndex := 0;
+  //mode selector updates now @ FormShow
 
   dmUtils.InsertBands(BandSelector);
   BandSelector.Items.Insert(0, 'all');
@@ -738,7 +735,12 @@ begin
   FollowRig.Checked := cqrini.ReadBool('Worked_grids', 'FollowRig', False);
   ShoWkdOnly.Checked := cqrini.ReadBool('Worked_grids', 'ShowWkdOnly', False);
   AutoUpdate.Enabled := True;
-  BandSelectorChange(nil)
+  BandSelectorChange(nil);
+  //we need this here. Otherwise user digital modes are not shown
+  dmUtils.InsertModes(WsMode);
+  WsMode.Items.Insert(0, 'any');
+  WsMode.Items.Insert(1, 'JT9+JT65');
+  WsMode.ItemIndex := 0;
 end;
 
 procedure TfrmWorkedGrids.LocMapClick(Sender: TObject);


### PR DESCRIPTION
Grid map did not load user digital modes to ModeSelector. Perhaps too early init (at form create) as they were loading ok to NewQso and QSO/Filter but not to grid map even when same dUtil routine was used for all.