### PR TITLE
fix: detect wsjt message, follow call routine

### DIFF
--- a/src/fNewQSO.pas
+++ b/src/fNewQSO.pas
@@ -2142,6 +2142,12 @@ begin
   begin
 
     index := pos(#$ad+#$bc+#$cb+#$da,Buf); //QTheader: magic number 0xadbccbda
+    if index < 1 then
+             begin
+              if dmData.DebugLevel>=1 then Writeln(index,':--------Not wjst message!!------------');
+              lblCall.Caption:= 'Not wjst msg!';
+              break;
+             end;
     RepStart := index; //for possibly reply creation
 
     if dmData.DebugLevel>=1 then Writeln('-----------------------decode start---------------------------------');


### PR DESCRIPTION
This fix detects wsjt type UDP message and rejects other UDP messages received from same port.

Follow callsign routine was not revised to newmonitor state and did not work at all. This returns it back to work.