### PR TITLE
MErging PR Initial Skimmer Support

### DIFF
--- a/src/dData.pas
+++ b/src/dData.pas
@@ -3499,7 +3499,7 @@ begin
     trBands.RollBack;
   trBands.StartTransaction;
   qBands.Open;
-  Writeln('qBands.RecorfdCount: ',qBands.RecordCount);
+  if dmData.DebugLevel>=1 then Writeln('qBands.RecorfdCount: ',qBands.RecordCount);
   if qBands.RecordCount = 0 then
     exit;
   band := qBands.Fields[1].AsString;
@@ -3515,7 +3515,7 @@ begin
     else
       mode := 'RTTY';
   end;
-  Writeln('TdmData.BandModFromFreq:',Result,' cw ',FloatToStr(cw),' ssb ',FloatToStr(ssb))
+  if dmData.DebugLevel>=1 then Writeln('TdmData.BandModFromFreq:',Result,' cw ',FloatToStr(cw),' ssb ',FloatToStr(ssb))
 end;
 
 function TdmData.TriggersExistsOnCqrlog_main : Boolean;

--- a/src/fDXCluster.lfm
+++ b/src/fDXCluster.lfm
@@ -402,6 +402,24 @@ object frmDXCluster: TfrmDXCluster
     object MenuItem3: TMenuItem
       Action = acFont
     end
+    object MenuItem8: TMenuItem
+      Caption = '-'
+    end
+    object MenuItem7: TMenuItem
+      Caption = 'CW Skimmer'
+      object mnuSkimAllowFreq: TMenuItem
+        Caption = 'Allow Set Frequency'
+        Checked = True
+        ShowAlwaysCheckable = True
+        OnClick = mnuSkimAllowFreqClick
+      end
+      object mnuSkimQSLCheck: TMenuItem
+        Caption = 'Send QSL State to Skimmer'
+        Checked = True
+        ShowAlwaysCheckable = True
+        OnClick = mnuSkimQSLCheckClick
+      end
+    end
     object MenuItem4: TMenuItem
       Caption = '-'
     end

--- a/src/fDXCluster.pas
+++ b/src/fDXCluster.pas
@@ -698,11 +698,11 @@ const
   CR = #13;
   LF = #10;
 var
-  sStart, sStop: Integer;
-  tmp, Chline: String;
-  itmp : Integer;
+  sStart, sStop, SkimCallStartPos, SkimCallStopPos: Integer;
+  stmp, tmp, Chline, Skimline, SkimCall, SkimFreq, SkimMode: String;
+  itmp, itmp2 : Integer;
   buffer : String;
-  f : Double;
+  f, etmp : Double;
 begin
   if lTelnet.GetMessage(buffer) = 0 then
     exit;
@@ -747,7 +747,20 @@ begin
             end;
         end;
       end;
-
+    if Pos('TO ALL DE SKIMMER',UpperCase(tmp)) > 0 then
+      Begin
+        Skimline := tmp;
+        SkimCallStartPos := Pos('"',Skimline) + 1;
+        SkimCallStopPos := Pos('"',copy(Skimline,SkimCallStartPos,Length(Skimline)-SkimCallStartPos));
+        SkimCall := copy(Skimline,SkimCallStartPos,SkimCallStopPos - 1);
+        SkimFreq := copy(Skimline,Pos('at ',Skimline) + 3,Length(Skimline)-Pos('at ',Skimline));
+        if NOT TryStrToFloat(SkimFreq,etmp) then
+           exit;
+        if (not dmData.BandModFromFreq(SkimFreq,SkimMode,stmp)) or (SkimMode='') then
+           exit;
+        if dmData.DebugLevel>=1 then WriteLn('Call: ' + SkimCall + ', Freq: ' + SkimFreq + ', Mode: ' + SkimMode);
+        frmNewQSO.NewQSOFromSpot(SkimCall,SkimFreq,SkimMode);
+      end;
     itmp := Pos('DX DE',UpperCase(tmp));
     if (itmp > 0) or TryStrToFloat(copy(tmp,1,Pos(' ',tmp)-1),f)  then
     begin

--- a/src/fDXCluster.pas
+++ b/src/fDXCluster.pas
@@ -44,11 +44,15 @@ type
     Label1: TLabel;
     lblInfo: TLabel;
     MenuItem1 : TMenuItem;
+    mnuSkimQSLCheck: TMenuItem;
     MenuItem2 : TMenuItem;
     MenuItem3 : TMenuItem;
     MenuItem4 : TMenuItem;
     MenuItem5 : TMenuItem;
     MenuItem6: TMenuItem;
