### PR TITLE
eQSL up&dnload: preferences button did not open right tab

### DIFF
--- a/src/CHANGELOG
+++ b/src/CHANGELOG
@@ -4,6 +4,7 @@ Legend:
   - bugfix
 --------------------
 2.3.0
+  - Preferences button in eQSL up&dn load opened wrong tab
   + TRXcontrol: M_Wri-button. Sets memory entry from current rig frequency and mode  (Saku, OH1KH)
   + Wsjt-x CQ-monitor: new features Wsjt-map ColorBack and xplanet support. (Saku, OH1KH)
   + Cq-monitor: Overtimed entries turn silvergray in Follow and "no history" (Saku, OH1KH)

--- a/src/feQSLDownload.pas
+++ b/src/feQSLDownload.pas
@@ -232,9 +232,9 @@ end;
 
 procedure TfrmeQSLDownload.btnPreferencesClick(Sender : TObject);
 begin
+  cqrini.WriteInteger('Pref', 'ActPageIdx', 18);  //set lotw tab active. Number may change if preferences page change
   with TfrmPreferences.Create(self) do
   try
-    pgPreferences.ActivePage := tabLoTW;
     ShowModal
   finally
     Free

--- a/src/feQSLUpload.pas
+++ b/src/feQSLUpload.pas
@@ -250,9 +250,9 @@ end;
 
 procedure TfrmeQSLUpload.btnPreferencesClick(Sender : TObject);
 begin
+  cqrini.WriteInteger('Pref', 'ActPageIdx', 18);  //set lotw tab active. Number may change if preferences page change
   with TfrmPreferences.Create(self) do
   try
-    pgPreferences.ActivePage := tabLoTW;
     ShowModal
   finally
     Free


### PR DESCRIPTION
Because of changes before to wanted tab selection elsewhere eQSL up- and download preferences-button  did not open right tab.
This is because preferences.showForm last line sets now active page from public variable that is loaded from configuration file (Changed it when I made right tab open from DXCluster and TRXcontrol some times ago)
Now found this and it is also ok now.
