### PR TITLE
fixed function result

### DIFF
--- a/src/dUtils.pas
+++ b/src/dUtils.pas
@@ -1053,6 +1053,7 @@ function TdmUtils.StdFormatLocator(loc:string):String;
 var
   s :String;
 begin
+  Result := loc;
   if loc = '' then exit;
   s :=  Upcase(copy(loc,1,4));
   s:= s + lowercase(copy(loc,5,6));   //max loc length 10 in database


### PR DESCRIPTION
Fixes issue #212 .
Initates Result with loc.  Returns now empty string if loc is empty.