### PR TITLE
Upgrade for N1MM remote

### DIFF
--- a/help/h1.html
+++ b/help/h1.html
@@ -551,6 +551,15 @@ There are no known dependencies issues.<br><br>
     <br>
     Address can also be other PC's IP address if wsjt-x is running in different networked PC than cqrlog, or even 0.0.0.0 when cqrlog listens all transmits from every wsjt-x in network.
     <br><br>
+    At WSJT-X 2.1.0 settings N1MM remote is renamed to "Secondary UDP server (deprecated)" and it is reported to be removed completely in future. Because of that it is now possible to set cqrlog's N1MM port to wsjt-x UDP server port number. WSJT-X 2.1.x UDP frames contain message #12 that
+     includes log information in ADIF format and N1MM remote can now parse that from binary data if you do not like to have monitoring properties (using wsjt remote) but want just qso logging (using N1MM remote).
+    <br><br>
+    N1MM remote has now better support for QRZ/HamQTH info fetch. If this is not allowed in preferences, or if there is no reponse from Web max waiting time (timeout)  is 5 seconds (You can not remove this property, so be patient. You can not have new qso for logging during 5 seconds!).
+    <br>While having qso you can write some notes like Name, QTH, Comment to QSO, etc. to NewQSO and it will saved with qso data during next wsjt-x "log qso/OK" event. They will not be overwritten by possible Qrz/HamQth info.
+    <br><br>
+    <strong>NOTE !!</strong> Wstx- does not send contest -name, -number and -string in ADIF logging datagram. Contest exchanges are placed to regular rst_s and rst_r strings. So cqrlog can not fill proper contest columns when logging is done with ADIF datagram using N1MM remote. 
+    <br><br>
+    
     <a name=ch3><h2><strong>Exit & Auto backup</strong></h2></a>
     To increase the safety of your log data, CQRLOG is equipped with an <strong>Auto backup</strong>
     option which allows you to export (ADIF) and store the log data in a safe location.

--- a/src/cqrlog.lpi
+++ b/src/cqrlog.lpi
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CONFIG>
   <ProjectOptions>
-    <Version Value="10"/>
+    <Version Value="11"/>
     <General>
       <Flags>
         <LRSInOutputDirectory Value="False"/>
@@ -31,7 +31,6 @@
     </PublishOptions>
     <RunParams>
       <local>
-        <FormatVersion Value="1"/>
         <CommandLineParams Value="--DEBUG=1"/>
         <LaunchingApplication PathPlusParams="/usr/X11R6/bin/xterm -T 'Lazarus Run Output' -e $(LazarusDir)/tools/runwait.sh $(TargetCmdLine)"/>
       </local>
@@ -41,6 +40,21 @@
           <Variable1 Name="HEAPTRC" Value="1"/>
         </UserOverrides>
       </environment>
+      <FormatVersion Value="2"/>
+      <Modes Count="1">
+        <Mode0 Name="default">
+          <local>
+            <CommandLineParams Value="--DEBUG=1"/>
+            <LaunchingApplication PathPlusParams="/usr/X11R6/bin/xterm -T 'Lazarus Run Output' -e $(LazarusDir)/tools/runwait.sh $(TargetCmdLine)"/>
+          </local>
+          <environment>
+            <UserOverrides Count="2">
+              <Variable0 Name="FIREBIRD" Value="/home/ok2cqr/projekty/cqrlog/testing"/>
+              <Variable1 Name="HEAPTRC" Value="1"/>
+            </UserOverrides>
+          </environment>
+        </Mode0>
+      </Modes>
     </RunParams>
     <RequiredPackages Count="10">
       <Item1>
@@ -789,6 +803,7 @@
     </CodeGeneration>
     <Linking>
       <Debugging>
+        <GenerateDebugInfo Value="False"/>
         <DebugInfoType Value="dsDwarf2Set"/>
       </Debugging>
     </Linking>

--- a/src/uVersion.pas
+++ b/src/uVersion.pas
@@ -9,7 +9,7 @@ const
   cMINOR      = 3;
   cRELEAS     = 0;
   cBUILD      = 3;
-  cBUILD_DATE = '2019-07-26';
+  cBUILD_DATE = '2019-08-21';
 
 implementation
 


### PR DESCRIPTION
Fixes issue #188
This upgrade can now handle "binary garbage" in case normal wsjt datagrams are pushed to N1MM remote port and dig possible ADIF information (datagram nr.12) from there.

Qrz/HamQth info fetch waiting is improved.

Some information can also be entered to NewQSO during qso from where they are added at logging phase.


Squashed commit of the following:

commit 845fff84c8de576ef5206f73c942c0f483ad4b52
Author: OH1KH <oh1kh@sral.fi>
Date:   Wed Aug 21 17:36:38 2019 +0300

    Web info fetch works now. Some data for logging may also be written to NewQSO before logging

commit a75206199d3deff2b86ee1263f3e382f218b884d
Author: OH1KH <oh1kh@sral.fi>
Date:   Wed Aug 21 12:22:22 2019 +0300

    Trying to make web fetch work, no luck

commit 90c82bddb5c0b3ae2e2f9a3e7b2e059202b06816
Author: OH1KH <oh1kh@sral.fi>
Date:   Mon Aug 19 17:55:18 2019 +0300

     Removed unused integer i definition

commit c1f1c2363edbe70a908d2f182cbabbd595bbdb2a
Author: OH1KH <oh1kh@sral.fi>
Date:   Mon Aug 19 17:52:52 2019 +0300

    N1MM can now dig adif from wsjt-x regular UDP messages (nr12 contains ADIF in ascii)