### PR TITLE
Fixes unknown column dxcc_ref

### DIFF
--- a/src/dData.pas
+++ b/src/dData.pas
@@ -2549,7 +2549,7 @@ begin
     end
   end;
   if pos('WHERE', Q.SQL.Text) > 0 then
-    Q.SQL.Text := 'SELECT COUNT(DISTINCT(LEFT(loc,4))) FROM cqrlog_main WHERE left(loc,4) <> "" AND '
+       Q.SQL.Text := 'SELECT COUNT(DISTINCT(LEFT(loc,4))) FROM view_cqrlog_main_by_qsodate WHERE left(loc,4) <> "" AND '
       + copy(Q.SQL.Text, pos('WHERE', Q.SQL.Text)+5, length(Q.SQL.Text))
    else
     Q.SQL.Text := 'SELECT COUNT(DISTINCT(LEFT(loc,4))) FROM cqrlog_main WHERE left(loc,4) <> "" ';


### PR DESCRIPTION
Issue #236 was not actually filter problem.
Distance counts in "qso list" window that were updated after setting filter did refer to cqrlog_main that really does not have column "dxcc_ref".
It appears as generated in "view_cqrlog_main_by_qsodate" that is now used instead of cqrlog_main and should fix this, and maybe other similar issues when filter is used.