### PR TITLE
wsjtx hi-speed timing change.

### DIFF
--- a/src/fNewQSO.pas
+++ b/src/fNewQSO.pas
@@ -2198,7 +2198,7 @@ begin
            DecodeTime(Time,Hour,Min,Sec,HSec);
            if dmData.DebugLevel>=1 then Writeln(' Timer FT mode - Sec is: ',Sec);
            case Sec of
-             13,28,43,58 :
+             12,27,42,57 :
                            begin  //set hispeed  decode time is coming
                               if ( tmrWsjtx.Interval = wLoSpeed ) then
                                 begin


### PR DESCRIPTION
HI-speed decode periods are set to begin one second earlier. New version of wsjt-x 2.2.0 uses new 3 stage decoding. This setting makes cqrlog's CQ-monitor follow decodes faster.

K1JT:
 FT8: Decoding is now spread over three intervals.  The first
      starts at t = 11.8 s into an Rx sequence and typically yields
      around 85% of the possible decodes for the sequence.  You
      therefore see most decodes much earlier than before.  A second
      processing step starts at 13.5 s, and the final one at 14.7 s.
      Overall decoding yield on crowded bands is improved by 10%