+    MenuItem7: TMenuItem;
+    MenuItem8: TMenuItem;
+    mnuSkimAllowFreq: TMenuItem;
     mnuCallalert : TMenuItem;
     Panel1: TPanel;
     Panel2: TPanel;
@@ -82,6 +86,8 @@ type
     procedure btnWebConnectClick(Sender: TObject);
     procedure edtCommandKeyPress(Sender: TObject; var Key: char);
     procedure mnuCallalertClick(Sender : TObject);
+    procedure mnuSkimAllowFreqClick(Sender: TObject);
+    procedure mnuSkimQSLCheckClick(Sender: TObject);
    procedure tmrAutoConnectTimer(Sender: TObject);
     procedure tmrSpotsTimer(Sender: TObject);
     procedure trChatSizeChange(Sender: TObject);
@@ -348,6 +354,8 @@ var
   p : TPoint;
 begin
   mnuCallalert.Checked := cqrini.ReadBool('DXCluster', 'AlertEnabled', False);
+  mnuSkimAllowFreq.Checked := cqrini.ReadBool('Skimmer', 'AllowFreqEnable', False);
+  mnuSkimQSLCheck.Checked := cqrini.ReadBool('Skimmer', 'QSLEnable', False);
   ChangeCallAlertCaption;
   p.x := 10;
   p.y := 10;
@@ -556,6 +564,9 @@ begin
   edtTelAddress.Text := telDesc;
 
   mnuCallalert.Checked := cqrini.ReadBool('DXCluster', 'AlertEnabled', False);
+  mnuSkimAllowFreq.Checked := cqrini.ReadBool('Skimmer', 'AllowFreqEnable', False);
+  mnuSkimQSLCheck.Checked := cqrini.ReadBool('Skimmer', 'QSLEnable', False);
+
   ChangeCallAlertCaption;
 
   if cqrini.ReadBool('DXCluster', 'ConAfterRun', False) then
@@ -666,6 +677,18 @@ begin
   ChangeCallAlertCaption
 end;
 
+procedure TfrmDXCluster.mnuSkimAllowFreqClick(Sender: TObject);
+begin
+  mnuSkimAllowFreq.Checked := not mnuSkimAllowFreq.Checked;
+  cqrini.WriteBool('Skimmer', 'AllowFreqEnable', mnuSkimAllowFreq.Checked);
+end;
+
+procedure TfrmDXCluster.mnuSkimQSLCheckClick(Sender: TObject);
+begin
+  mnuSkimQSLCheck.Checked := not mnuSkimQSLCheck.Checked;
+  cqrini.WriteBool('Skimmer', 'QSLEnable', mnuSkimQSLCheck.Checked);
+end;
+
 procedure TfrmDXCluster.tmrAutoConnectTimer(Sender: TObject);
 begin
   tmrAutoConnect.Enabled := False;
@@ -699,7 +722,7 @@ const
   LF = #10;
 var
   sStart, sStop, SkimCallStartPos, SkimCallStopPos, SkimParserAnchor: Integer;
-  stmp, tmp, Chline, Skimline, SkimCall, SkimFreq, SkimMode, prefix, waz, itu, cont, lat, long: String;
+  stmp, tmp, Chline, Skimline, SkimCall, SkimFreq, SkimMode, prefix: String;
   itmp, itmp2, QSLState, SkimCTYid : Integer;
   buffer : String;
   f, etmp : Double;
@@ -747,20 +770,23 @@ begin
             end;
         end;
       end;
