### PR TITLE
Some fixes to CW

### DIFF
--- a/src/cqrlog.lpi
+++ b/src/cqrlog.lpi
@@ -39,7 +39,7 @@
     </PublishOptions>
     <RunParams>
       <local>
-        <CommandLineParams Value="--DEBUG=1"/>
+        <CommandLineParams Value="--DEBUG=0"/>
         <LaunchingApplication PathPlusParams="/usr/X11R6/bin/xterm -T 'Lazarus Run Output' -e $(LazarusDir)/tools/runwait.sh $(TargetCmdLine)"/>
       </local>
       <environment>
@@ -52,7 +52,7 @@
       <Modes Count="1">
         <Mode0 Name="default">
           <local>
-            <CommandLineParams Value="--DEBUG=1"/>
+            <CommandLineParams Value="--DEBUG=0"/>
             <LaunchingApplication PathPlusParams="/usr/X11R6/bin/xterm -T 'Lazarus Run Output' -e $(LazarusDir)/tools/runwait.sh $(TargetCmdLine)"/>
           </local>
           <environment>
@@ -105,7 +105,7 @@
         <MinVersion Major="1" Minor="2" Release="1" Valid="True"/>
       </Item10>
     </RequiredPackages>
-    <Units Count="106">
+    <Units Count="108">
       <Unit0>
         <Filename Value="cqrlog.lpr"/>
         <IsPartOfProject Value="True"/>
@@ -800,6 +800,17 @@
         <Filename Value="azidis3.pas"/>
         <IsPartOfProject Value="True"/>
       </Unit105>
+      <Unit106>
+        <Filename Value="fCWKeys.pas"/>
+        <IsPartOfProject Value="True"/>
+        <ComponentName Value="frmCWKeys"/>
+        <HasResources Value="True"/>
+        <ResourceBaseClass Value="Form"/>
+      </Unit106>
+      <Unit107>
+        <Filename Value="fCWKeys.lfm"/>
+        <IsPartOfProject Value="True"/>
+      </Unit107>
     </Units>
   </ProjectOptions>
   <CompilerOptions>

--- a/src/fCWKeys.lfm
+++ b/src/fCWKeys.lfm
@@ -1,19 +1,27 @@
 object frmCWKeys: TfrmCWKeys
-  Left = 392
-  Height = 67
-  Top = 566
-  Width = 682
-  Caption = 'CW keys'
-  ClientHeight = 67
-  ClientWidth = 682
+  Left = 253
+  Height = 93
+  Top = 106
+  Width = 820
+  Caption = 'Memory keys'
+  ClientHeight = 93
+  ClientWidth = 820
   KeyPreview = True
   OnClose = FormClose
+  OnKeyDown = FormKeyDown
   OnKeyUp = FormKeyUp
   OnShow = FormShow
-  LCLVersion = '0.9.30.2'
+  LCLVersion = '2.0.4.0'
   inline fraCWKeys: TfraCWKeys
-    Height = 67
+    Height = 93
+    Width = 820
     Align = alClient
-    ClientHeight = 67
+    ClientHeight = 93
+    ClientWidth = 820
+    inherited lblToShowMouseOverTextCwKeys: TLabel
+      AnchorSideLeft.Control = fraCWKeys
+      AnchorSideBottom.Control = fraCWKeys
+      Top = 74
+    end
   end
 end

--- a/src/fCWKeys.pas
+++ b/src/fCWKeys.pas
@@ -6,7 +6,7 @@ interface
 
 uses
   Classes, SysUtils, FileUtil, LResources, Forms, Controls, Graphics, Dialogs,
-  StdCtrls, ExtCtrls,frCWKeys;
+  StdCtrls, ExtCtrls,frCWKeys,LCLType;
 
 type
 
@@ -15,10 +15,11 @@ type
   TfrmCWKeys = class(TForm)
     fraCWKeys : TfraCWKeys;
     procedure FormClose(Sender: TObject; var CloseAction: TCloseAction);
+    procedure FormKeyDown(Sender: TObject; var Key: Word; Shift: TShiftState);
     procedure FormKeyUp(Sender : TObject; var Key : Word; Shift : TShiftState);
     procedure FormShow(Sender: TObject);
   private
-    procedure SendCWMessage(cwkey : String);
+
   public
     { public declarations }
   end; 
@@ -33,23 +34,27 @@ uses dUtils,fNewQSO;
 
 { TfrmCWKeys }
 
-procedure TfrmCWKeys.SendCWMessage(cwkey : String);
-begin
-  frmNewQSO.CWint.SendText(dmUtils.GetCWMessage(cwkey,frmNewQSO.edtCall.Text,
-      frmNewQSO.edtHisRST.Text, frmNewQSO.edtContestSerialSent.Text,frmNewQSO.edtContestExchangeMessageSent.Text,
-      frmNewQSO.edtName.Text,frmNewQSO.lblGreeting.Caption,''));
-end;
-
 procedure TfrmCWKeys.FormClose(Sender: TObject; var CloseAction: TCloseAction);
 begin
   dmUtils.SaveWindowPos(frmCWKeys)
 end;
 
