### PR TITLE
add workaround for js8 to have correct lotw adif upload

### DIFF
--- a/src/fLoTWExport.pas
+++ b/src/fLoTWExport.pas
@@ -407,8 +407,17 @@ begin
       tmp := '<CALL' + dmUtils.StringToADIF(dmUtils.RemoveSpaces(dmData.Q1.FieldByName('callsign').AsString));
       Writeln(f,tmp);
 
-      tmp := '<MODE' + dmUtils.StringToADIF(dmData.Q1.FieldByName('mode').AsString);
-      Writeln(f,tmp);
+      if (dmData.Q1.FieldByName('mode').AsString = 'JS8') then begin
+        tmp := '<MODE:4>MFSK';
+        Writeln(f,tmp);
+        tmp := '<SUBMODE:3>JS8';
+        Writeln(f,tmp);
+      end
+      else begin
+        tmp := '<MODE' + dmUtils.StringToADIF(dmData.Q1.FieldByName('mode').AsString);
+        Writeln(f,tmp);
+      end;
+
 
       tmp := '<BAND' + dmUtils.StringToADIF(dmData.Q1.FieldByName('band').AsString);
       Writeln(f,tmp);


### PR DESCRIPTION
	- when a qso is logged with mode JS8 in the lotw adif export function the mode js8 is
          replaced by <MODE:4>MFSK<SUBMODE:3>JS8. so js8 can now confirmed correct
        - this is a workaround until the database is enhanced with field submode to implement adif 3.0.9