### PR TITLE
fix issue #166 DXCC list fails when qsl received field is filled wrong

### DIFF
--- a/src/fNewQSO.lfm
+++ b/src/fNewQSO.lfm
@@ -1,7 +1,7 @@
 object frmNewQSO: TfrmNewQSO
-  Left = 108
+  Left = 27
   Height = 709
-  Top = 153
+  Top = 173
   Width = 997
   HelpType = htKeyword
   HelpKeyword = 'help/index.html'
@@ -3092,6 +3092,7 @@ object frmNewQSO: TfrmNewQSO
             'SPE'
           )
           OnEnter = cmbQSL_SEnter
+          OnExit = cmbQSL_SExit
           OnKeyDown = cmbQSL_SKeyDown
           TabOrder = 9
           Text = 'MD'
@@ -3118,6 +3119,7 @@ object frmNewQSO: TfrmNewQSO
             ''
           )
           OnEnter = cmbQSL_REnter
+          OnExit = cmbQSL_RExit
           OnKeyDown = cmbQSL_RKeyDown
           TabOrder = 10
         end

--- a/src/fNewQSO.pas
+++ b/src/fNewQSO.pas
@@ -383,7 +383,9 @@ type
     procedure cmbIOTAEnter(Sender: TObject);
     procedure cmbPropagationChange(Sender : TObject);
     procedure cmbQSL_REnter(Sender: TObject);
+    procedure cmbQSL_RExit(Sender: TObject);
     procedure cmbQSL_SEnter(Sender: TObject);
+    procedure cmbQSL_SExit(Sender: TObject);
     procedure cmbSatelliteChange(Sender : TObject);
     procedure dbgrdQSOBeforeColumnSized(Sender: TObject);
     procedure edtAwardEnter(Sender: TObject);
@@ -4320,9 +4322,19 @@ begin
   cmbQSL_R.SelectAll
 end;
 
+procedure TfrmNewQSO.cmbQSL_RExit(Sender: TObject);
+begin
+  cmbQSL_R.Text := trim(cmbQSL_R.Text);
+end;
+
 procedure TfrmNewQSO.cmbQSL_SEnter(Sender: TObject);
 begin
   cmbQSL_S.SelectAll
+end;
+
+procedure TfrmNewQSO.cmbQSL_SExit(Sender: TObject);
+begin
+  cmbQSL_S.Text := trim(cmbQSL_S.Text);
 end;
 
 procedure TfrmNewQSO.cmbSatelliteChange(Sender : TObject);


### PR DESCRIPTION
fix issue #166 DXCC list fails when qsl received field is filled wrong
	- gui trims now qslr and qsls field when focus is lost
	- Hint: user is still responsible for entering valid qsl flags, garbage in means garbage out