### PR TITLE
Fix: wsjt monitor

### DIFF
--- a/src/fMonWsjtx.pas
+++ b/src/fMonWsjtx.pas
@@ -1570,6 +1570,7 @@ begin
      Message:=LineFilter(Message);
      msgCall := ExtractWord(2,Message,[' ']);
      msgLocator := ExtractWord(3,Message,[' ']);
+     CqDir := ''; // Must be reseted here, otherwise will print old CQ DIR from previous decoded line
 
      Fox73 := ((msgCall = 'RR73') and (msgLocator =''));
 


### PR DESCRIPTION
If previous line was directed cq prints cq direction also into my message line.
Common variable was not reseted after last use.
Happens very seldom, so was not found before.