### PR TITLE
Allows AR SK send with Icom/hamlib cw interface

### DIFF
--- a/src/fCWType.pas
+++ b/src/fCWType.pas
@@ -97,7 +97,7 @@ begin
    (CWkey = '?') or (CWkey = ',') or (CWkey='.') or (CWkey='/') or (CWkey = ' ') or
    (CWkey = '<') or (CWkey = '>') or (CWkey = ':') or (CWkey = ')') or (CWkey = '(') or
    (CWkey = ';') or (CWkey = '@') or (CWkey = 'ß') or (CWkey ='Ü') or (CWkey ='Ö') or
-   (CWkey = 'Ä') then
+   (CWkey = 'Ä') or (CWkey ='^') then
   begin
     if rgMode.ItemIndex = 0 then //letter mode
       frmNewQSO.CWint.SendText(CWkey)


### PR DESCRIPTION
Passing ^ in CWType allows character combinations  (AR, SK ... ) to be sent when hamlib cw interface is selected.
Works only in word mode, not in letter mode. 
^ can be passed to CW macros and works there without any source modification.

This is tested with Icom 7300. May not work in other brand rigs.