### PR TITLE
Only show LO tab if Sat mode is active

### DIFF
--- a/src/fNewQSO.lfm
+++ b/src/fNewQSO.lfm
@@ -3557,11 +3557,11 @@ object frmNewQSO: TfrmNewQSO
           Height = 135
           Top = 376
           Width = 938
-          ActivePage = tabSatellite
+          ActivePage = tabDXCCStat
           Align = alBottom
           Anchors = [akTop, akLeft, akRight, akBottom]
           BorderSpacing.Top = 40
-          TabIndex = 1
+          TabIndex = 0
           TabOrder = 28
           object tabDXCCStat: TTabSheet
             Caption = 'DXCC statistic'

--- a/src/fNewQSO.pas
+++ b/src/fNewQSO.pas
@@ -1383,6 +1383,9 @@ begin
   end;
 
   pgDetails.Pages[1].TabVisible := cqrini.ReadBool('NewQSO','SatelliteMode', False);
+  pgDetails.Pages[2].TabVisible := cqrini.ReadBool('NewQSO','SatelliteMode', False);
+  if cqrini.ReadBool('NewQSO','SatelliteMode',False) then
+    frmNewQSO.pgDetails.TabIndex := 1;
 
   //this have to be done here when log is selected (settings at database)
   frmReminder.chRemi.Checked := cqrini.ReadBool('Reminder','chRemi',False);

--- a/src/fPreferences.pas
+++ b/src/fPreferences.pas
@@ -1628,8 +1628,13 @@ begin
   begin
      frmNewQSO.btnClearSatelliteClick(nil);
      frmNewQSO.pgDetails.TabIndex := 0
+  end
+  else
+  begin
+     frmNewQSO.pgDetails.TabIndex := 1
   end;
   frmNewQSO.pgDetails.Pages[1].TabVisible  := chkSatelliteMode.Checked;
+  frmNewQSO.pgDetails.Pages[2].TabVisible  := chkSatelliteMode.Checked;
 
   if ReloadFreq then
     dmUtils.InsertFreq(frmNewQSO.cmbFreq);


### PR DESCRIPTION
This should restore the default behaviour. The DXCC tab is default. All other tabs hidden if sat mode is disabled. 
If sat mode is enabled the two tabs sat and lo config are shown. In this case default tab to open on start is the sat tab. 
@ok2cqr Hope this fixes our concerns from https://github.com/ok2cqr/cqrlog/pull/251#issuecomment-591363867