### PR TITLE
Fill contest form call from 2clic of bandmap or dxcuster spot

### DIFF
--- a/src/fNewQSO.pas
+++ b/src/fNewQSO.pas
@@ -6251,7 +6251,13 @@ begin
     freq := FloatToStr(etmp);
     frmTRXControl.SetModeFreq(mode,freq);
     edtCallExit(nil);
-    BringToFront
+    BringToFront;
+    if frmContest.Showing then
+     Begin
+     //this makes "double round" setting new qso but works with minimal code
+     frmContest.edtCall.Text:=frmNewQSO.edtCall.Text;
+     frmContest.edtCallExit(nil);
+     end
   end
 end;
 


### PR DESCRIPTION
Small code that allows adding bandmap call or dxcluster spot  to contest form's call column.

Actually makes call adding to new qso twice  if contest form is open (first add band/spot then take call from new to contest form and add it again to new qso) , but that simplifies code and seems to work ok.

This is not very deeply tested, but seems to work so far (tested in ARRL DX-CW running now).