-    if Pos('TO ALL DE SKIMMER',UpperCase(tmp)) > 0 then
-      Begin //Handle Double Click in CwSkimmer via Telnet Commands
-        Skimline := tmp;
-        SkimCallStartPos := Pos('"',Skimline) + 1;
-        SkimCallStopPos := Pos('"',copy(Skimline,SkimCallStartPos,Length(Skimline)-SkimCallStartPos));
-        SkimCall := copy(Skimline,SkimCallStartPos,SkimCallStopPos - 1);
-        SkimFreq := copy(Skimline,Pos('at ',Skimline) + 3,Length(Skimline)-Pos('at ',Skimline));
-        if NOT TryStrToFloat(SkimFreq,etmp) then
-           exit;
-        if (not dmData.BandModFromFreq(SkimFreq,SkimMode,stmp)) or (SkimMode='') then
-           exit;
-        if dmData.DebugLevel>=1 then WriteLn('Call: ' + SkimCall + ', Freq: ' + SkimFreq + ', Mode: ' + SkimMode);
-        frmNewQSO.NewQSOFromSpot(SkimCall,SkimFreq,SkimMode);
-      end;
+    if  (mnuSkimAllowFreq.Checked) then
+      Begin
+      if Pos('TO ALL DE SKIMMER',UpperCase(tmp)) > 0 then
+        Begin //Handle Double Click in CwSkimmer via Telnet Commands
+          Skimline := tmp;
+          SkimCallStartPos := Pos('"',Skimline) + 1;
+          SkimCallStopPos := Pos('"',copy(Skimline,SkimCallStartPos,Length(Skimline)-SkimCallStartPos));
+          SkimCall := copy(Skimline,SkimCallStartPos,SkimCallStopPos - 1);
+          SkimFreq := copy(Skimline,Pos('at ',Skimline) + 3,Length(Skimline)-Pos('at ',Skimline));
+          if NOT TryStrToFloat(SkimFreq,etmp) then
+             exit;
+          if (not dmData.BandModFromFreq(SkimFreq,SkimMode,stmp)) or (SkimMode='') then
+             exit;
+          if dmData.DebugLevel>=1 then WriteLn('Call: ' + SkimCall + ', Freq: ' + SkimFreq + ', Mode: ' + SkimMode);
+          frmNewQSO.NewQSOFromSpot(SkimCall,SkimFreq,SkimMode);
+        end;
+    end;
     itmp := Pos('DX DE',UpperCase(tmp));
     if (itmp > 0) or TryStrToFloat(copy(tmp,1,Pos(' ',tmp)-1),f)  then
     begin
@@ -773,45 +799,48 @@ begin
         LeaveCriticalsection(csTelnet);
         if dmData.DebugLevel>=1 then Writeln('Leave critical section On Receive')
       end;
