### PR TITLE
Modified wsjtx monitor period settings

### DIFF
--- a/src/fMonWsjtx.pas
+++ b/src/fMonWsjtx.pas
@@ -847,9 +847,9 @@ var
     tmr: integer;
 begin
   tmrCqPeriod.Enabled := False;
-  tmr := 61000;
+  tmr := 60000;
   case CurMode of
-       'FT8': tmr := 16000;
+       'FT8': tmr := 15000;
        'FT4': tmr := 8000;
   end;
   tmrCqPeriod.Interval := tmr;

--- a/src/fNewQSO.pas
+++ b/src/fNewQSO.pas
@@ -2198,7 +2198,7 @@ begin
            DecodeTime(Time,Hour,Min,Sec,HSec);
            if dmData.DebugLevel>=1 then Writeln(' Timer FT mode - Sec is: ',Sec);
            case Sec of
-             13,28,43,58 :
+             12,27,42,57 :
                            begin  //set hispeed  decode time is coming
                               if ( tmrWsjtx.Interval = wLoSpeed ) then
                                 begin


### PR DESCRIPTION
HI-speed decode periods are set to begin one second earlier. New version of wsjt-x 2.2.0 uses new 3 stage decoding. These settings makes cqrlog's CQ-monitor follow decodes faster.

K1JT:
FT8: Decoding is now spread over three intervals. The first
starts at t = 11.8 s into an Rx sequence and typically yields
around 85% of the possible decodes for the sequence. You
therefore see most decodes much earlier than before. A second
processing step starts at 13.5 s, and the final one at 14.7 s.
Overall decoding yield on crowded bands is improved by 10%

Squashed commit of the following:

commit 4086283aec5169a2fe9c2ca357da85bdecdb5bbd
Author: OH1KH <oh1kh@sral.fi>
Date:   Fri May 15 14:39:05 2020 +0300

    Changed period timers a bit

commit 501366c438d882ee2221c1e14d7e141826c31a11
Author: OH1KH <oh1kh@sral.fi>
Date:   Fri May 15 08:52:45 2020 +0300

    wsjtx hi-speed timing change.

    HI-speed decode periods set to beging one second earlier. New version of wsjt-x 2.2.0 uses new 3 stage decoding. This setting makes cqrlog CQ-monitor to follow decodes faster.

     FT8: Decoding is now spread over three intervals.  The first
          starts at t = 11.8 s into an Rx sequence and typically yields
          around 85% of the possible decodes for the sequence.  You
          therefore see most decodes much earlier than before.  A second
          processing step starts at 13.5 s, and the final one at 14.7 s.
          Overall decoding yield on crowded bands is improved by 10%