### PR TITLE
Removes states in case of USA from CQ monitor

### DIFF
--- a/src/cqrlog.lpi
+++ b/src/cqrlog.lpi
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CONFIG>
   <ProjectOptions>
-    <Version Value="10"/>
+    <Version Value="11"/>
     <General>
       <Flags>
         <LRSInOutputDirectory Value="False"/>
@@ -31,7 +31,6 @@
     </PublishOptions>
     <RunParams>
       <local>
-        <FormatVersion Value="1"/>
         <CommandLineParams Value="--DEBUG=1"/>
         <LaunchingApplication PathPlusParams="/usr/X11R6/bin/xterm -T 'Lazarus Run Output' -e $(LazarusDir)/tools/runwait.sh $(TargetCmdLine)"/>
       </local>
@@ -41,6 +40,21 @@
           <Variable1 Name="HEAPTRC" Value="1"/>
         </UserOverrides>
       </environment>
+      <FormatVersion Value="2"/>
+      <Modes Count="1">
+        <Mode0 Name="default">
+          <local>
+            <CommandLineParams Value="--DEBUG=1"/>
+            <LaunchingApplication PathPlusParams="/usr/X11R6/bin/xterm -T 'Lazarus Run Output' -e $(LazarusDir)/tools/runwait.sh $(TargetCmdLine)"/>
+          </local>
+          <environment>
+            <UserOverrides Count="2">
+              <Variable0 Name="FIREBIRD" Value="/home/ok2cqr/projekty/cqrlog/testing"/>
+              <Variable1 Name="HEAPTRC" Value="1"/>
+            </UserOverrides>
+          </environment>
+        </Mode0>
+      </Modes>
     </RunParams>
     <RequiredPackages Count="10">
       <Item1>

--- a/src/fMonWsjtx.pas
+++ b/src/fMonWsjtx.pas
@@ -1784,6 +1784,8 @@ begin
        msgRes, WAZ, posun, ITU, lat, long);
      if (pos(',', msgRes)) > 0 then
        msgRes := copy(msgRes, 1, pos(',', msgRes) - 1);
+     //case of USA print it only. Forget state. It is not shown full and may be bogus
+     if pos('USA',upcase(msgRes))>0 then msgRes := 'USA';
 
      if LocalDbg then
        Writeln('My continent is:', mycont, '  His continent is:', cont);


### PR DESCRIPTION
Stops discussions about wrong state in CQ-monitor.
Can reverted if we later get method to get proper state information for US callsign.
Until that this is the easiest way.