+procedure TfrmCWKeys.FormKeyDown(Sender: TObject; var Key: Word;
+  Shift: TShiftState);
+begin
+   case Key of
+   VK_F1 .. VK_F10,
+   33,
+   34              : frmNewQSO.FormKeyDown(Sender,Key,Shift);
+   VK_ESCAPE       : frmNewQSO.CWint.StopSending;
+   end;
+end;
+
 procedure TfrmCWKeys.FormKeyUp(Sender : TObject; var Key : Word;
   Shift : TShiftState);
 begin
-  if (Sender is TButton) then
-    ShowMessage('JO')
+  if (Key >= VK_F1) and (Key <= VK_F10) and (Shift = []) then
+                      frmNewQSO.FormKeyUp(Sender,Key,Shift);
 end;
 
 procedure TfrmCWKeys.FormShow(Sender: TObject);

--- a/src/fCWType.lfm
+++ b/src/fCWType.lfm
@@ -1,12 +1,12 @@
 object frmCWType: TfrmCWType
   Left = 324
-  Height = 490
+  Height = 506
   Top = 8
   Width = 846
   AllowDropFiles = True
   BorderIcons = [biSystemMenu]
   Caption = 'CW type'
-  ClientHeight = 490
+  ClientHeight = 506
   ClientWidth = 846
   Icon.Data = {
     BE0C00000000010001002020000001001800A80C000016000000280000002000
@@ -115,9 +115,10 @@ object frmCWType: TfrmCWType
   }
   OnClose = FormClose
   OnKeyDown = FormKeyDown
+  OnKeyUp = FormKeyUp
   OnShow = FormShow
   Position = poMainFormCenter
-  LCLVersion = '2.0.0.4'
+  LCLVersion = '2.0.4.0'
   object pnlBottom: TPanel
     AnchorSideLeft.Control = Owner
     AnchorSideRight.Control = Owner
@@ -126,7 +127,7 @@ object frmCWType: TfrmCWType
     AnchorSideBottom.Side = asrBottom
     Left = 0
     Height = 35
-    Top = 455
+    Top = 471
     Width = 846
     Align = alBottom
     BevelOuter = bvNone
@@ -184,12 +185,13 @@ object frmCWType: TfrmCWType
     AnchorSideBottom.Control = pnlBottom
     Left = 0
     Height = 294
-    Top = 161
+    Top = 177
     Width = 846
     Anchors = [akTop, akLeft, akRight, akBottom]
     OnChange = mChange
+    OnKeyDown = FormKeyDown
     OnKeyPress = mKeyPress
-    OnKeyUp = mKeyUp
+    OnKeyUp = FormKeyUp
     ParentFont = False
     ScrollBars = ssAutoBoth
     TabOrder = 1
@@ -199,12 +201,12 @@ object frmCWType: TfrmCWType
     AnchorSideTop.Control = Owner
     AnchorSideRight.Control = Owner
     Left = 0
-    Height = 88
+    Height = 104
     Top = 0
     Width = 846
     Align = alTop
     BevelOuter = bvNone
-    ClientHeight = 88
+    ClientHeight = 104
     ClientWidth = 846
     TabOrder = 2
     object lblWpm: TLabel
@@ -214,7 +216,7 @@ object frmCWType: TfrmCWType
       AnchorSideTop.Side = asrCenter
       Left = 133
       Height = 17
-      Top = 36
+      Top = 44
       Width = 32
       BorderSpacing.Left = 6
       Caption = 'wpm'
@@ -227,15 +229,16 @@ object frmCWType: TfrmCWType
       AnchorSideTop.Side = asrCenter
       Left = 77
       Height = 34
-      Top = 27
+      Top = 35
       Width = 50
       BorderSpacing.Left = 6
       Increment = 2
       MaxValue = 99
       MinValue = 5
       OnChange = edtSpeedChange
+      OnMouseLeave = edtSpeedMouseLeave
       TabOrder = 0
-      Value = 5
+      Value = 15
     end
     object rgMode: TRadioGroup
       AnchorSideLeft.Control = pnlTop
@@ -244,13 +247,14 @@ object frmCWType: TfrmCWType
       AnchorSideBottom.Control = pnlTop
       AnchorSideBottom.Side = asrBottom
       Left = 278
-      Height = 84
+      Height = 100
       Top = 2
       Width = 291
       Anchors = [akTop, akLeft, akBottom]
       AutoFill = True
       BorderSpacing.Top = 2
       BorderSpacing.Bottom = 2
+      Caption = 'Send CW using'
       ChildSizing.LeftRightSpacing = 6
       ChildSizing.TopBottomSpacing = 6
       ChildSizing.EnlargeHorizontal = crsHomogenousChildResize
