### PR TITLE
Sync left frame list and tab opening

### DIFF
--- a/src/fPreferences.pas
+++ b/src/fPreferences.pas
@@ -2976,6 +2976,7 @@ begin
   WinKeyerChanged := False;
 
   pgPreferences.ActivePageIndex := ActPageIdx;    //set wanted tab for showing when open. ActTab is public variable.
+  lbPreferences.ItemIndex := ActPageIdx;
 end;
 
 procedure TfrmPreferences.edtPoll2Exit(Sender: TObject);


### PR DESCRIPTION
This bug has been there for long. My fault not fixing it before as it was always seen and so easy to fix.

Depending from where the preferences was opened (NewQSO,DXCluster, TRXcontrol etc..) tab active was not in sync with left frame listbox item.
