### PR TITLE
 Added 'Contest name' to group edit

### DIFF
--- a/src/dUtils.pas
+++ b/src/dUtils.pas
@@ -70,6 +70,7 @@ const
   C_RBN_BANDS = '630M,160M,80M,40M,30M,20M,17M,15M,12M,10M,6M,2M';
   C_RBN_MODES = 'CW,RTTY,PSK31';
 
+  C_CONTEST_LIST_FILE_NAME = 'ContestName.tab';
 
 type
 
@@ -133,6 +134,7 @@ type
     property GrayLineOffset: currency read fGraylineOffset write fGrayLineOffset;
     property SysUTC: boolean read fSysUTC write fSysUTC;
 
+    procedure InsertContests(cmbContestName: TComboBox);
     procedure InsertModes(cmbMode: TComboBox);
     procedure InsertQSL_S(QSL_S: TComboBox);
     procedure InsertQSL_R(QSL_R: TcomboBox);
@@ -556,7 +558,28 @@ begin
   USstates[49] := 'WV, West Virginia';
   USstates[50] := 'WY, Wyoming';
 end;
-
+procedure TdmUtils.InsertContests(cmbContestName: TComboBox);
+var
+    ListOfContests : TStringList;
+    s: string;
+    Contestfile :TextFile;
+begin
+  // loading the contest list from ~/.config/cqrlog/ContestNames.tab
+  // Format of File   CONTEST_ID|CONTEST_DESCRIPTION
+  // see ADIF 3.0.9 http://www.adif.org/309/ADIF_309.htm#Contest_ID
+  // File have to be UTF8 without BOM
+  ListOfContests:= TStringList.Create;
+  ListOfContests.Clear;
+  ListOfContests.Sorted:=True;
+  if FileExists(dmData.HomeDir + C_CONTEST_LIST_FILE_NAME) then
+  begin
+       ListOfContests.LoadFromFile(dmData.HomeDir + C_CONTEST_LIST_FILE_NAME);
+       cmbContestName.Clear;
+       cmbContestName.Items := ListOfContests;
+       cmbContestName.Items.Insert(0,'');
+  end;
+  ListOfContests.Free;
+end;
 procedure TdmUtils.InsertModes(cmbMode: TComboBox);
 var
   i: integer;

--- a/src/fContest.pas
+++ b/src/fContest.pas
@@ -65,9 +65,6 @@ type
     { public declarations }
   end;
 
-const
-  C_CONTEST_LIST_FILE_NAME = 'ContestName.tab';
-
 var
   frmContest: TfrmContest;
   RSTstx: string = ''; //contest mode serial numbers store
@@ -342,27 +339,9 @@ begin
 end;
 
 procedure TfrmContest.FormCreate(Sender: TObject);
-var
-    ListOfContests : TStringList;
-    s: string;
-    Contestfile :TextFile;
 begin
   frmContest.KeyPreview := True;
-  // loading the contest list from ~/.config/cqrlog/ContestNames.tab
-  // Format of File   CONTEST_ID|CONTEST_DESCRIPTION
-  // see ADIF 3.0.9 http://www.adif.org/309/ADIF_309.htm#Contest_ID
-  // File have to be UTF8 without BOM
-  ListOfContests:= TStringList.Create;
-  ListOfContests.Clear;
-  ListOfContests.Sorted:=True;
-  if FileExists(dmData.HomeDir + C_CONTEST_LIST_FILE_NAME) then
-  begin
-       ListOfContests.LoadFromFile(dmData.HomeDir + C_CONTEST_LIST_FILE_NAME);
-       cmbContestName.Clear;
-       cmbContestName.Items := ListOfContests;
-       cmbContestName.Items.Insert(0,'');
-  end;
-  ListOfContests.Free;
+  dmUtils.InsertContests(cmbContestName);
 end;
 
 procedure TfrmContest.FormClose(Sender: TObject; var CloseAction: TCloseAction);

--- a/src/fGroupEdit.lfm
+++ b/src/fGroupEdit.lfm
@@ -148,21 +148,21 @@ object frmGroupEdit: TfrmGroupEdit
   }
   OnShow = FormShow
   Position = poMainFormCenter
-  LCLVersion = '1.6.0.4'
+  LCLVersion = '2.0.2.0'
   object GroupBox1: TGroupBox
     Left = 0
     Height = 108
     Top = 0
     Width = 385
     Align = alClient
-    ClientHeight = 104
-    ClientWidth = 381
+    ClientHeight = 106
+    ClientWidth = 383
     TabOrder = 0
     object Label1: TLabel
       Left = 10
       Height = 17
       Top = 7
-      Width = 37
+      Width = 35
       Caption = 'Field:'
       ParentColor = False
     end
@@ -170,7 +170,7 @@ object frmGroupEdit: TfrmGroupEdit
       Left = 10
       Height = 17
       Top = 39
-      Width = 43
+      Width = 40
       Caption = 'Value:'
       ParentColor = False
     end
@@ -178,14 +178,14 @@ object frmGroupEdit: TfrmGroupEdit
       Left = 6
       Height = 17
       Top = 68
-      Width = 45
+      Width = 41
       Caption = 'lblInfo'
       ParentColor = False
       Visible = False
     end
     object cmbField: TComboBox
       Left = 62
-      Height = 31
+      Height = 29
       Top = -1
       Width = 242
       ItemHeight = 0
@@ -222,6 +222,7 @@ object frmGroupEdit: TfrmGroupEdit
         'eQSL sent date'
         'eQSL rcvd'
         'eQSL rcvd date'
+        'Contest name'
       )
       OnChange = cmbFieldChange
       Style = csDropDownList
@@ -229,7 +230,7 @@ object frmGroupEdit: TfrmGroupEdit
     end
     object cmbValue: TComboBox
       Left = 62
-      Height = 29
+      Height = 34
       Top = 34
       Width = 312
       ItemHeight = 0

--- a/src/fGroupEdit.pas
+++ b/src/fGroupEdit.pas
@@ -17,7 +17,7 @@ interface
 
 uses
   Classes, SysUtils, LResources, Forms, Controls, Graphics, Dialogs, StdCtrls,
-  ExtCtrls, lcltype;
+  ExtCtrls, lcltype, strutils;
 
 type
 
@@ -93,7 +93,11 @@ begin
            cmbValue.Items.Add('N');
            cmbValue.ItemIndex := 0;
            cmbValue.Style:=csDropDownList;
-         end
+         end;
+    32 : begin
+           dmUtils.InsertContests(cmbValue);
+           cmbValue.Style:=csDropDown;
+         end;
    end
 end;
 {eQSL sent        28
@@ -456,6 +460,13 @@ begin
             sql := 'eqsl_qsl_rcvd='+QuotedStr('E')+',eqsl_qslrdate='+
                    QuotedStr(cmbValue.Text)
         end;
+   32 : begin
+           if (cmbValue.Text='') and (Application.MessageBox('Dou you really want to clear Contest name field?',
+              'Question ...',mb_YesNo+mb_IconQuestion)=idNo) then
+             exit;
+           sql := 'contestname='+QuotedStr(ExtractWord(1,cmbValue.Text,['|']));
+         end;
+
 {eQSL sent        28
  eQSL sent date   29
  eQSL rcvd        30


### PR DESCRIPTION
Fixes issue #196 

Moved contest name selection list creation to dUtils (is now used by Contest and Group edit).
