### PR TITLE
Tooltip typo: callsing -> callsign

### DIFF
--- a/src/fNewQSO.lfm
+++ b/src/fNewQSO.lfm
@@ -2726,7 +2726,7 @@ object frmNewQSO: TfrmNewQSO
           AnchorSideRight.Side = asrBottom
           Left = 485
           Height = 23
-          Hint = 'Opens qrz.com callsing profile in webbrowser'
+          Hint = 'Opens qrz.com callsign profile in webbrowser'
           Top = 338
           Width = 23
           Anchors = [akTop, akRight]


### PR DESCRIPTION
Just noticed a typo in a tooltip when I moused over it. Hopefully it's easy enough to take this drive-by fix.