### PR TITLE
Fixed USA states remove from CQ monitor

### DIFF
--- a/src/fMonWsjtx.pas
+++ b/src/fMonWsjtx.pas
@@ -1784,6 +1784,8 @@ begin
        msgRes, WAZ, posun, ITU, lat, long);
      if (pos(',', msgRes)) > 0 then
        msgRes := copy(msgRes, 1, pos(',', msgRes) - 1);
+     //case of USA print it only. Forget state. It is not shown full and may be bogus
+     if pos('USA',upcase(msgRes))=1 then msgRes := 'USA';
 
      if LocalDbg then
        Writeln('My continent is:', mycont, '  His continent is:', cont);


### PR DESCRIPTION
OK. This is fixed one. '>0' changed to '=1' to accept only USA at the beginning of line.
Sadly found out that previous reported South Korea as USA because of string "usa" was found in the middle of city name.