@@ -276,7 +280,7 @@ object frmCWType: TfrmCWType
       AnchorSideTop.Side = asrCenter
       Left = 6
       Height = 17
-      Top = 36
+      Top = 44
       Width = 65
       BorderSpacing.Left = 6
       Caption = 'CW speed'
@@ -291,7 +295,7 @@ object frmCWType: TfrmCWType
     AnchorSideRight.Side = asrBottom
     AnchorSideBottom.Side = asrBottom
     Height = 73
-    Top = 88
+    Top = 104
     Width = 846
     Anchors = [akTop, akLeft, akRight]
     ClientHeight = 73

--- a/src/fCWType.pas
+++ b/src/fCWType.pas
@@ -60,8 +60,10 @@ type
     procedure btnPgUpClick(Sender: TObject);
     procedure btnPgUpMouseEnter(Sender: TObject);
     procedure btnPgUpMouseLeave(Sender: TObject);
+    procedure edtSpeedMouseLeave(Sender: TObject);
     procedure FormClose(Sender: TObject; var CloseAction: TCloseAction);
     procedure FormKeyDown(Sender: TObject; var Key: Word; Shift: TShiftState);
+    procedure FormKeyUp(Sender: TObject; var Key: Word; Shift: TShiftState);
     procedure FormShow(Sender: TObject);
     procedure btnClearClick(Sender: TObject);
     procedure btnCloseClick(Sender: TObject);
@@ -69,7 +71,6 @@ type
     procedure fraCWKeys1Resize(Sender: TObject);
     procedure mChange(Sender: TObject);
     procedure mKeyPress(Sender: TObject; var Key: char);
-    procedure mKeyUp(Sender: TObject; var Key: Word; Shift: TShiftState);
     procedure rgModeClick(Sender: TObject);
   private
     { private declarations }
@@ -111,17 +112,28 @@ begin
   m.SetFocus;
 end;
 
-procedure TfrmCWType.FormKeyDown(Sender: TObject; var Key: Word;
-  Shift: TShiftState);
-begin
-  if key = 27 then
-    frmNewQSO.CWint.StopSending
-end;
-
 procedure TfrmCWType.FormClose(Sender: TObject; var CloseAction: TCloseAction);
 begin
   cqrini.WriteInteger('CW','Mode',rgMode.ItemIndex);
   dmUtils.SaveWindowPos(frmCWType)
+end;
+
+procedure TfrmCWType.FormKeyDown(Sender: TObject; var Key: Word;
+  Shift: TShiftState);
+begin
+  case Key of
+   VK_F1 .. VK_F10,
+   33,
+   34              : frmNewQSO.FormKeyDown(Sender,Key,Shift);
+   VK_ESCAPE       : frmNewQSO.CWint.StopSending;
+   end;
+end;
+
+procedure TfrmCWType.FormKeyUp(Sender: TObject; var Key: Word;
+  Shift: TShiftState);
+begin
+  if (Key >= VK_F1) and (Key <= VK_F10) and (Shift = []) then
+                      frmNewQSO.FormKeyUp(Sender,Key,Shift);
 end;
 
 procedure TfrmCWType.btnF1MouseEnter(Sender: TObject);
@@ -138,7 +150,9 @@ end;
 
 procedure TfrmCWType.btnF2Click(Sender: TObject);
 begin
