### PR TITLE
Setting DX spot line info text to clipboard

### DIFF
--- a/help/h21.html
+++ b/help/h21.html
@@ -39,9 +39,15 @@ preferences on the node. The Command line box is used for all commands,
 settings etc. with one exception - the Tilde key (~) is used for spotting.
 The color coding and spot filtering is set up in the
 <a href="h1.html#ah11"><b>Preferences menu</b></a>. <strong>Connect</strong> to the
-luster node by simply clicking the 'Connect' button. You should see the cluster node
+Cluster node by simply clicking the 'Connect' button. You should see the cluster node
 messages indicating progress. You can enter any command into the 'Command' field
 (ie. SH/DX to display last spots, SH/U to see the users connected to the node etc.).
+<br> Double click with mouse left on DX spot line applies DX callsign to NewQSO and sets rig frequency to spot QRG.
+<br>If there is additional info available on spot line it is copied to clipboard. You can set cursor to desired NewQSO field and apply info from clipboard with Ctrl-V.
+ That is an easy and quick way to store IOTA, SOTA, WWFF or other info from DX spot line to qso record.
+<br>This works with normal spots starting with "DX de" and also from lines printed by "sh/dx" command.
+
+
 </p><img src="img/h4b.png" border="0"> <img src="img/h4c.png" border="0"><br><p>
 With <b>Ctrl-W</b> you can send a spot to DXCluster if you are connected. If NewQSO is empty the spot is generated from last logged call from current log. If there is a call entered in NewQSO/Call field it will be used for spot generation.
 Additionally you can add used Mode and RST sent by pressing button <b>+Mode_Rst</b> and/or add locators by pressing button <b>+Locators</b>.

--- a/src/cqrlog.lpi
+++ b/src/cqrlog.lpi
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CONFIG>
   <ProjectOptions>
-    <Version Value="10"/>
+    <Version Value="11"/>
     <General>
       <Flags>
         <LRSInOutputDirectory Value="False"/>
@@ -39,8 +39,7 @@
     </PublishOptions>
     <RunParams>
       <local>
-        <FormatVersion Value="1"/>
-        <CommandLineParams Value="--DEBUG=1"/>
+        <CommandLineParams Value="--DEBUG=0"/>
         <LaunchingApplication PathPlusParams="/usr/X11R6/bin/xterm -T 'Lazarus Run Output' -e $(LazarusDir)/tools/runwait.sh $(TargetCmdLine)"/>
       </local>
       <environment>
@@ -49,6 +48,21 @@
           <Variable1 Name="HEAPTRC" Value="1"/>
         </UserOverrides>
       </environment>
+      <FormatVersion Value="2"/>
+      <Modes Count="1">
+        <Mode0 Name="default">
+          <local>
+            <CommandLineParams Value="--DEBUG=0"/>
+            <LaunchingApplication PathPlusParams="/usr/X11R6/bin/xterm -T 'Lazarus Run Output' -e $(LazarusDir)/tools/runwait.sh $(TargetCmdLine)"/>
+          </local>
+          <environment>
+            <UserOverrides Count="2">
+              <Variable0 Name="FIREBIRD" Value="/home/ok2cqr/projekty/cqrlog/testing"/>
+              <Variable1 Name="HEAPTRC" Value="1"/>
+            </UserOverrides>
+          </environment>
+        </Mode0>
+      </Modes>
     </RunParams>
     <RequiredPackages Count="10">
       <Item1>


### PR DESCRIPTION
When DX spot is selected with double (left) click and DX callsign is set to NewQSO same time the info part of DX spot line is applied to clipboard.
User can then set cursor to a NewQSO field, like "comment to QSO", and press Ctrl-V to store the info (IOTA, SOTA, WWFF etc.) in easy way.

Squashed commit of the following:

commit e643e3a1c72b6d434b36ffed3f1c6721c0e2fa06
Author: OH1KH <oh1kh@sral.fi>
Date:   Sun Mar 22 14:07:40 2020 +0200

     removing debugs

commit c99de38846ab0550637ab4f470d06988562fa117
Author: OH1KH <oh1kh@sral.fi>
Date:   Sun Mar 22 13:41:19 2020 +0200

    a bug fix

commit eea816e6e6d62f70cca3f1ca437e348fe2da5d86
Author: OH1KH <oh1kh@sral.fi>
Date:   Sun Mar 22 13:18:03 2020 +0200

    Changed info copy to double(left)click and updated help file

commit d462a1c086745783af1b65e069430f0dbb80e9e3
Author: OH1KH <oh1kh@sral.fi>
Date:   Sat Mar 21 13:16:59 2020 +0200

    add item in DXCluster right click menu top: 'select, copy info, add to newqso'