### PR TITLE
Remove vfo query: fmv -> fm

### DIFF
--- a/src/uCWKeying.pas
+++ b/src/uCWKeying.pas
@@ -680,7 +680,7 @@ begin
   if DebugMode then
      Writeln('CWint connected to hamlib');
 
-  tcp.SendMessage('fmv'+LineEnding);
+  tcp.SendMessage('fm'+LineEnding);
   SetSpeed(fSpeed)
 end;
 

--- a/src/uRigControl.pas
+++ b/src/uRigControl.pas
@@ -532,7 +532,7 @@ begin
     RigCommand.Clear
   end
   else begin
-    cmd := 'fmv'+LineEnding;
+    cmd := 'fm'+LineEnding;
     if DebugMode then Writeln('Sending: '+cmd);
     rcvdFreqMode.SendMessage(cmd)
   end


### PR DESCRIPTION
I did find fmv from 2 places. As far as I can find out the vfo handling is not implemented anywhere . There seems to be some hidden vfo buttons at TRXConrol unused.
Polling vfo does not even work with Icom rigs causing just RPRT -11
I think we do not need it. Advise me if I'm wrong!