### PR TITLE
Update Docker image to Ubuntu Eoan

### DIFF
--- a/docker-build/Dockerfile
+++ b/docker-build/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:disco
+FROM ubuntu:eoan
 
 RUN apt-get update && apt-get -y upgrade
 


### PR DESCRIPTION
Seems like Ubuntu disco is not available anymore. My builds on eoan run fine though.

References: https://github.com/ok2cqr/cqrlog/issues/277