### PR TITLE
RotorControl L > R > L buttons now works without using stop button

### DIFF
--- a/src/fRotControl.pas
+++ b/src/fRotControl.pas
@@ -177,20 +177,34 @@ begin
 end;
 procedure TfrmRotControl.btnLeftClick(Sender: TObject);
 begin
+   rotor.StopRot;
+   tmrStopRot.Enabled:=False;
+   sleep(100);
+   Application.ProcessMessages;
    rotor.LeftRot;
    tmrStopRot.Enabled:=True;
    btnLeft.Font.Color:=clGreen;
    btnLeft.Font.Style:=btnLeft.Font.Style+[fsBold];
    btnLeft.Repaint;
+   btnRight.Font.Color:=clDefault;
+   btnRight.Font.Style:=btnRight.Font.Style-[fsBold];
+   btnRight.Repaint;
 end;
 
 procedure TfrmRotControl.btnRightClick(Sender: TObject);
 begin
+   rotor.StopRot;
+   tmrStopRot.Enabled:=False;
+   sleep(100);
+   Application.ProcessMessages;
    rotor.RightRot;
    tmrStopRot.Enabled:=True;
    btnRight.Font.Color:=clGreen;
    btnRight.Font.Style:=btnRight.Font.Style+[fsBold];
    btnRight.Repaint;
+   btnLeft.Font.Color:=clDefault;
+   btnLeft.Font.Style:=btnLeft.Font.Style-[fsBold];
+   btnLeft.Repaint;
 end;
 
 procedure TfrmRotControl.btnStopClick(Sender: TObject);


### PR DESCRIPTION
Visual fix.
Turn left, Turn right, buttons in RotControl did work when pressed without using stop button in the middle, but green coloring of previous direction button stayed on.
This fixes green to exist only in active direction button.

Pressing left/right now issues also first a stop command, waits a bit and then issues direction command.
