### PR TITLE
Returned rig polling 'fm' to 'fmv'

### DIFF
--- a/src/cqrlog.lpi
+++ b/src/cqrlog.lpi
@@ -97,7 +97,7 @@
         <MinVersion Major="1" Minor="2" Release="1" Valid="True"/>
       </Item10>
     </RequiredPackages>
-    <Units Count="102">
+    <Units Count="104">
       <Unit0>
         <Filename Value="cqrlog.lpr"/>
         <IsPartOfProject Value="True"/>
@@ -773,6 +773,14 @@
         <HasResources Value="True"/>
         <ResourceBaseClass Value="DataModule"/>
       </Unit101>
+      <Unit102>
+        <Filename Value="uRigControl.pas"/>
+        <IsPartOfProject Value="True"/>
+      </Unit102>
+      <Unit103>
+        <Filename Value="uRotControl.pas"/>
+        <IsPartOfProject Value="True"/>
+      </Unit103>
     </Units>
   </ProjectOptions>
   <CompilerOptions>

--- a/src/cqrlog.lpr
+++ b/src/cqrlog.lpr
@@ -23,7 +23,7 @@ uses
   fRadioMemories, fAddRadioMemory, fException, fCommentToCall,
   fNewCommentToCall, fFindCommentToCall, frExportPref, fExportPref,
   fWorkedGrids, fPropDK0WCY, fRemind, fContest, fMonWsjtx, fXfldigi,
-  dMembership, dSatellite;
+  dMembership, dSatellite, uRigControl, uRotControl;
 var
   Splash : TfrmSplash;
 

--- a/src/uCWKeying.pas
+++ b/src/uCWKeying.pas
@@ -682,7 +682,7 @@ begin
   if DebugMode then
      Writeln('CWint connected to hamlib');
 
-  tcp.SendMessage('fm'+LineEnding);
+  tcp.SendMessage('fmv'+LineEnding);
   SetSpeed(fSpeed)
 end;
 

--- a/src/uRigControl.pas
+++ b/src/uRigControl.pas
@@ -554,7 +554,7 @@ begin
     RigCommand.Clear
   end
   else begin
-    cmd := 'fm'+LineEnding;
+    cmd := 'fmv'+LineEnding;
     if DebugMode then Writeln('Sending: '+cmd);
     rcvdFreqMode.SendMessage(cmd)
   end


### PR DESCRIPTION
'v' is generating errors with Icom rigs, but Kenwoods can not survive without it. If 'v' is missing And Kenwood user pushes A/B vfo button from rig from panel cqrlog continues to show previous vfo frequency.
This is a rigctrl "feature" of Kenwood that it needs user action to poll current vfo before asking frequency.

uRigControl.pas is not suitable for fixing this easy. So we just leave errors for Icom as they do no bigger harm.

Added uRigControl.pas and uRotControl.pas to project. I can not see no harm with this. Finding them is now easier from unit list.