-      if (Pos('-#:',UpperCase(tmp)) > 0) then
-      Begin //Handle Spot from Skimmer
-        Skimline := tmp;
-        SkimParserAnchor := Pos('-#:',UpperCase(Skimline));
-        SkimCall := copy(Skimline,SkimParserAnchor + 15 , 16);
-        SkimCall := copy(SkimCall,0, Pos(' ',SkimCall) - 1);
-        SkimFreq := copy(Skimline,SkimParserAnchor + 6, 7);
-        if NOT TryStrToFloat(SkimFreq,etmp) then
-           exit;
-        if (not dmData.BandModFromFreq(SkimFreq,SkimMode,stmp)) or (SkimMode='') then
-           exit;
-        if dmData.DebugLevel>=1 then Writeln('CAll: ' + SkimCall + ' Freq: ' + SkimFreq);
-        SkimCTYid := dmDXCluster.id_country(SkimCall,now,stmp,stmp,stmp,stmp,stmp,stmp,stmp);
-        dmDXCluster.DXCCInfo(SkimCTYid,FloatToStr(etmp/1000),SkimMode,QSLState);
-        if dmData.DebugLevel>=1 then Writeln('QSLState: ' + FloatToStr(QSLState));
-        case QSLState of
-          0:
-            begin
-              lTelnet.SendMessage('SKIMMER/STATUS ' + SkimCall + ' ' + SkimFreq + ' DUPE' + #13 + #10);
-              if dmData.DebugLevel>=1 then Writeln('DUPE');
-            end;
-          1:
-            begin
-              lTelnet.SendMessage('SKIMMER/STATUS ' + SkimCall + ' ' + SkimFreq + ' NEWCTY' + #13 + #10);
-              if dmData.DebugLevel>=1 then Writeln('NEWCTY');
-            end;
-          2:
-            begin
-              lTelnet.SendMessage('SKIMMER/STATUS ' + SkimCall + ' ' + SkimFreq + ' BNDCTY' + #13 + #10);
-              if dmData.DebugLevel>=1 then Writeln('BNDCTY');
-            end;
-          4:
-            begin
-              lTelnet.SendMessage('SKIMMER/STATUS ' + SkimCall + ' ' + SkimFreq + ' NOTCFM' + #13 + #10);
-              if dmData.DebugLevel>=1 then Writeln('NOTCFM');
-            end;
-          else
+      if  (mnuSkimQSLCheck.Checked) then
+      Begin
+        if (Pos('-#:',UpperCase(tmp)) > 0) then
+        Begin //Handle Spot from Skimmer
+          Skimline := tmp;
+          SkimParserAnchor := Pos('-#:',UpperCase(Skimline));
+          SkimCall := copy(Skimline,SkimParserAnchor + 15 , 16);
+          SkimCall := copy(SkimCall,0, Pos(' ',SkimCall) - 1);
+          SkimFreq := copy(Skimline,SkimParserAnchor + 6, 7);
+          if NOT TryStrToFloat(SkimFreq,etmp) then
+             exit;
+          if (not dmData.BandModFromFreq(SkimFreq,SkimMode,stmp)) or (SkimMode='') then
+             exit;
+          if dmData.DebugLevel>=1 then Writeln('CAll: ' + SkimCall + ' Freq: ' + SkimFreq);
+          SkimCTYid := dmDXCluster.id_country(SkimCall,now,stmp,stmp,stmp,stmp,stmp,stmp,stmp);
+          dmDXCluster.DXCCInfo(SkimCTYid,FloatToStr(etmp/1000),SkimMode,QSLState);
+          if dmData.DebugLevel>=1 then Writeln('QSLState: ' + FloatToStr(QSLState));
+          case QSLState of
+            0:
+              begin
+                lTelnet.SendMessage('SKIMMER/STATUS ' + SkimCall + ' ' + SkimFreq + ' DUPE' + #13 + #10);
+                if dmData.DebugLevel>=1 then Writeln('DUPE');
+              end;
+            1:
+              begin
+                lTelnet.SendMessage('SKIMMER/STATUS ' + SkimCall + ' ' + SkimFreq + ' NEWCTY' + #13 + #10);
+                if dmData.DebugLevel>=1 then Writeln('NEWCTY');
+              end;
+            2:
+              begin
+                lTelnet.SendMessage('SKIMMER/STATUS ' + SkimCall + ' ' + SkimFreq + ' BNDCTY' + #13 + #10);
+                if dmData.DebugLevel>=1 then Writeln('BNDCTY');
+              end;
+            4:
+              begin
+                lTelnet.SendMessage('SKIMMER/STATUS ' + SkimCall + ' ' + SkimFreq + ' NOTCFM' + #13 + #10);
+                if dmData.DebugLevel>=1 then Writeln('NOTCFM');
+              end;
+            else
+          end;
         end;
-      end
+      end;
     end
     else begin
       if (Pos('LOGIN',UpperCase(tmp)) > 0) and (telUser <> '') then

--- a/src/fDXCluster.pas
+++ b/src/fDXCluster.pas
@@ -698,7 +698,7 @@ const
   CR = #13;
   LF = #10;
 var
-  sStart, sStop, SkimCallStartPos, SkimCallStopPos: Integer;
+  sStart, sStop, SkimCallStartPos, SkimCallStopPos, SkimParserAnchor: Integer;
   stmp, tmp, Chline, Skimline, SkimCall, SkimFreq, SkimMode: String;
   itmp, itmp2 : Integer;
   buffer : String;
@@ -748,7 +748,7 @@ begin
         end;
       end;
     if Pos('TO ALL DE SKIMMER',UpperCase(tmp)) > 0 then
-      Begin
+      Begin //Handle Double Click in CwSkimmer via Telnet Commands
         Skimline := tmp;
         SkimCallStartPos := Pos('"',Skimline) + 1;
         SkimCallStopPos := Pos('"',copy(Skimline,SkimCallStartPos,Length(Skimline)-SkimCallStartPos));
@@ -772,6 +772,15 @@ begin
       finally
         LeaveCriticalsection(csTelnet);
         if dmData.DebugLevel>=1 then Writeln('Leave critical section On Receive')
+      end;
+      if (Pos('-#:',UpperCase(tmp)) > 0) then
+      begin //Handle Spot from Skimmer
+        Skimline := tmp;
+        SkimParserAnchor := Pos('-#:',UpperCase(Skimline));
+        SkimCall := copy(Skimline,SkimParserAnchor + 15 , 16);
+        SkimCall := copy(SkimCall,0, Pos(' ',SkimCall) - 1);
+        SkimFreq := copy(Skimline,SkimParserAnchor + 6, 7);
+        Writeln('CAll: ' + SkimCall + ' Freq: ' + SkimFreq);
       end
     end
     else begin


### PR DESCRIPTION
Hi,
I added rudimentary Skimmer Support to Telnet DX Cluster. Two features were implemented:

1. Click in Skimmer Bandmap switches Radio to Skimmer frequency and sends call to NewQSO Window if call present.
2. If Skimmer decodes a spot and sends it to Telnet Client, A QSL check is performed to send back following state to Skimmer: 

DUPE	Worked this call on this band	Gray
NEWCTY	All-time new country	        Red
BNDCTY	New country on this band	Pink
NOTCFM	Worked but not confirmed	Blue

Open:
I didn't get the need for critical section due to the fact I'm fairly new to pascal. I may used it wrong.
Best regards,
Olli, DH2WQ
