### PR TITLE
Warn plain text passwords in log ini files

### DIFF
--- a/src/fDBConnect.pas
+++ b/src/fDBConnect.pas
@@ -454,7 +454,8 @@ begin
       dmData.Q.Open;
       l.Text := dmData.Q.Fields[0].AsString;
       l.SaveToFile(dlgSave.FileName);
-      ShowMessage('Config file saved to '+dlgSave.FileName)
+      ShowMessage('Config file saved to '+dlgSave.FileName
+      +#10+#13+#10+#13+'Warning !'+#10+#13+'File may contain passwords'+#10+#13+'in plain text format')
     finally
       dmData.Q.Close;
       dmData.trQ.Rollback;


### PR DESCRIPTION
When exporting log preferences user may not understand that passwords, if set any, are in plain text format.
