### PR TITLE
Don't remove debian/cqrlog* on clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,9 +11,8 @@ cqrlog: src/cqrlog.lpi
 	gzip tools/cqrlog.1 -c > tools/cqrlog.1.gz
 
 clean:
-	rm -f -v src/*.o src/*.ppu src/*.bak src/lnet/lib/*.ppu src/lnet/lib/*.o src/lnet/lib/*.bak src/cqrlog src/cqrlog.compiled debian/cqrlog.* src/ipc/*.o src/ipc/*.ppu src/cqrlog.or
+	rm -f -v src/*.o src/*.ppu src/*.bak src/lnet/lib/*.ppu src/lnet/lib/*.o src/lnet/lib/*.bak src/cqrlog src/cqrlog.compiled src/ipc/*.o src/ipc/*.ppu src/cqrlog.or
 	rm -f -v src/*.lrs src/*.ps src/*.lrt src/*.rsh  src/*.rst src/*.a src/synapse/*.a src/synapse/*.o src/synapse/*.ppu
-	rm -rf debian/cqrlog
 	rm -f -v src/mysql/*.ppu src/mysq/*.bak src/mysql/*.o
 	rm -f -v tools/cqrlog.1.gz
 	rm -rf src/backup


### PR DESCRIPTION
This interferes with the packaging in Debian, and is hard to remove via
a patch because "clean" is invoked even when patches are not applied.
Specifically, it removes https://salsa.debian.org/debian-hamradio-team/cqrlog/blob/master/debian/cqrlog.install

(To remove debian/ artifacts at "clean" time, use debian/clean instead,
but shouldn't be needed as debhelper will clean up by itself.)