### PR TITLE
Add RS-44 to satellites

### DIFF
--- a/ctyfiles/sat_name.tab
+++ b/ctyfiles/sat_name.tab
@@ -55,6 +55,7 @@ RS-5|Radio Sputnik 5
 RS-6|Radio Sputnik 6
 RS-7|Radio Sputnik 7
 RS-8|Radio Sputnik 8
+RS-44|Radio Sputnik 44 (DOSAAF-85)
 SAREX|Shuttle Amateur Radio Experiment packet digipeater
 SO-35|Sunsat-OSCAR 35
 SO-41|Saudi-OSCAR 41


### PR DESCRIPTION
Add RS-44 to database. Corresponding with ARRL's recent update of tqsl's config.xml.