### PR TITLE
Fix eQSL upload selector texts and CQ-monitor follow addition

### DIFF
--- a/src/cqrlog.lpi
+++ b/src/cqrlog.lpi
@@ -820,6 +820,7 @@
     </CodeGeneration>
     <Linking>
       <Debugging>
+        <GenerateDebugInfo Value="False"/>
         <DebugInfoType Value="dsDwarf2Set"/>
       </Debugging>
     </Linking>

--- a/src/fMonWsjtx.pas
+++ b/src/fMonWsjtx.pas
@@ -1170,6 +1170,8 @@ begin
 
   if (( msgList.Count < 2 ) and (pos(edtFollowCall.Text,msgList[0])>0))//1 items: Fcall exist: "OH1KH/IMAGE"
    or (( msgList.Count > 1 ) and (pos(edtFollowCall.Text,msgList[0])=0))//2 or more items and Fcall is not 1st
+    or (( msgList.Count > 1 ) and (pos(edtFollowCall.Text,msgList[0])=1) //special call is 1st and second is
+       and frmWorkedGrids.GridOK(msgList[1]) )                                         //locator like "F5MYK/MM OJ12"
      then
           begin
             edtFollow.Font.Color := clBlack;

--- a/src/feQSLUpload.pas
+++ b/src/feQSLUpload.pas
@@ -195,7 +195,20 @@ end;
 procedure TfrmeQSLUpload.FormShow(Sender : TObject);
 begin
   dmUtils.LoadWindowPos(frmeQSLUpload);
-  edtQTH.Text := cqrini.ReadString('eQSL','QTH','')
+  edtQTH.Text := cqrini.ReadString('eQSL','QTH','');
+  if dmData.IsFilter then
+    begin
+      rbWebExportNotExported.Caption:='Export all QSOs which have never been uploaded (bypass filter results)';
+      rbWebExportAll.Caption:='Export QSOs from filter result';
+      rbWebExportAll.Checked:=true;
+    end
+   else
+    begin
+      rbWebExportNotExported.Caption:='Export only QSOs which have never been uploaded';
+      rbWebExportAll.Caption:='Export all QSOs in log';
+      rbWebExportNotExported.Checked:=true;
+    end;
+
 end;
 
 procedure TfrmeQSLUpload.FormClose(Sender : TObject;


### PR DESCRIPTION
- Changes eQSL upload radio button selector texts by filter activated to make user understand better what is uploaded.

- CQ-monitor/follow: In addition to follow decodes by selected callsign follows also free text originated by selected call. This may happen if selected call is a special call or has extension /M /MM. The he can not show his location in CQ line but he can send a free text message for every now and then like "F5MYK/MM OJ12". Now follow copies line if follwed call is then first word and second word is qualified locator. It makes it easier to catch from all decoded results.

Squashed commit of the following:

commit e0c4122832915d0215f209b3338facdf88fb0817
Author: OH1KH <oh1kh@sral.fi>
Date:   Mon Dec 23 13:01:05 2019 +0200

    Change eQSL upload selector texts by filter

commit 049721fa318749eeb72f880836d34bdda7ad176a
Merge: 758a845 f5ab805
Author: OH1KH <oh1kh@sral.fi>
Date:   Sun Dec 15 08:48:09 2019 +0200

    Merge branch 'master' into follow_fix

commit 758a845dc3a952ee638728fd61f57abe1e07eb13
Author: OH1KH <oh1kh@sral.fi>
Date:   Sat Dec 14 14:43:05 2019 +0200

    Follow call now founds speciall calls locator indication(freetext) like 'F5MYK/MM OJ12'