### PR TITLE
Fix CQmonitor follow call typing was right-to-left

### DIFF
--- a/src/fMonWsjtx.lfm
+++ b/src/fMonWsjtx.lfm
@@ -12,7 +12,7 @@ object frmMonWsjtx: TfrmMonWsjtx
   OnDropFiles = FormDropFiles
   OnHide = FormHide
   OnShow = FormShow
-  LCLVersion = '1.8.4.0'
+  LCLVersion = '2.0.0.4'
   object lblBand: TLabel
     AnchorSideLeft.Control = Owner
     AnchorSideTop.Control = Owner
@@ -261,7 +261,6 @@ object frmMonWsjtx: TfrmMonWsjtx
       Top = 5
       Width = 80
       BorderSpacing.Left = 3
-      OnChange = edtFollowCallChange
       OnEnter = edtFollowCallEnter
       OnExit = edtFollowCallExit
       OnKeyDown = edtFollowCallKeyDown

--- a/src/fMonWsjtx.pas
+++ b/src/fMonWsjtx.pas
@@ -64,7 +64,6 @@ type
     procedure cmNeverClick(Sender: TObject);
     procedure EditAlertEnter(Sender: TObject);
     procedure EditAlertExit(Sender: TObject);
-    procedure edtFollowCallChange(Sender: TObject);
     procedure edtFollowCallEnter(Sender: TObject);
     procedure edtFollowCallExit(Sender: TObject);
     procedure edtFollowCallKeyDown(Sender: TObject; var Key: word;
@@ -475,11 +474,6 @@ begin
   cqrini.WriteBool('MonWsjtx', 'Follow', tbFollow.Checked);
   EditAlert.Text := trim(EditAlert.Text);
   EditedText := EditAlert.Text;
-end;
-
-procedure TfrmMonWsjtx.edtFollowCallChange(Sender: TObject);
-begin
-  edtFollowCall.Text:=trim(UpperCase(edtFollowCall.Text));        //no spaces  upcase
 end;
 
 procedure TfrmMonWsjtx.edtFollowCallEnter(Sender: TObject);


### PR DESCRIPTION
Small fix.
Doing trim+uppercase to edtFollowCall.Text every time it changes makes typing order of letters A .. Z have right-to-left order. Numbers have left-to-right order ! Strange!  Removed trim+upercase.