### PR TITLE
Wsjt-x remote used nonexisting variable if CQ-monitor was closed

### DIFF
--- a/src/CHANGELOG
+++ b/src/CHANGELOG
@@ -4,6 +4,7 @@ Legend:
   - bugfix
 --------------------
 2.3.0
+  - Wsjt-x remote used nonexisting variable if CQ-monitor was closed (Saku, OH1KH)
   + wsjt-x: stop TX if split answer to CQ not accepted by caller (Saku, OH1KH)
   - Preferences button in eQSL up&dn load opened wrong tab
   + TRXcontrol: M_Wri-button. Sets memory entry from current rig frequency and mode  (Saku, OH1KH)

--- a/src/fNewQSO.pas
+++ b/src/fNewQSO.pas
@@ -2511,7 +2511,11 @@ begin
            if dmData.DebugLevel>=1 then Writeln(' WSJTX decode #5 logging: press save');
            SaveRemote;
            if dmData.DebugLevel>=1 then Writeln(' WSJTX decode #5 logging now ended');
-           frmMonWsjtx.DblClickCall :='';
+           if ((frmMonWsjtx <> nil) and (frmMonWsjtx.DblClickCall <> '')) then //CQ-monitor exist
+                                    begin
+                                      if dmData.DebugLevel>=1 then Writeln('Reset 2click call:',frmMonWsjtx.DblClickCall,' QSO logged');
+                                      frmMonWsjtx.DblClickCall :='';
+                                    end;
          end; //QSO logged in
 
      6 : begin //Close


### PR DESCRIPTION
Nasty bug. Did not remember that wsjt-x remote can be run also without opening CQ-monitor (Who really wants it !?!)

This fixes only the Access violation bug, but is NOT completely same as I have in test binary 2.3.0-101. There are some other changes to this "sTx" routine too, but I want to see myself that they are working as I expect. So I need some days to play with them.
I'll do another pull request then for the rest of this part.

There are also in pull request queue (exist in TBin 2.3.0-101):
- fixed some text "realy" to "really" on several message boxes
- Exit & Autobackup: preferences,message box and help file text changes to clear out that this can also  prevent accidental program closing 