### PR TITLE
Filter do_date fix

### DIFF
--- a/help/index_right.html
+++ b/help/index_right.html
@@ -8,7 +8,7 @@
     <META HTTP-EQUIV="Pragma" CONTENT="no-cache">
     <title>CQRLOG - Help Index</title></head>
 <body>
-<strong><h1>CQRLOG for LINUX (version 2.3.0)</h1></strong>
+<strong><h1>CQRLOG for LINUX (version 2.4.0)</h1></strong>
 by<br><br>
 <i>Petr Hlozek, OK7AN
     [<a href="http://www.ok7an.com">http://www.ok7an.com</a>]</i>

--- a/src/cqrlog.lpi
+++ b/src/cqrlog.lpi
@@ -23,14 +23,14 @@
       <StringTable ProductVersion="0.3.1.2026"/>
     </VersionInfo>
     <MacroValues Count="1">
-      <Macro1 Name="LCLWidgetType" Value="qt5"/>
+      <Macro3 Name="LCLWidgetType" Value="gtk2"/>
     </MacroValues>
     <BuildModes Count="1">
       <Item1 Name="default" Default="True"/>
       <SharedMatrixOptions Count="3">
-        <Item1 ID="364409174580" Modes="default" Type="IDEMacro" MacroName="LCLWidgetType" Value="qt5"/>
+        <Item1 ID="364409174580" Type="IDEMacro" MacroName="LCLWidgetType" Value="qt5"/>
         <Item2 ID="890734883088" Type="IDEMacro" MacroName="LCLWidgetType" Value="gtk3"/>
-        <Item3 ID="102898540782" Type="IDEMacro" MacroName="LCLWidgetType" Value="gtk2"/>
+        <Item3 ID="102898540782" Modes="default" Type="IDEMacro" MacroName="LCLWidgetType" Value="gtk2"/>
       </SharedMatrixOptions>
     </BuildModes>
     <PublishOptions>
@@ -820,7 +820,6 @@
     </CodeGeneration>
     <Linking>
       <Debugging>
-        <GenerateDebugInfo Value="False"/>
         <DebugInfoType Value="dsDwarf2Set"/>
       </Debugging>
     </Linking>

--- a/src/fFilter.lfm
+++ b/src/fFilter.lfm
@@ -452,7 +452,6 @@ object frmFilter: TfrmFilter
       Top = 59
       Width = 114
       CalendarDisplaySettings = [dsShowHeadings, dsShowDayNames, dsStartMonday]
-      DefaultToday = True
       DateOrder = doYMd
       DateFormat = 'YMD'
       ButtonWidth = 23
@@ -1377,7 +1376,6 @@ object frmFilter: TfrmFilter
       Height = 34
       Top = 40
       Width = 95
-      OnExit = edtDateToExit
       TabOrder = 0
     end
     object edtPwrFrom: TEdit
@@ -1391,7 +1389,6 @@ object frmFilter: TfrmFilter
       Anchors = [akTop, akRight]
       BorderSpacing.Top = 6
       BorderSpacing.Right = 6
-      OnExit = edtDateFromExit
       TabOrder = 1
     end
     object Label19: TLabel

--- a/src/fFilter.pas
+++ b/src/fFilter.pas
@@ -150,8 +150,6 @@ type
     procedure FormShow(Sender: TObject);
     procedure btnCancelClick(Sender: TObject);
     procedure btnOKClick(Sender: TObject);
-    procedure edtDateFromExit(Sender: TObject);
-    procedure edtDateToExit(Sender: TObject);
   private
     procedure saveFilter(filename:String);
     procedure loadFilter(filename:string);
@@ -176,308 +174,247 @@ var
   grb_by    : String = '';
   p         : TExplodeArray;
   i         : Integer = 0;
+  Mask      : String = '';
+  sDate     : String = '';
 begin
   if chkRemember.Checked then saveFilter(dmData.HomeDir + C_FILTER_LAST_SETTINGS_FILE_NAME);
+  //if empty date-to make it as today. NOTE that empty calendar.Text is not empty string, but Date is =0!
+  if edtDateTo.Date = 0 then edtDateTo.Date := now;
 
   tmp := '';
   if (edtCallSign.Text <> '') then
-  begin
-    if rbExactlyCall.Checked then
-      tmp := ' (callsign = ' + QuotedStr(edtCallSign.Text)+')'
-    else
-      tmp := ' (callsign LIKE ''%' + edtCallSign.Text + '%'')';
-    tmp := tmp + ' AND';
-  end;
-  if (edtDXCC.Text <> '') then
-  begin
-    tmp := tmp + ' (dxcc_ref = '+ QuotedStr(edtDXCC.Text)+')';
-    tmp := tmp + ' AND'
-  end;
-  if ((edtFreqFrom.Text <> '') and (edtFreqTo.Text <> '')) then
-  begin
-    tmp := tmp + ' (freq >= ' + edtFreqFrom.Text + ') AND '+
-                 ' (freq <= ' + edtFreqTo.Text + ')';
-    tmp := tmp + ' AND'
-  end;
-  if (cmbMode.Text <> '') then
-  begin
-    tmp := tmp + ' (mode = ' + QuotedStr(cmbMode.Text)+')';
-    tmp := tmp + ' AND'
-  end;
+                                begin
+                                  if rbExactlyCall.Checked then   tmp := ' (callsign = ' + QuotedStr(edtCallSign.Text)+') AND'
+                                  else
+                                    tmp := ' (callsign LIKE ''%' + edtCallSign.Text + '%'') AND';
+                                end;
+
+  if (edtDXCC.Text <> '') then tmp := tmp + ' (dxcc_ref = '+ QuotedStr(edtDXCC.Text)+') AND';
+
+  if   ((edtFreqFrom.Text <> '')
+   and (edtFreqTo.Text <> ''))     then tmp := tmp + ' (freq >= ' + edtFreqFrom.Text + ') AND '+
+                                                     ' (freq <= ' + edtFreqTo.Text + ') AND';
+
+  if (cmbMode.Text <> '') then   tmp := tmp + ' (mode = ' + QuotedStr(cmbMode.Text)+') AND';
+
   if ( cmbContestName.Text <> '') then
-  begin
-    if cbIncConName.Checked then
-       tmp := tmp + ' (UPPER(contestname) LIKE ''%' + upcase(cmbContestName.Text) + '%'')'
-      else
-       tmp := tmp + ' (UPPER(contestname) = ' + QuotedStr(upcase(cmbContestName.Text))+')';
-    tmp := tmp + ' AND'
-  end;
-  if (edtSTX.Text <> '') then
-  begin
-    tmp := tmp + ' (stx = ' + QuotedStr(edtSTX.Text)+')';
-    tmp := tmp + ' AND'
-  end;
-  if (edtSRX.Text <> '') then
-    begin
-      tmp := tmp + ' (srx = ' + QuotedStr(edtSRX.Text)+')';
-      tmp := tmp + ' AND'
-    end;
-  if (edtSTXstr.Text <> '') then
-    begin
-      tmp := tmp + ' (UPPER(stx_string) = ' + QuotedStr(upcase(edtSTXstr.Text))+')';
-      tmp := tmp + ' AND'
-    end;
-  if (edtSRXstr.Text <> '') then
-    begin
-      tmp := tmp + ' (UPPER(srx_string) = ' + QuotedStr(upcase(edtSRXstr.Text))+')';
-      tmp := tmp + ' AND'
-    end;
-  if (edtDateFrom.Text <> '') then
-  begin
-    tmp := tmp + ' (qsodate >= ' + QuotedStr(edtDateFrom.Text) + ') AND (qsodate <= ' +
-                QuotedStr(edtDateTo.Text) + ')';
-    tmp := tmp + ' AND'
-  end;
+                                      begin
+                                        if cbIncConName.Checked then
+                                           tmp := tmp + ' (UPPER(contestname) LIKE ''%' +
+                                                         upcase(cmbContestName.Text) + '%'') AND'
+                                          else
+                                           tmp := tmp + ' (UPPER(contestname) = ' +
+                                                        QuotedStr(upcase(cmbContestName.Text))+') AND';
+                                        end;
+
+  if (edtSTX.Text <> '') then tmp := tmp + ' (stx = ' + QuotedStr(edtSTX.Text)+') AND';
+
+  if (edtSRX.Text <> '') then  tmp := tmp + ' (srx = ' + QuotedStr(edtSRX.Text)+') AND';
+
+  if (edtSTXstr.Text <> '') then  tmp := tmp + ' (UPPER(stx_string) = ' + QuotedStr(upcase(edtSTXstr.Text))+') AND';
+
+  if (edtSRXstr.Text <> '') then  tmp := tmp + ' (UPPER(srx_string) = ' + QuotedStr(upcase(edtSRXstr.Text))+') AND';
+
+  //NOTE that empty calendar.Text is not empty string, but Date is =0!
+  if edtDateFrom.Date <> 0 then tmp := tmp + ' (qsodate >= ' + QuotedStr(dmUtils.MyDateToStr(edtDateFrom.Date)) +
+                                             ') AND (qsodate <= ' + QuotedStr(dmUtils.MyDateToStr(edtDateTo.Date)) +
+                                             ') AND';
+
   if (edtLocator.Text <> '') then
-  begin
-    if rbExactlyLoc.Checked then
-      tmp := tmp + ' (loc = ' + QuotedStr(edtLocator.Text)+')'
-    else
-      tmp := tmp + ' (loc LIKE ''%' + edtLocator.Text + '%'')';
-    tmp := tmp + ' AND';
-  end;
+                                  begin
+                                    if rbExactlyLoc.Checked then
+                                      tmp := tmp + ' (loc = ' + QuotedStr(edtLocator.Text)+') AND'
+                                    else
+                                      tmp := tmp + ' (loc LIKE ''%' + edtLocator.Text + '%'') AND';
+                                  end;
   if (edtQTH.Text <> '') then
-  begin
-    if rbExactlyQth.Checked then
-      tmp := tmp + ' (qth = ' + QuotedStr(edtQTH.Text)+')'
-    else
-      tmp := tmp + ' (qth LIKE ''%' + edtQTH.Text + '%'')';
-    tmp := tmp + ' AND';
-  end;
-  if (edtQSLVia.Text <> '') then
-  begin
-    tmp := tmp + ' (qsl_via = ' + QuotedStr(edtQSLVia.Text)+')';
-    tmp := tmp + ' AND'
-  end;
+                                  begin
+                                    if rbExactlyQth.Checked then
+                                      tmp := tmp + ' (qth = ' + QuotedStr(edtQTH.Text)+') AND'
+                                    else
+                                      tmp := tmp + ' (qth LIKE ''%' + edtQTH.Text + '%'') AND';
+                                  end;
+
+  if (edtQSLVia.Text <> '') then  tmp := tmp + ' (qsl_via = ' + QuotedStr(edtQSLVia.Text)+') AND';
+
   if (cmbQSL_S.Text <> '') then
-  begin
-    if cmbQSL_S.Text = 'S' then
-      tmp := tmp + ' (qsl_s LIKE ''%' + cmbQSL_S.Text + '%'')'
-    else begin
-      if cmbQSL_S.Text = 'Empty' then
-        tmp := tmp + '((qsl_s = ' + QuotedStr('')+') or (qsl_s is null))'
-      else
-        tmp := tmp + '(qsl_s = ' + QuotedStr(cmbQSL_S.Text)+')'
-    end;
-    tmp := tmp + ' AND'
-  end;
+                                  begin
+                                    if cmbQSL_S.Text = 'S' then
+                                      tmp := tmp + ' (qsl_s LIKE ''%' + cmbQSL_S.Text + '%'') AND'
+                                    else
+                                     begin
+                                      if cmbQSL_S.Text = 'Empty' then
+                                        tmp := tmp + '((qsl_s = ' + QuotedStr('')+') or (qsl_s is null)) AND'
+                                      else
+                                        tmp := tmp + '(qsl_s = ' + QuotedStr(cmbQSL_S.Text)+') AND'
+                                     end;
+                                  end;
   if (cmbQSL_R.Text <> '') then
-  begin
-    if cmbQSL_R.Text = 'Empty' then
-      tmp := tmp + '((qsl_r = ' + QuotedStr('')+') or (qsl_r is null))'
-    else
-      tmp := tmp + '(qsl_r = ' + QuotedStr(cmbQSL_R.Text)+')';
-    tmp := tmp + ' AND'
-  end;
+                                  begin
+                                    if cmbQSL_R.Text = 'Empty' then
+                                      tmp := tmp + '((qsl_r = ' + QuotedStr('')+') or (qsl_r is null)) AND'
+                                    else
+                                      tmp := tmp + '(qsl_r = ' + QuotedStr(cmbQSL_R.Text)+') AND';
+                                  end;
   if (edtIOTA.Text <> '') then
-  begin
-    if rbExactlyIOTA.Checked then
-      tmp := tmp + ' (iota = ' + QuotedStr(edtIOTA.Text)+')'
-    else
-      tmp := tmp + ' (iota LIKE ''%' + edtIOTA.Text + '%'')';
-    tmp := tmp + ' AND'
-  end;
-  if chkIOTAOnly.Checked then
-  begin
-    tmp := tmp + ' (iota IS NOT NULL)';
-    tmp := tmp + ' AND'
-  end;
+                                  begin
+                                    if rbExactlyIOTA.Checked then
+                                      tmp := tmp + ' (iota = ' + QuotedStr(edtIOTA.Text)+') AND'
+                                     else
+                                      tmp := tmp + ' (iota LIKE ''%' + edtIOTA.Text + '%'') AND';
+                                  end;
+
+  if chkIOTAOnly.Checked then tmp := tmp + ' (iota IS NOT NULL) AND';
+
   if (edtReMarks.Text <> '') then
-  begin
-    if rbExactlyRem.Checked then
-      tmp := tmp + ' (remarks = ' + QuotedStr(edtRemarks.Text)+')'
-    else
-      tmp := tmp + ' (remarks LIKE ''%' + edtRemarks.Text + '%'')';
-    tmp := tmp + ' AND';
-  end;
+                                  begin
+                                    if rbExactlyRem.Checked then
+                                      tmp := tmp + ' (remarks = ' + QuotedStr(edtRemarks.Text)+') AND'
+                                     else
+                                      tmp := tmp + ' (remarks LIKE ''%' + edtRemarks.Text + '%'') AND';
+                                  end;
   if (edtDiplom.Text <> '') then
-  begin
-    if rbExactlyDiplom.Checked then
-      tmp := tmp + ' (award = ' + QuotedStr(edtDiplom.Text)+')'
-    else
-      tmp := tmp + ' (award LIKE ''%' + edtDiplom.Text + '%'')';
-    tmp := tmp + ' AND';
-  end;
+                                  begin
+                                    if rbExactlyDiplom.Checked then
+                                      tmp := tmp + ' (award = ' + QuotedStr(edtDiplom.Text)+') AND'
+                                     else
+                                      tmp := tmp + ' (award LIKE ''%' + edtDiplom.Text + '%'') AND';
+                                  end;
   if (edtMyLoc.Text <> '') then
-  begin
-    if rbExactlyMyLoc.Checked then
-      tmp := tmp + ' (my_loc = ' + QuotedStr(edtMyLoc.Text)+')'
-    else
-      tmp := tmp + ' (my_loc LIKE ''%' + edtMyLoc.Text + '%'')';
-    tmp := tmp + ' AND';
-  end;
-  if (edtWAZ.Text <> '') then
-  begin
-    tmp := tmp + ' (waz = ' + edtWAZ.Text + ')';
-    tmp := tmp + ' AND';
-  end;
-  if (edtITU.Text <> '') then
-  begin
-    tmp := tmp + ' (itu = ' + edtITU.Text + ')';
-    tmp := tmp + ' AND';
-  end;
+                                  begin
+                                    if rbExactlyMyLoc.Checked then
+                                      tmp := tmp + ' (my_loc = ' + QuotedStr(edtMyLoc.Text)+') AND'
+                                     else
+                                      tmp := tmp + ' (my_loc LIKE ''%' + edtMyLoc.Text + '%'') AND';
+                                  end;
+
+  if (edtWAZ.Text <> '') then  tmp := tmp + ' (waz = ' + edtWAZ.Text + ') AND';
+
+  if (edtITU.Text <> '') then tmp := tmp + ' (itu = ' + edtITU.Text + ') AND';
+
   if (edtCounty.Text <> '') then
-  begin
-    if rbExactlyCounty.Checked then
-      tmp := tmp + ' (county = ' + QuotedStr(edtCounty.Text)+')'
-    else
-      tmp := tmp + ' (county LIKE ''%' + edtCounty.Text + '%'')';
-    tmp := tmp + ' AND';
-  end;
+                                  begin
+                                    if rbExactlyCounty.Checked then
+                                      tmp := tmp + ' (county = ' + QuotedStr(edtCounty.Text)+') AND'
+                                     else
+                                      tmp := tmp + ' (county LIKE ''%' + edtCounty.Text + '%'') AND';
+                                  end;
 
-  if edtState.Text <> '' then
-  begin
-    tmp := tmp + ' (state = ' + QuotedStr(edtState.Text)+')';
-    tmp := tmp + ' AND';
-  end;
+  if edtState.Text <> '' then tmp := tmp + ' (state = ' + QuotedStr(edtState.Text)+') AND';
 
-  if cmbProfile.ItemIndex > 0 then
-  begin
-    tmp := tmp + '(profile = ' + IntToStr(dmData.GetNRFromProfile(cmbProfile.Text)) + ')';
-    tmp := tmp + ' AND';
-  end;
-  
+  if cmbProfile.ItemIndex > 0 then tmp := tmp + '(profile = ' + IntToStr(dmData.GetNRFromProfile(cmbProfile.Text)) +
+                                                ') AND';
+
   if cmbLoTW_qsls.ItemIndex > 0 then
-  begin
-    if cmbLoTW_qsls.ItemIndex = 1 then
-      tmp := tmp + ' (lotw_qsls='+QuotedStr('Y')+') AND'
-    else
-      tmp := tmp +  '(lotw_qsls <> '+QuotedStr('Y')+') AND'
-  end;
+                                  begin
+                                    if cmbLoTW_qsls.ItemIndex = 1 then
+                                      tmp := tmp + ' (lotw_qsls='+QuotedStr('Y')+') AND'
+                                     else
+                                      tmp := tmp +  '(lotw_qsls <> '+QuotedStr('Y')+') AND'
+                                  end;
   
   if cmbLoTW_qslr.ItemIndex > 0 then
-  begin
-    if cmbLoTW_qslr.ItemIndex = 1 then
-      tmp := tmp + ' (lotw_qslr='+QuotedStr('L')+') AND'
-    else
-      tmp := tmp + ' (lotw_qslr <> '+QuotedStr('L')+') AND'
-  end;
+                                  begin
+                                    if cmbLoTW_qslr.ItemIndex = 1 then
+                                      tmp := tmp + ' (lotw_qslr='+QuotedStr('L')+') AND'
+                                     else
+                                      tmp := tmp + ' (lotw_qslr <> '+QuotedStr('L')+') AND'
+                                  end;
 
   if edtCont.Text <> '' then
-  begin
-    if pos(';',edtCont.Text) > 0 then
-    begin
-      SetLength(p,0);
-      p := dmUtils.Explode(';',edtCont.Text);
-      for i:=0 to Length(p)-1 do
-        tmp := tmp + ' (cont = '+QuotedStr(p[i])+') OR'
-    end
-    else
-      tmp := tmp + ' (cont = '+QuotedStr(edtCont.Text)+') AND'
-  end;
+                                  begin
+                                    if pos(';',edtCont.Text) > 0 then
+                                    begin
+                                      SetLength(p,0);
+                                      p := dmUtils.Explode(';',edtCont.Text);
+                                      for i:=0 to Length(p)-1 do
+                                        tmp := tmp + ' (cont = '+QuotedStr(p[i])+') OR'
+                                    end
+                                    else
+                                      tmp := tmp + ' (cont = '+QuotedStr(edtCont.Text)+') AND'
+                                  end;
 
   if cmbeQSL_qsls.ItemIndex > 0 then
-  begin
-    if cmbeQSL_qsls.ItemIndex = 1 then
-      tmp := tmp + ' (eqsl_qsl_sent = '+QuotedStr('Y')+') AND'
-    else
-      tmp := tmp +  '(eqsl_qsl_sent <> '+QuotedStr('Y')+') AND'
-  end;
+                                  begin
+                                    if cmbeQSL_qsls.ItemIndex = 1 then
+                                      tmp := tmp + ' (eqsl_qsl_sent = '+QuotedStr('Y')+') AND'
+                                     else
+                                      tmp := tmp +  '(eqsl_qsl_sent <> '+QuotedStr('Y')+') AND'
+                                  end;
 
   if cmbeQSL_qslr.ItemIndex > 0 then
-  begin
-    if cmbeQSL_qslr.ItemIndex = 1 then
-      tmp := tmp + ' (eqsl_qsl_rcvd = '+QuotedStr('E')+') AND'
-    else
-      tmp := tmp + ' (eqsl_qsl_rcvd <> '+QuotedStr('E')+') AND'
-  end;
+                                  begin
+                                    if cmbeQSL_qslr.ItemIndex = 1 then
+                                      tmp := tmp + ' (eqsl_qsl_rcvd = '+QuotedStr('E')+') AND'
+                                     else
+                                      tmp := tmp + ' (eqsl_qsl_rcvd <> '+QuotedStr('E')+') AND'
+                                  end;
 
-  if ((edtPwrFrom.Text <> '') and (edtPwrTo.Text <> '')) then
-  begin
-    tmp := tmp + ' (pwr >= ' + edtPwrFrom.Text + ') AND '+
-                 ' (pwr <= ' + edtPwrTo.Text + ')';
-    tmp := tmp + ' AND'
-  end;
+  if ((edtPwrFrom.Text <> '') and (edtPwrTo.Text <> '')) then  tmp := tmp + ' (pwr >= ' + edtPwrFrom.Text + ') AND '+
+                                                                            ' (pwr <= ' + edtPwrTo.Text + ') AND';
 
-  if cmbMembers.ItemIndex >0 then
-    tmp := tmp + ' (club_nr'+IntToStr(cmbMembers.ItemIndex)+' <> '+QuotedStr('')+') AND';
+
+  if cmbMembers.ItemIndex >0 then tmp := tmp + ' (club_nr'+IntToStr(cmbMembers.ItemIndex)+' <> '+
+                                               QuotedStr('')+') AND';
 
   if (tmp <> '') then
-  begin
-    tmp := Trim(tmp);
-    tmp := copy(tmp,1,Length(tmp)-3);
+                      begin
+                        tmp := Trim(tmp);
+                        tmp := copy(tmp,1,Length(tmp)-3);
 
-    case cmbSort.ItemIndex of
-      0 : OrderBy := '';  //Already set in view   OrderBy := ' ORDER BY qsodate,time_on';
-      1 : OrderBy := ' ORDER BY callsign';
-      2 : OrderBy := ' ORDER BY mode';
-      3 : OrderBy := ' ORDER BY freq';
-      4 : OrderBy := ' ORDER BY name';
-      5 : OrderBy := ' ORDER BY qth';
-      6 : OrderBy := ' ORDER BY dxcc_ref';
-      7 : OrderBy := ' ORDER BY award';
-      8 : OrderBy := ' ORDER BY state';
-      9 : OrderBy := ' ORDER BY county';
-     10 : OrderBy := ' ORDER BY dxcc_ref';
-     11 : OrderBy := ' ORDER BY dxcc_ref,callsign';
-     12 : OrderBy := ' ORDER By qsl_via,callsign,dxcc_ref';
-     13 : OrderBy := ' ORDER By callsign,dxcc_ref';
-     14 : OrderBy := ' ORDER BY waz';
-     15 : OrderBy := ' ORDER BY itu';
-     16 : OrderBy := ' ORDER BY loc'
-    end;//case
+                        case cmbSort.ItemIndex of
+                          0 : OrderBy := '';  //Already set in view   OrderBy := ' ORDER BY qsodate,time_on';
+                          1 : OrderBy := ' ORDER BY callsign';
+                          2 : OrderBy := ' ORDER BY mode';
+                          3 : OrderBy := ' ORDER BY freq';
+                          4 : OrderBy := ' ORDER BY name';
+                          5 : OrderBy := ' ORDER BY qth';
+                          6 : OrderBy := ' ORDER BY dxcc_ref';
+                          7 : OrderBy := ' ORDER BY award';
+                          8 : OrderBy := ' ORDER BY state';
+                          9 : OrderBy := ' ORDER BY county';
+                         10 : OrderBy := ' ORDER BY dxcc_ref';
+                         11 : OrderBy := ' ORDER BY dxcc_ref,callsign';
+                         12 : OrderBy := ' ORDER By qsl_via,callsign,dxcc_ref';
+                         13 : OrderBy := ' ORDER By callsign,dxcc_ref';
+                         14 : OrderBy := ' ORDER BY waz';
+                         15 : OrderBy := ' ORDER BY itu';
+                         16 : OrderBy := ' ORDER BY loc'
+                        end;//case
 
-    case cmbGroupBy.ItemIndex of
-      1  : grb_by := 'GROUP BY dxcc_ref';
-      2  : grb_by := 'GROUP BY remarks';
-      3  : grb_by := 'GROUP BY award';
-      4  : grb_by := 'GROUP BY callsign';
-      5  : grb_by := 'GROUP BY idcall';
-      6  : grb_by := 'GROUP BY loc';
-      7  : grb_by := 'GROUP BY iota';
-      8  : grb_by := 'GROUP BY waz';
-      9  : grb_by := 'GROUP BY itu';
-      10 : grb_by := 'GROUP BY state';
-      11 : grb_by := 'GROUP BY county';
-      12 : grb_by := 'GROUP BY club_nr1';
-      13 : grb_by := 'GROUP BY club_nr2';
-      14 : grb_by := 'GROUP BY club_nr3';
-      15 : grb_by := 'GROUP BY club_nr4';
-      16 : grb_by := 'GROUP BY club_nr5'
-    end; //case
+                        case cmbGroupBy.ItemIndex of
+                          1  : grb_by := 'GROUP BY dxcc_ref';
+                          2  : grb_by := 'GROUP BY remarks';
+                          3  : grb_by := 'GROUP BY award';
+                          4  : grb_by := 'GROUP BY callsign';
+                          5  : grb_by := 'GROUP BY idcall';
+                          6  : grb_by := 'GROUP BY loc';
+                          7  : grb_by := 'GROUP BY iota';
+                          8  : grb_by := 'GROUP BY waz';
+                          9  : grb_by := 'GROUP BY itu';
+                          10 : grb_by := 'GROUP BY state';
+                          11 : grb_by := 'GROUP BY county';
+                          12 : grb_by := 'GROUP BY club_nr1';
+                          13 : grb_by := 'GROUP BY club_nr2';
+                          14 : grb_by := 'GROUP BY club_nr3';
+                          15 : grb_by := 'GROUP BY club_nr4';
+                          16 : grb_by := 'GROUP BY club_nr5'
+                        end; //case
 
-    if chkNot.Checked then tmp:= 'NOT( '+tmp+' )';
-    tmp := 'SELECT * FROM view_cqrlog_main_by_qsodate WHERE ' + tmp + ' ' + grb_by +' ' + OrderBy;
+                        if chkNot.Checked then tmp:= 'NOT( '+tmp+' )';
+                        tmp := 'SELECT * FROM view_cqrlog_main_by_qsodate WHERE ' + tmp + ' ' + grb_by +' ' + OrderBy;
 
-    dmData.qCQRLOG.Close;
-    dmData.qCQRLOG.SQL.Text := tmp;
-    if dmData.DebugLevel >=1 then
-      Writeln(tmp);
-    if dmData.trCQRLOG.Active then
-      dmData.trCQRLOG.Rollback;
-    dmData.trCQRLOG.StartTransaction;
-    dmData.qCQRLOG.Open;
-    dmData.qCQRLOG.Last
-  end;
+                        dmData.qCQRLOG.Close;
+                        dmData.qCQRLOG.SQL.Text := tmp;
+                        if dmData.DebugLevel >=1 then
+                          Writeln(tmp);
+                        if dmData.trCQRLOG.Active then
+                          dmData.trCQRLOG.Rollback;
+                        dmData.trCQRLOG.StartTransaction;
+                        dmData.qCQRLOG.Open;
+                        dmData.qCQRLOG.Last
+                      end;
   ModalResult := mrOK;
-end;
-
-procedure TfrmFilter.edtDateFromExit(Sender: TObject);
-begin
-  if Length(edtDateFrom.Text)=8 then
-  begin
-    tmp := edtDateFrom.Text;
-    edtDateFrom.Text := copy(tmp,1,4) + '-' + copy(tmp,5,2) + '-' + copy(tmp,7,2)
-  end
-end;
-
-procedure TfrmFilter.edtDateToExit(Sender: TObject);
-begin
-  if Length(edtDateTo.Text)=8 then
-  begin
-    tmp := edtDateTo.Text;
-    edtDateTo.Text := copy(tmp,1,4) + '-' + copy(tmp,5,2) + '-' + copy(tmp,7,2)
-  end
 end;
 
 procedure TfrmFilter.btnCancelClick(Sender: TObject);
@@ -533,12 +470,9 @@ end;
 //creates and shows itself in every opening
 
 procedure TfrmFilter.FormShow(Sender: TObject);
-var
-  Mask, sDate : String;
+
 begin
   dmUtils.LoadFontSettings(self);
-  Mask  := '';
-  sDate := '';
   dmUtils.InsertQSL_S(cmbQSL_S);
   cmbQSL_S.Items.Insert(9,'S');
   cmbQSL_S.Items.Add('Empty');
@@ -546,8 +480,7 @@ begin
   cmbQSL_R.Items.Add('Empty');
   dmUtils.InsertModes(cmbMode);
   cmbMode.Items.Insert(0,'');
-  dmUtils.DateInRightFormat(now,Mask,sDate);
-  edtDateTo.Text       := sDate;
+
   dmData.InsertProfiles(cmbProfile,True);
   cmbProfile.Text := dmData.GetDefaultProfileText;
   cmbProfile.Items.Insert(0,'Any profile');
@@ -626,6 +559,7 @@ begin
 
 end;
 
+
 procedure TfrmFilter.edtLocatorChange(Sender: TObject);
 begin
    if rbExactlyLoc.Checked then
@@ -670,8 +604,10 @@ begin
       edtFreqFrom.Text         := '';
       edtFreqTo.Text           := '';
       cmbMode.Text             := '';
-      edtDateFrom.Text         := '';
-      edtDateTo.Text           := dmUtils.MyDateToStr(now);
+      edtDateFrom.Text         := '';    //
+      edtDateFrom.Date         := 0;     //I think one (date or Text) is enough, but for sure ...
+      edtDateTo.Text           := '';    //
+      edtDateTo.Date           := 0;     //
       edtLocator.Text          := '';
       edtQTH.Text              := '';
       cmbQSL_S.Text            := '';
@@ -738,8 +674,11 @@ begin
       filini.WriteString('freq','freq_from',edtFreqFrom.Text);
       filini.WriteString('freq','freq_to',edtFreqTo.Text);
       filini.WriteString('mode','mode',cmbMode.Text);
-      filini.WriteString('date','date_from',edtDateFrom.Text);
-      filini.WriteString('date','date_to',edtDateTo.Text);
+      //NOTE that empty calendar is not empty string, but date is 0!
+      if edtDateFrom.Date = 0 then filini.WriteString('date','date_from','')
+       else filini.WriteString('date','date_from',dmUtils.MyDateToStr(edtDateFrom.Date));
+      if edtDateTo.Date = 0 then  filini.WriteString('date','date_to','')
+       else filini.WriteString('date','date_to',dmUtils.MyDateToStr(edtDateTo.Date));
       filini.WriteString('locator','locator',edtLocator.Text);
       filini.WriteBool('locator','exactly',rbExactlyLoc.Checked);
       filini.WriteString('qth','qth',edtQTH.Text);
@@ -795,8 +734,9 @@ var
       edtFreqFrom.Text        := filini.ReadString('freq','freq_from','');
       edtFreqTo.Text          := filini.ReadString('freq','freq_to','');
       cmbMode.Text            := filini.ReadString('mode','mode','');
+      //I think setting just .Text sets also .Date in case of empty
       edtDateFrom.Text        := filini.ReadString('date','date_from','');
-      edtDateTo.Text          := filini.ReadString('date','date_to',dmUtils.MyDateToStr(now));
+      edtDateTo.Text          := filini.ReadString('date','date_to','');
       edtLocator.Text         := filini.ReadString('locator','locator','');
       rbIncludeLoc.Checked    := not filini.ReadBool('locator','exactly',True);
       edtQTH.Text             := filini.ReadString('qth','qth','');

--- a/src/fPreferences.lfm
+++ b/src/fPreferences.lfm
@@ -6931,7 +6931,6 @@ object frmPreferences: TfrmPreferences
             AutoSize = False
             NumGlyphs = 1
             MaxLength = 10
-            OnEditingDone = DateEditCallEditingDone
             TabOrder = 2
             Text = '    .  .  '
           end
@@ -6952,7 +6951,6 @@ object frmPreferences: TfrmPreferences
             BorderSpacing.Top = 10
             NumGlyphs = 1
             MaxLength = 10
-            OnEditingDone = DateEditLocEditingDone
             TabOrder = 3
             Text = '    .  .  '
           end

--- a/src/fPreferences.pas
+++ b/src/fPreferences.pas
@@ -1025,8 +1025,6 @@ type
     procedure cmbSpeedR2Change(Sender : TObject);
     procedure cmbStopBitsR1Change(Sender : TObject);
     procedure cmbStopBitsR2Change(Sender : TObject);
-    procedure DateEditCallEditingDone(Sender: TObject);
-    procedure DateEditLocEditingDone(Sender: TObject);
     procedure edtK3NGSerSpeedChange(Sender: TObject);
     procedure edtLocChange(Sender: TObject);
     procedure edtR1RigCtldArgsChange(Sender: TObject);
@@ -2367,16 +2365,6 @@ end;
 procedure TfrmPreferences.cmbStopBitsR2Change(Sender : TObject);
 begin
   TRXChanged := True
-end;
-
-procedure TfrmPreferences.DateEditCallEditingDone(Sender: TObject);
-begin
-
-end;
-
-procedure TfrmPreferences.DateEditLocEditingDone(Sender: TObject);
-begin
-
 end;
 
 procedure TfrmPreferences.edtK3NGSerSpeedChange(Sender: TObject);


### PR DESCRIPTION
This will fix calendar (TDateEdit) usage and allows to save filter with from_date and to_date empty.
Some clean ups for code creating the SQLfilter (btnOK pressed)
Version number update to help index page.

Squashed commit of the following:

commit 48a290c44aa6bf6d9fe48c8e7aebf8e3d367d42d
Author: OH1KH <oh1kh@sral.fi>
Date:   Mon Dec 2 19:15:24 2019 +0200

    cqrlog version to 2.4.0 at help index

commit d5227f8dabd8224c1cadde5a0651c1fb296eab59
Author: OH1KH <oh1kh@sral.fi>
Date:   Sun Dec 1 12:03:07 2019 +0200

    Date fixes

commit 913649f18650be8aa629a486d241630594b18f98
Merge: 67d1330 e1d0d62
Author: OH1KH <oh1kh@sral.fi>
Date:   Sun Dec 1 10:56:38 2019 +0200

    merged master

commit 67d13300acb1ef01f26825b2aea52d95ee859bda
Merge: 122db64 e9c4c88
Author: OH1KH <oh1kh@sral.fi>
Date:   Mon Nov 25 15:46:22 2019 +0200

    Merge branch 'master' into filter_to_date

commit 122db64c540b877ea4974c6f70382a1d9d436826
Author: OH1KH <oh1kh@sral.fi>
Date:   Mon Nov 18 17:43:18 2019 +0200

    Fixed date-to: save as empty