### PR TITLE
HamlibCW tune with AM mode

### DIFF
--- a/src/fTRXControl.pas
+++ b/src/fTRXControl.pas
@@ -166,6 +166,7 @@ type
     procedure LoadButtonCaptions;
     procedure SetDebugMode(DebugMode : Boolean);
     procedure LoadBandButtons;
+    procedure HLTune(start:boolean);
   end;
 
 {
@@ -221,12 +222,40 @@ property RigPoll     : Word    read fRigPoll     write fRigPoll;
 var
   frmTRXControl: TfrmTRXControl;
   thRig : TRigThread;
+  ModeWas : String;  //store mode while tuning with AM
+  BwWas : integer;
+  Tuning  : Boolean = false;
 
 implementation
 {$R *.lfm}
 
 { TfrmTRXControl }
 uses dUtils, dData, fNewQSO, fBandMap, uMyIni, fGrayline, fRadioMemories;
+
+procedure TfrmTRXControl.HLTune(start:boolean);
+Begin
+  if Assigned(radio) then
+   Begin
+    if start then
+     Begin
+      if not Tuning then
+        begin
+          ModeWas := GetActualMode;
+          BwWas := GetBandWidth(ModeWas);
+          SetMode('AM',0);
+          radio.PttOn;
+          Tuning :=true;
+        end;
+     end
+    else
+     begin
+          radio.PttOff;
+          if Tuning then SetMode(ModeWas, BwWas);
+          Tuning :=false;
+     end;
+   end;
+end;
+
 
 procedure TRigThread.Execute;
 

--- a/src/uCWKeying.pas
+++ b/src/uCWKeying.pas
@@ -52,6 +52,7 @@ type
       fActive : Boolean;
       fSpeed  : Word;
       ser     : TBlockSerial;
+
     public
       constructor Create; override;
       destructor  Destroy; override;
@@ -145,6 +146,7 @@ type
 
 implementation
 
+uses fTRXControl;
 
 constructor TCWWinKeyerUSB.Create;
 begin
@@ -747,12 +749,14 @@ end;
 
 procedure TCWHamLib.TuneStart;
 begin
-  //not supported
+  //supported via AM mode
+  frmTRXControl.HLTune(true);
 end;
 
 procedure TCWHamLib.TuneStop;
 begin
-  //not supported
+  //supported via AM mode
+  frmTRXControl.HLTune(false);
 end;
 
 procedure TCWHamLib.StopSending;

--- a/src/uRigControl.pas
+++ b/src/uRigControl.pas
@@ -108,6 +108,8 @@ type TRigControl = class
     procedure PwrOn;
     procedure PwrOff;
     procedure PwrStBy;
+    procedure PttOn;
+    procedure PttOff;
 end;
 
 implementation
@@ -242,6 +244,14 @@ end;
 procedure TRigControl.ClearRit;
 begin
   RigCommand.Add('J 0')
+end;
+procedure TRigControl.PttOn;
+begin
+  RigCommand.Add('T 1')
+end;
+procedure TRigControl.PttOff;
+begin
+  RigCommand.Add('T 0')
 end;
 procedure TRigControl.PwrOn;
 begin


### PR DESCRIPTION
When hamlib keyer is selected NewQSO/File/Tune will be supported by setting rig to AM and PTT on.
It could be implemented also via hamlib command  U TUNER 1 / U TUNER 0 but then it would work only when rig has tuner.
Setting AM mode is more general and produces 50% of power output setting. (silent AM carrier power is half of 100% modulated carrier).

For next 2 pull requests (TRXControl frequency setting changes & wsjt-x contest mode decode) an upgrade to database tables is needed. It would be best to do it "proper way" via database version check/update at program start. I would like to see it ready done by you so that I do not mess up anything.

For freqmem table:
| Field     | Type              | Null   | Key | Default | Extra          |
| info       | varchar(25)   | YES  |        | NULL    |                |      //description of memory

For cqrlog main:
| ser_s      | int(11)   | YES  |        | NULL    |                |    //contest serial send 
| ser_r      | int( 11)  | YES  |        | NULL    |                |     //contest serial received 
| xch_s      | varchar(250)   | YES  |        | NULL    |                |  //contest exchange message sent
| xch_s      | varchar(250)   | YES  |        | NULL    |                | //contest exchange message received
| contestname    | varchar(25)   | YES  |        | NULL    |                |  //name of contest

| submode          |varchar(20)    |YES  |        | NULL    |                |  //for ADIF purposes

I think accepting NULL values would give some kind of backward compatibility (old cqrlog version with 
 new database version)
