### PR TITLE
QT5 fix for LoTW download

### DIFF
--- a/src/fImportLoTWWeb.pas
+++ b/src/fImportLoTWWeb.pas
@@ -73,6 +73,7 @@ begin
   Done := False;
   FileSize := 0;
   mStat.Clear;
+  mStat.Lines.Add(''); //needed for QT5. Otherwise SockCallBack  mStat.Lines.Count-1 gives error when there are no lines. Gtk2 works ok!
   Application.ProcessMessages;
   if not dmUtils.IsDateOK(edtDateFrom.Text) then
   begin


### PR DESCRIPTION
After testing with QT5 compile found out that LoTW download dies to "index -1" issue.
For some reason mStat.Lines.Count acts differently with QT5 than Gtk2 giving error when line is updated to mStat.Lines.Strings[mStat.Lines.Count-1]  at first call to SockCallBack .
  
That gives -1 because there are no lines after Clear,  but why Gtk2 works with this??