### PR TITLE
fix RBN,Bandmap,DXCluster 2xclick on empty view crashes program

### DIFF
--- a/src/fRbnMonitor.pas
+++ b/src/fRbnMonitor.pas
@@ -632,8 +632,13 @@ begin
 end;
 
 procedure TfrmRbnMonitor.sgRbnDblClick(Sender: TObject);
+var i:real;
+    f:TFormatSettings;
 begin
-  frmNewQSO.NewQSOFromSpot(sgRbn.Cells[2,sgRbn.Row],sgRbn.Cells[1,sgRbn.Row],sgRbn.Cells[3,sgRbn.Row],True)
+  //if (sgRbn.Cells[1,sgRbn.Row]<>'Freq') then  //easy way, but works only with header
+  f.DecimalSeparator := '.';
+  if TryStrToFloat( sgRbn.Cells[1,sgRbn.Row],i,f) then
+    frmNewQSO.NewQSOFromSpot(sgRbn.Cells[2,sgRbn.Row],sgRbn.Cells[1,sgRbn.Row],sgRbn.Cells[3,sgRbn.Row],True)
 end;
 
 procedure TfrmRbnMonitor.sgRbnDrawCell(Sender: TObject; aCol, aRow: Integer;

--- a/src/uColorMemo.pas
+++ b/src/uColorMemo.pas
@@ -6,6 +6,7 @@ other changes by Petr Hlozek, OK7AN
   - public functions and constants renamed to English
 
 Get info from spot, OH1KH
+click on empty memo crashes, fix OH1KH
 }
 
 {$mode objfpc}{$H+}
@@ -680,7 +681,8 @@ var z,c,v,a:longint;
      bl1:=x;bl2:=x; //select line under cursor
      nactiblok(x,c);
      ua:='';
-     for v:=x to c do ua:=ua+vety[v]^.te+#13#10;
+     if vetp < 0 then exit; //otherwise double click on empty memo crashes program (band map, dx cluster)
+      for v:=x to c do ua:=ua+vety[v]^.te+#13#10;
      //writeln('Spot line: ',ua);
      if pos('DX de',ua)=1 then   //normal DX spot
       Begin


### PR DESCRIPTION
RBN monitor:
  - Double click on empty monitor (I.E. opened but not yet connected, or empty because of filter settings) causes grid header text "Freq" to be placed as frequency to rig cat and NewQSO frequency column. Crashes as "Freq" is not a number. Now disabled if can not be converted to number.

UColorMemo (used in Band map and DXCluster):
  -  Double click on empty memo causes crash as there are no spot lines to get info from. Now returns from getInfoFromSpot if 'vetp' (what ever it is? Seems to be line count, I guess)  is negative.
