### PR TITLE
fix ft4 new sequence length and ft4 as submode

### DIFF
--- a/src/dUtils.pas
+++ b/src/dUtils.pas
@@ -38,13 +38,13 @@ const
     ':', '|', '-', '=', '+', '@', '#', '*', '%', '_', '(', ')', '$', '<', '>'];
   empty_freq = '0.00000';
   empty_azimuth = '0.0';
-  cMaxModes = 46; //last added FT4
+  cMaxModes = 47; //last added FT4 and JS8
   cModes: array [0..cMaxModes] of string =
     ('CW', 'SSB', 'AM', 'FM', 'RTTY', 'SSTV', 'PACTOR', 'PSK', 'ATV', 'CLOVER', 'GTOR', 'MTOR',
     'PSK31', 'HELL', 'MT63',
     'QRSS', 'CWQ', 'BPSK31', 'MFSK', 'JT44', 'FSK44', 'WSJT', 'AMTOR',
     'THROB', 'BPSK63', 'PACKET',
-    'OLIVIA', 'MFSK16', 'JT4','JT6M', 'JT65', 'JT65A', 'JT65B', 'JT65C',
+    'OLIVIA', 'MFSK16', 'JS8', 'JT4','JT6M', 'JT65', 'JT65A', 'JT65B', 'JT65C',
     'JT9', 'QRA64', 'ISCAT', 'MSK144', 'FT8', 'FT4', 'FSK441', 'PSK125',
     'PSK63', 'WSPR', 'PSK250', 'ROS', 'DIGITALVOICE');
   cMaxBandsCount = 27; //26 bands

--- a/src/fExportProgress.pas
+++ b/src/fExportProgress.pas
@@ -194,7 +194,12 @@ var
     end;
     if exMode then
     begin
-      tmp := '<MODE' + dmUtils.StringToADIF(Mode);
+      if (Mode = 'JS8') then
+        tmp := '<MODE:4>MFSK<SUBMODE:3>JS8'
+      else if (Mode = 'FT4') then
+        tmp := '<MODE:4>MFSK<SUBMODE:3>FT4'
+      else
+        tmp := '<MODE' + dmUtils.StringToADIF(Mode);
       Write(f,tmp);
       leng := leng + Length(tmp)
     end;

--- a/src/fLoTWExport.pas
+++ b/src/fLoTWExport.pas
@@ -426,6 +426,12 @@ begin
         tmp := '<SUBMODE:3>JS8';
         Writeln(f,tmp);
       end
+      else if (dmData.Q1.FieldByName('mode').AsString = 'FT4') then begin
+        tmp := '<MODE:4>MFSK';
+        Writeln(f,tmp);
+        tmp := '<SUBMODE:3>FT4';
+        Writeln(f,tmp);
+      end
       else begin
         tmp := '<MODE' + dmUtils.StringToADIF(dmData.Q1.FieldByName('mode').AsString);
         Writeln(f,tmp);

--- a/src/fMonWsjtx.pas
+++ b/src/fMonWsjtx.pas
@@ -850,7 +850,7 @@ begin
   tmr := 61000;
   case CurMode of
        'FT8': tmr := 16000;
-       'FT4': tmr := 6500;
+       'FT4': tmr := 8000;
   end;
   tmrCqPeriod.Interval := tmr;
   if LocalDbg then Writeln('Period timer set to: ',tmr);


### PR DESCRIPTION
	- ft4 sequence length was changed from 6 sec to 7.4 sec
	- ADIF 3.1.0 is out > FT4 is SUBMODE of MODE MFSK
	- LOTW ADIF upload works now correct
        - correct ADIF Export (SUBMODE for FT4 and JS8)