### PR TITLE
Fixes award field clear

### DIFF
--- a/src/fNewQSO.pas
+++ b/src/fNewQSO.pas
@@ -1086,6 +1086,7 @@ begin
   mCallBook.Clear;
   dmData.qQSOBefore.Close;
   lblIOTA.Font.Color := clDefault;
+  idcall := ''; //OH1KH: this line fixes issue #201 but does it something wrong elsewhere? (I did not notice)
   if frmQSODetails.Showing then
   begin
     frmQSODetails.ClearAll;


### PR DESCRIPTION
This fixes issue #201

I did not notice it doing any harm elsewhere. Please check!

To test:
Add one club to preferences so that notice of membership is printed to AWARD field.
Uncheck NewQSO "Auto" checbox
Enter club member call to "callsign" field
Move cursor with mouse to "frequency" filed. You can move it directly or move with TAB to elsewhere and then come back to "frequency" field with mouse.
Then press 2x ESC. Call and everything else is removed but text stays in "AWARD" field. 
But ONLY if cursor is in the "frequency" field at the time 2x ESC is pressed.
--------
Making a breakpoint into ClearAll loop where all TEdits are cleared you can see that AWARD is cleared, but after procedure ClearAll  exits text is returned from somewhere to AWARD again.
(I did not dig the root cause further).
--------
Adding "idcall" clear to ClearAll procedure prevents this to happen.