-  frmNewQSO.CWint.SendText(dmUtils.GetCWMessage('F2',frmNewQSO.edtCall.Text,
+  m.SetFocus; //after click focus back to memo
+  if Assigned(frmNewQSO.CWint) and (frmNewQSO.cmbMode.Text='CW') then
+   frmNewQSO.CWint.SendText(dmUtils.GetCWMessage('F2',frmNewQSO.edtCall.Text,
       frmNewQSO.edtHisRST.Text, frmNewQSO.edtContestSerialSent.Text,frmNewQSO.edtContestExchangeMessageSent.Text,
       frmNewQSO.edtName.Text,frmNewQSO.lblGreeting.Caption,''));
 end;
@@ -152,7 +166,9 @@ end;
 
 procedure TfrmCWType.btnF10Click(Sender: TObject);
 begin
-  frmNewQSO.CWint.SendText(dmUtils.GetCWMessage('F10',frmNewQSO.edtCall.Text,
+  m.SetFocus; //after click focus back to memo
+  if Assigned(frmNewQSO.CWint) and (frmNewQSO.cmbMode.Text='CW') then
+   frmNewQSO.CWint.SendText(dmUtils.GetCWMessage('F10',frmNewQSO.edtCall.Text,
       frmNewQSO.edtHisRST.Text, frmNewQSO.edtContestSerialSent.Text,frmNewQSO.edtContestExchangeMessageSent.Text,
       frmNewQSO.edtName.Text,frmNewQSO.lblGreeting.Caption,''));
 end;
@@ -164,7 +180,9 @@ end;
 
 procedure TfrmCWType.btnF1Click(Sender: TObject);
 begin
-  frmNewQSO.CWint.SendText(dmUtils.GetCWMessage('F1',frmNewQSO.edtCall.Text,
+  m.SetFocus; //after click focus back to memo
+  if Assigned(frmNewQSO.CWint) and (frmNewQSO.cmbMode.Text='CW') then
+   frmNewQSO.CWint.SendText(dmUtils.GetCWMessage('F1',frmNewQSO.edtCall.Text,
       frmNewQSO.edtHisRST.Text, frmNewQSO.edtContestSerialSent.Text,frmNewQSO.edtContestExchangeMessageSent.Text,
       frmNewQSO.edtName.Text,frmNewQSO.lblGreeting.Caption,''));
 end;
@@ -183,7 +201,9 @@ end;
 
 procedure TfrmCWType.btnF3Click(Sender: TObject);
 begin
-  frmNewQSO.CWint.SendText(dmUtils.GetCWMessage('F3',frmNewQSO.edtCall.Text,
+  m.SetFocus; //after click focus back to memo
+  if Assigned(frmNewQSO.CWint) and (frmNewQSO.cmbMode.Text='CW') then
+   frmNewQSO.CWint.SendText(dmUtils.GetCWMessage('F3',frmNewQSO.edtCall.Text,
       frmNewQSO.edtHisRST.Text, frmNewQSO.edtContestSerialSent.Text,frmNewQSO.edtContestExchangeMessageSent.Text,
       frmNewQSO.edtName.Text,frmNewQSO.lblGreeting.Caption,''));
 end;
@@ -202,7 +222,9 @@ end;
 
 procedure TfrmCWType.btnF4Click(Sender: TObject);
 begin
-  frmNewQSO.CWint.SendText(dmUtils.GetCWMessage('F4',frmNewQSO.edtCall.Text,
+  m.SetFocus; //after click focus back to memo
+  if Assigned(frmNewQSO.CWint) and (frmNewQSO.cmbMode.Text='CW') then
+   frmNewQSO.CWint.SendText(dmUtils.GetCWMessage('F4',frmNewQSO.edtCall.Text,
       frmNewQSO.edtHisRST.Text, frmNewQSO.edtContestSerialSent.Text,frmNewQSO.edtContestExchangeMessageSent.Text,
       frmNewQSO.edtName.Text,frmNewQSO.lblGreeting.Caption,''));
 end;
@@ -221,7 +243,9 @@ end;
 
 procedure TfrmCWType.btnF5Click(Sender: TObject);
 begin
-  frmNewQSO.CWint.SendText(dmUtils.GetCWMessage('F5',frmNewQSO.edtCall.Text,
+  m.SetFocus; //after click focus back to memo
+  if Assigned(frmNewQSO.CWint) and (frmNewQSO.cmbMode.Text='CW') then
+   frmNewQSO.CWint.SendText(dmUtils.GetCWMessage('F5',frmNewQSO.edtCall.Text,
       frmNewQSO.edtHisRST.Text, frmNewQSO.edtContestSerialSent.Text,frmNewQSO.edtContestExchangeMessageSent.Text,
       frmNewQSO.edtName.Text,frmNewQSO.lblGreeting.Caption,''));
 end;
@@ -240,7 +264,9 @@ end;
 
 procedure TfrmCWType.btnF6Click(Sender: TObject);
 begin
-  frmNewQSO.CWint.SendText(dmUtils.GetCWMessage('F6',frmNewQSO.edtCall.Text,
+  m.SetFocus; //after click focus back to memo
+  if Assigned(frmNewQSO.CWint) and (frmNewQSO.cmbMode.Text='CW') then
+   frmNewQSO.CWint.SendText(dmUtils.GetCWMessage('F6',frmNewQSO.edtCall.Text,
       frmNewQSO.edtHisRST.Text, frmNewQSO.edtContestSerialSent.Text,frmNewQSO.edtContestExchangeMessageSent.Text,
       frmNewQSO.edtName.Text,frmNewQSO.lblGreeting.Caption,''));
 end;
@@ -259,7 +285,9 @@ end;
 
 procedure TfrmCWType.btnF7Click(Sender: TObject);
 begin
-  frmNewQSO.CWint.SendText(dmUtils.GetCWMessage('F7',frmNewQSO.edtCall.Text,
+  m.SetFocus; //after click focus back to memo
+  if Assigned(frmNewQSO.CWint) and (frmNewQSO.cmbMode.Text='CW') then
+   frmNewQSO.CWint.SendText(dmUtils.GetCWMessage('F7',frmNewQSO.edtCall.Text,
       frmNewQSO.edtHisRST.Text, frmNewQSO.edtContestSerialSent.Text,frmNewQSO.edtContestExchangeMessageSent.Text,
       frmNewQSO.edtName.Text,frmNewQSO.lblGreeting.Caption,''));
 end;
@@ -278,7 +306,9 @@ end;
 
 procedure TfrmCWType.btnF8Click(Sender: TObject);
 begin
-  frmNewQSO.CWint.SendText(dmUtils.GetCWMessage('F8',frmNewQSO.edtCall.Text,
+  m.SetFocus; //after click focus back to memo
+  if Assigned(frmNewQSO.CWint) and (frmNewQSO.cmbMode.Text='CW') then
+   frmNewQSO.CWint.SendText(dmUtils.GetCWMessage('F8',frmNewQSO.edtCall.Text,
       frmNewQSO.edtHisRST.Text, frmNewQSO.edtContestSerialSent.Text,frmNewQSO.edtContestExchangeMessageSent.Text,
       frmNewQSO.edtName.Text,frmNewQSO.lblGreeting.Caption,''));
 end;
@@ -297,7 +327,9 @@ end;
 
 procedure TfrmCWType.btnF9Click(Sender: TObject);
 begin
-  frmNewQSO.CWint.SendText(dmUtils.GetCWMessage('F9',frmNewQSO.edtCall.Text,
+  m.SetFocus; //after click focus back to memo
+  if Assigned(frmNewQSO.CWint) and (frmNewQSO.cmbMode.Text='CW') then
+   frmNewQSO.CWint.SendText(dmUtils.GetCWMessage('F9',frmNewQSO.edtCall.Text,
       frmNewQSO.edtHisRST.Text, frmNewQSO.edtContestSerialSent.Text,frmNewQSO.edtContestExchangeMessageSent.Text,
       frmNewQSO.edtName.Text,frmNewQSO.lblGreeting.Caption,''));
 end;
@@ -344,6 +376,10 @@ begin
   frmCWType.lblToShowMouseOverText.Caption:='';
 end;
 
+procedure TfrmCWType.edtSpeedMouseLeave(Sender: TObject);
+begin
+   m.SetFocus; //after click focus back to memo
+end;
 
 procedure TfrmCWType.FormShow(Sender: TObject);
 begin
@@ -369,7 +405,6 @@ procedure TfrmCWType.edtSpeedChange(Sender: TObject);
 begin
   frmNewQSO.CWint.SetSpeed(edtSpeed.Value);
   frmNewQSO.sbNewQSO.Panels[2].Text := IntToStr(edtSpeed.Value)+'WPM';
-
 end;
 procedure TfrmCWType.fraCWKeys1Resize(Sender: TObject);
  var
@@ -423,7 +458,8 @@ Begin
    if msg<>'' then
     Begin
      if LocalDbg then Writeln('Blocksend out:'+msg);
-     frmNewQSO.CWint.SendText(msg);
+     if Assigned(frmNewQSO.CWint) and (frmNewQSO.cmbMode.Text='CW') then
+       frmNewQSO.CWint.SendText(msg);
     end;
    WasMemoLen :=length(m.lines.text);
 end;
@@ -459,7 +495,8 @@ begin
             case rgMode.ItemIndex of
 
                  0:               Begin
-                                       frmNewQSO.CWint.SendText(l); //letter mode
+                                       if Assigned(frmNewQSO.CWint) and (frmNewQSO.cmbMode.Text='CW') then
+                                         frmNewQSO.CWint.SendText(l); //letter mode
                                        WasMemoLen :=length(m.lines.text);
                                   end;
                  1:               Begin  //word mode , first word is send character by character
@@ -474,7 +511,8 @@ begin
                                       end
                                     else
                                       Begin
-                                      frmNewQSO.CWint.SendText(l);
+                                      if Assigned(frmNewQSO.CWint) and (frmNewQSO.cmbMode.Text='CW') then
+                                       frmNewQSO.CWint.SendText(l);
                                       WasMemoLen :=length(m.lines.text);
                                       end;
                                   end;
@@ -495,32 +533,6 @@ begin
     blocksend;
     Switch2Word := false;
    end;
-end;
-
-procedure TfrmCWType.mKeyUp(Sender: TObject; var Key: Word; Shift: TShiftState);
-
-begin
-  if key = 33 then//pgup
-  begin
-    SetSpeed(2);
-    key := 0
-  end;
-
-  if key = 34 then//pgup
-  begin
-    SetSpeed(-2);
-    key := 0
-  end;
-
-  if (key >= VK_F1) and (key <= VK_F10) then
-  begin
-    frmNewQSO.CWint.SendText(dmUtils.GetCWMessage(dmUtils.GetDescKeyFromCode(key),frmNewQSO.edtCall.Text,
-       frmNewQSO.edtHisRST.Text, frmNewQSO.edtContestSerialSent.Text,frmNewQSO.edtContestExchangeMessageSent.Text,
-       frmNewQSO.edtName.Text,frmNewQSO.lblGreeting.Caption,''));
-  end;
-
-  if Key = VK_ESCAPE then
-    frmNewQSO.CWint.StopSending
 end;
 
 procedure TfrmCWType.rgModeClick(Sender: TObject);

--- a/src/fNewQSO.lfm
+++ b/src/fNewQSO.lfm
@@ -1,5 +1,5 @@
 object frmNewQSO: TfrmNewQSO
-  Left = 159
+  Left = 191
   Height = 709
   Top = 64
   Width = 997
@@ -2135,6 +2135,7 @@ object frmNewQSO: TfrmNewQSO
   OnCreate = FormCreate
   OnKeyDown = FormKeyDown
   OnKeyPress = FormKeyPress
+  OnKeyUp = FormKeyUp
   OnShow = FormShow
   OnWindowStateChange = FormWindowStateChange
   LCLVersion = '2.0.4.0'
@@ -3857,7 +3858,7 @@ object frmNewQSO: TfrmNewQSO
           Left = 355
           Height = 23
           Hint = 'Show locator on map'
-          Top = 302
+          Top = 338
           Width = 23
           Anchors = [akTop, akRight]
           BorderSpacing.Top = 3
@@ -4826,9 +4827,11 @@ object frmNewQSO: TfrmNewQSO
       end
       object MenuItem73: TMenuItem
         Action = acCWType
+        Visible = False
       end
       object MenuItem72: TMenuItem
         Action = acCWFKey
+        Caption = 'Memory keys'
       end
       object MenuItem80: TMenuItem
         Action = acDetails

--- a/src/fXfldigi.lfm
+++ b/src/fXfldigi.lfm
@@ -3,14 +3,14 @@ object frmxfldigi: Tfrmxfldigi
   Height = 193
   Top = 15
   Width = 347
-  Caption = 'frmxfldigi'
+  Caption = 'fldigi xmlrpc'
   ClientHeight = 193
   ClientWidth = 347
   OnClose = FormClose
   OnCreate = FormCreate
   OnHide = FormHide
   OnShow = FormShow
-  LCLVersion = '1.6.4.0'
+  LCLVersion = '2.0.4.0'
   object lbCall: TLabel
     Left = 8
     Height = 15
@@ -148,7 +148,7 @@ object frmxfldigi: Tfrmxfldigi
     AnchorSideLeft.Side = asrCenter
     AnchorSideTop.Control = Owner
     Left = 68
-    Height = 15
+    Height = 17
     Top = 0
     Width = 211
     Caption = 'Data received from fldigi xmlrpc'
@@ -169,7 +169,7 @@ object frmxfldigi: Tfrmxfldigi
   end
   object Label1: TLabel
     Left = 8
-    Height = 15
+    Height = 17
     Top = 104
     Width = 96
     Caption = 'Comment QSO'
@@ -179,7 +179,7 @@ object frmxfldigi: Tfrmxfldigi
   end
   object Label2: TLabel
     Left = 256
-    Height = 15
+    Height = 17
     Top = 104
     Width = 46
     Caption = 'County'
@@ -200,7 +200,7 @@ object frmxfldigi: Tfrmxfldigi
   end
   object Label4: TLabel
     Left = 8
-    Height = 15
+    Height = 17
     Top = 56
     Width = 39
     Caption = 'Name'
@@ -210,7 +210,7 @@ object frmxfldigi: Tfrmxfldigi
   end
   object Label5: TLabel
     Left = 88
-    Height = 15
+    Height = 17
     Top = 56
     Width = 28
     Caption = 'QTH'
@@ -220,7 +220,7 @@ object frmxfldigi: Tfrmxfldigi
   end
   object Label6: TLabel
     Left = 224
-    Height = 15
+    Height = 17
     Top = 56
     Width = 27
     Caption = 'Grid'
@@ -230,7 +230,7 @@ object frmxfldigi: Tfrmxfldigi
   end
   object Label7: TLabel
     Left = 296
-    Height = 15
+    Height = 17
     Top = 56
     Width = 34
     Caption = 'State'
@@ -240,7 +240,7 @@ object frmxfldigi: Tfrmxfldigi
   end
   object Label8: TLabel
     Left = 8
-    Height = 15
+    Height = 17
     Top = 16
     Width = 25
     Caption = 'Call'
@@ -250,9 +250,9 @@ object frmxfldigi: Tfrmxfldigi
   end
   object Label9: TLabel
     Left = 88
-    Height = 15
+    Height = 17
     Top = 16
-    Width = 27
+    Width = 28
     Caption = 'Freq'
     Font.Color = clBlue
     ParentColor = False
@@ -260,9 +260,9 @@ object frmxfldigi: Tfrmxfldigi
   end
   object Label10: TLabel
     Left = 160
-    Height = 15
+    Height = 17
     Top = 16
-    Width = 35
+    Width = 36
     Caption = 'Mode'
     Font.Color = clBlue
     ParentColor = False
@@ -270,7 +270,7 @@ object frmxfldigi: Tfrmxfldigi
   end
   object Label11: TLabel
     Left = 224
-    Height = 15
+    Height = 17
     Top = 16
     Width = 30
     Caption = 'RSTs'
@@ -280,7 +280,7 @@ object frmxfldigi: Tfrmxfldigi
   end
   object Label12: TLabel
     Left = 296
-    Height = 15
+    Height = 17
     Top = 16
     Width = 28
     Caption = 'RSTr'

--- a/src/frCWKeys.lfm
+++ b/src/frCWKeys.lfm
@@ -7,8 +7,8 @@ object fraCWKeys: TfraCWKeys
   ClientWidth = 823
   OnResize = FrameResize
   TabOrder = 0
-  DesignLeft = 347
-  DesignTop = 175
+  DesignLeft = 305
+  DesignTop = 136
   object btnF1: TButton
     Left = 0
     Height = 32

--- a/src/frCWKeys.pas
+++ b/src/frCWKeys.pas
@@ -5,7 +5,7 @@ unit frCWKeys;
 interface
 
 uses
-  Classes, SysUtils, FileUtil, Forms, Controls, StdCtrls,ActnList;
+  Classes, SysUtils, FileUtil, Forms, Controls, StdCtrls,ActnList, LCLType;
 
 type
 
@@ -50,7 +50,6 @@ type
     procedure btnPgDnMouseLeave(Sender: TObject);
     procedure btnPgUpMouseEnter(Sender: TObject);
     procedure btnPgUpMouseLeave(Sender: TObject);
-    procedure FrameMouseEnter(Sender: TObject);
     procedure FrameResize(Sender: TObject);
     procedure btnClicked(Sender: TObject);
   private
@@ -242,54 +241,34 @@ begin
   self.lblToShowMouseOverTextCwKeys.Caption:='';
 end;
 
-procedure TfraCWKeys.FrameMouseEnter(Sender: TObject);
-begin
-
-end;
-
 procedure TfraCWKeys.btnClicked(Sender : TObject);
 var
   cwkey : String;
-  speed : integer;
+  Key   : Word;
 begin
   if Sender is TButton then
   begin
-    cwkey := copy((Sender as TButton).Name,4,3);
-    if dmData.DebugLevel >=1 then Writeln('Button: ',cwkey);
-
+    cwkey := copy((Sender as TButton).Name,4,4);
     case cwkey of
-    'PgU'      :begin
-                  if Assigned(frmNewQSO.CWint) then
-                  begin
-                    speed := frmNewQSO.CWint.GetSpeed+2;
-                    frmNewQSO.CWint.SetSpeed(speed);
-                    frmNewQSO.sbNewQSO.Panels[2].Text := IntToStr(speed)+'WPM';
-                    if (frmCWType <> nil ) then frmCWType.edtSpeed.Value := speed;
-                  end
-                end;
-
-    'PgD'       :begin
-                    if Assigned(frmNewQSO.CWint) then
-                    begin
-                      speed := frmNewQSO.CWint.GetSpeed-2;
-                      frmNewQSO.CWint.SetSpeed(speed);
-                      frmNewQSO.sbNewQSO.Panels[2].Text := IntToStr(speed)+'WPM';
-                      if (frmCWType <> nil ) then frmCWType.edtSpeed.Value := speed;
-                    end
-                  end;
-    else
-      Begin
-        cwkey := copy((Sender as TButton).Name,4,3);
-        if ((frmNewQSO.cmbMode.Text='SSB') or (frmNewQSO.cmbMode.Text='FM') or (frmNewQSO.cmbMode.Text='AM')) then
-           frmNewQSO.RunVK(cwkey)
-        else
-        if Assigned(frmNewQSO.CWint) then
-         frmNewQSO.CWint.SendText(dmUtils.GetCWMessage(cwkey,frmNewQSO.edtCall.Text,frmNewQSO.edtHisRST.Text,
-         frmNewQSO.edtContestSerialSent.Text,frmNewQSO.edtContestExchangeMessageSent.Text,
-         frmNewQSO.edtName.Text,frmNewQSO.lblGreeting.Caption,''));
+      'F1'  :    Key := VK_F1;
+      'F2'  :    Key := VK_F2;
+      'F3'  :    Key := VK_F3;
+      'F4'  :    Key := VK_F4;
+      'F5'  :    Key := VK_F5;
+      'F6'  :    Key := VK_F6;
+      'F7'  :    Key := VK_F7;
+      'F8'  :    Key := VK_F8;
+      'F9'  :    Key := VK_F9;
+      'F10' :    Key := VK_F10;
+      'PgUp':    Key := 33; //PgUp
+      'PgDn':    Key := 34; //PgDn
+      else
+       Key := 0; // in case of failure. Should not happen...
       end;
-    end;
+    //if dmData.DebugLevel >=1 then Writeln('CW keys button: ',cwkey,' Key: ',Key);
+    frmNewQSO.FormKeyDown(nil,Key,[]);
   end;
+
 end;
 
 procedure TfraCWKeys.UpdateFKeyLabels;


### PR DESCRIPTION
Common to all keyers:
 F1 .. F10 CW-keys (from keyboard) works now if NewQSO, CWKeys or CWType window is active
 F1 .. F10 keyboard auto repeat disabled (long keypress do not fill CW buffers)
 CW is now sent only if rig mode (NewQSO/mode selector) is CW
 Windows/CWType is not visible in menu list if keyer is set to "None" at Preferences/CW interface
 Moving rig from other mode to CW sends "stop keying" (specially Hamlib/rig buffer may contain old morse in some cases)
 Source code is cleaned up (removed duplicate blocks, etc.)

HamLib keyer:
  Tried to make Hamlib keyer handshake better. Now messages up tp 10 characters are sent by one hamlib command,
  longer messages are sent letter by letter.

Tested with WinKeyer and Hamlib keyer (Icom IC7300) modes. (I have no other keyers)

Squashed commit of the following:

commit 01c977f6fa3f7af4f832810f5b26edc4ea9dc25b
Author: OH1KH <oh1kh@sral.fi>
Date:   Mon Jan 27 16:18:32 2020 +0200

    Fixed CWkeyer=None bug. Renamed CWkeys and fldig xmlrpc windows. CWType not visible in window-menu if CWkeyer=none

commit 11af0b67853307aba04844a02acfbe6c295a9325
Author: OH1KH <oh1kh@sral.fi>
Date:   Sat Jan 25 11:17:09 2020 +0200

    CWType layout fix

commit deeb091a36fda8549e3cd44c52d29aa864046a12
Author: OH1KH <oh1kh@sral.fi>
Date:   Sat Jan 25 06:30:53 2020 +0200

    Cleaned up CWinit code

commit 8054a777105817913a9686fff941187c2cfea086
Author: OH1KH <oh1kh@sral.fi>
Date:   Sat Jan 25 06:00:08 2020 +0200

    Some form CWType fixes. Tested now with WinKeyer and HamLib

commit 01feb59b88b83bf3d85eb8ae00557d3bc4a515b7
Author: OH1KH <oh1kh@sral.fi>
Date:   Fri Jan 24 17:36:14 2020 +0200

    Be sure mode is CW before sending to keyer

commit e41fa781d88de3dae41f9a01c0e8838cdbfe432b
Author: OH1KH <oh1kh@sral.fi>
Date:   Wed Jan 22 19:26:27 2020 +0200

    Flush (stop)CW when entering to CW mode

commit b93b35b200cafb0dbbac43743d959d0f7f2a1b41
Author: OH1KH <oh1kh@sral.fi>
Date:   Wed Jan 22 12:55:58 2020 +0200

    Fkeys-CW  only when CW mode. Hamlib handsahake fix

commit 06ff5beeb3af531d0d4f41269dc9412e0bb74c77
Author: OH1KH <oh1kh@sral.fi>
Date:   Mon Jan 20 12:38:04 2020 +0200

    button click does not lock Fkey

commit 888334ed2ea63cf97e6fb201b1d02ca1b4a951ab
Author: OH1KH <oh1kh@sral.fi>
Date:   Mon Jan 20 12:23:48 2020 +0200

    Removed a debug print

commit fafd570a0be0a1b108e00fdffda47e67009d0d1f
Author: OH1KH <oh1kh@sral.fi>
Date:   Mon Jan 20 12:19:00 2020 +0200

    String lenght over 10 is sent now letter by letter. Trimmed some parts of code

commit a88bd362894d3987c5d02d5df25275f4b0a24419
Author: OH1KH <oh1kh@sral.fi>
Date:   Sun Jan 19 15:37:25 2020 +0200

    Still buffering problem exist

commit 093fadf6984fda0ce3f37618cccda0caca8f7935
Author: OH1KH <oh1kh@sral.fi>
Date:   Sun Jan 19 15:12:20 2020 +0200

    Cleaned some debug code

commit 29c26e3847870c500388d22481adb89e0fa615f8
Author: OH1KH <oh1kh@sral.fi>
Date:   Sun Jan 19 15:00:28 2020 +0200

    Prevent F-key repeats(need key up).Cleaned some CW code. F-keys work now also if 'CW keys' form is active. Improved HamLib Morse sending response readings (HamLib itself still has problem with buffering)

commit 8f5cf3e26820e4967e04d2387c15c16ed515923b
Author: OH1KH <oh1kh@sral.fi>
Date:   Sun Jan 19 12:00:35 2020 +0200

    Backup push. Nothing ready yet