### PR TITLE
Numbers only does not work with QT5 in fChangeFreq

### DIFF
--- a/src/fChangeFreq.lfm
+++ b/src/fChangeFreq.lfm
@@ -1,7 +1,7 @@
 object frmChangeFreq: TfrmChangeFreq
-  Left = 468
+  Left = 471
   Height = 185
-  Top = 316
+  Top = 192
   Width = 557
   HorzScrollBar.Page = 324
   VertScrollBar.Page = 184
@@ -12,7 +12,7 @@ object frmChangeFreq: TfrmChangeFreq
   ClientHeight = 185
   ClientWidth = 557
   Position = poOwnerFormCenter
-  LCLVersion = '1.6.0.4'
+  LCLVersion = '2.0.8.0'
   object Label1: TLabel
     Left = 14
     Height = 17
@@ -25,7 +25,7 @@ object frmChangeFreq: TfrmChangeFreq
     Left = 169
     Height = 17
     Top = 16
-    Width = 25
+    Width = 24
     Caption = 'End'
     ParentColor = False
   end
@@ -33,7 +33,7 @@ object frmChangeFreq: TfrmChangeFreq
     Left = 14
     Height = 17
     Top = 72
-    Width = 23
+    Width = 22
     Caption = 'CW'
     ParentColor = False
   end
@@ -41,7 +41,7 @@ object frmChangeFreq: TfrmChangeFreq
     Left = 174
     Height = 17
     Top = 72
-    Width = 34
+    Width = 32
     Caption = 'RTTY'
     ParentColor = False
   end
@@ -54,43 +54,43 @@ object frmChangeFreq: TfrmChangeFreq
     ParentColor = False
   end
   object edtBegin: TEdit
-    Left = 12
-    Height = 27
+    Left = 14
+    Height = 34
     Top = 33
     Width = 100
-    NumbersOnly = True
+    OnKeyPress = ChkKeyPress
     TabOrder = 0
   end
   object edtEnd: TEdit
-    Left = 168
-    Height = 27
+    Left = 169
+    Height = 34
     Top = 33
     Width = 100
-    NumbersOnly = True
+    OnKeyPress = ChkKeyPress
     TabOrder = 1
   end
   object edtCW: TEdit
     Left = 12
-    Height = 27
+    Height = 34
     Top = 89
     Width = 100
-    NumbersOnly = True
+    OnKeyPress = ChkKeyPress
     TabOrder = 2
   end
   object edtRTTY: TEdit
     Left = 168
-    Height = 27
+    Height = 34
     Top = 89
     Width = 100
-    NumbersOnly = True
+    OnKeyPress = ChkKeyPress
     TabOrder = 3
   end
   object edtSSB: TEdit
     Left = 328
-    Height = 27
+    Height = 34
     Top = 89
     Width = 100
-    NumbersOnly = True
+    OnKeyPress = ChkKeyPress
     TabOrder = 4
   end
   object btnOK: TButton
@@ -116,10 +116,10 @@ object frmChangeFreq: TfrmChangeFreq
   end
   object edtRXOffset: TEdit
     Left = 14
-    Height = 27
+    Height = 34
     Top = 145
     Width = 98
-    NumbersOnly = True
+    OnKeyPress = ChkKeyPress
     TabOrder = 5
     Text = '0'
   end
@@ -127,16 +127,16 @@ object frmChangeFreq: TfrmChangeFreq
     Left = 14
     Height = 17
     Top = 129
-    Width = 62
+    Width = 59
     Caption = 'RX offset'
     ParentColor = False
   end
   object edtTXOffset: TEdit
     Left = 168
-    Height = 27
+    Height = 34
     Top = 145
     Width = 100
-    NumbersOnly = True
+    OnKeyPress = ChkKeyPress
     TabOrder = 6
     Text = '0'
   end
@@ -144,7 +144,7 @@ object frmChangeFreq: TfrmChangeFreq
     Left = 168
     Height = 17
     Top = 129
-    Width = 61
+    Width = 58
     Caption = 'TX offset'
     ParentColor = False
   end
@@ -152,7 +152,7 @@ object frmChangeFreq: TfrmChangeFreq
     Left = 115
     Height = 17
     Top = 39
-    Width = 30
+    Width = 29
     Caption = 'MHz'
     ParentColor = False
   end
@@ -160,7 +160,7 @@ object frmChangeFreq: TfrmChangeFreq
     Left = 115
     Height = 17
     Top = 96
-    Width = 30
+    Width = 29
     Caption = 'MHz'
     ParentColor = False
   end
@@ -168,7 +168,7 @@ object frmChangeFreq: TfrmChangeFreq
     Left = 115
     Height = 17
     Top = 151
-    Width = 30
+    Width = 29
     Caption = 'MHz'
     ParentColor = False
   end
@@ -176,7 +176,7 @@ object frmChangeFreq: TfrmChangeFreq
     Left = 272
     Height = 17
     Top = 39
-    Width = 30
+    Width = 29
     Caption = 'MHz'
     ParentColor = False
   end
@@ -184,7 +184,7 @@ object frmChangeFreq: TfrmChangeFreq
     Left = 272
     Height = 17
     Top = 96
-    Width = 30
+    Width = 29
     Caption = 'MHz'
     ParentColor = False
   end
@@ -192,7 +192,7 @@ object frmChangeFreq: TfrmChangeFreq
     Left = 272
     Height = 17
     Top = 151
-    Width = 30
+    Width = 29
     Caption = 'MHz'
     ParentColor = False
   end
@@ -200,7 +200,7 @@ object frmChangeFreq: TfrmChangeFreq
     Left = 432
     Height = 17
     Top = 96
-    Width = 30
+    Width = 29
     Caption = 'MHz'
     ParentColor = False
   end

--- a/src/fChangeFreq.pas
+++ b/src/fChangeFreq.pas
@@ -37,8 +37,10 @@ type
     Label8 : TLabel;
     Label9 : TLabel;
     procedure btnOKClick(Sender: TObject);
+    procedure ChkKeyPress(Sender: TObject; var Key: char);
   private
     { private declarations }
+
   public
     { public declarations }
   end; 
@@ -50,6 +52,12 @@ implementation
 {$R *.lfm}
 
 { TfrmChangeFreq }
+
+procedure TfrmChangeFreq.ChkKeyPress(Sender: TObject; var Key: char);
+begin
+  if (not (Key in ['0'..'9', '.','-','+', #8, #127])) OR ( (Key = '.') and (pos('.',TEdit(Sender).Text)>0) ) then Key := #0;
+end;
+
 
 procedure TfrmChangeFreq.btnOKClick(Sender: TObject);
 var
@@ -106,6 +114,7 @@ begin
 
   ModalResult := mrOK;
 end;
+
 
 end.
 


### PR DESCRIPTION
For some unknown reason preferences/bands/frequencies/modify do not allow dot (or comma) for band Begin, End, TXoffset and RXoffset TEdit boxes when compiled with QT5 support. GTK2 compiled works OK.
All boxes in form have NumbersOnly:=true.  Middle line modes (CW,RTTY,SSB)  TEdit boxes do allow dot!
Tried even by deleting edtBegin TEdit box, then copying edtCW TEdit box and renamed the copy as edtBegin, but even the copy does not allow decimal dot input!

Assigned NumbersOnly:=false and added OnKeyPress that allows only 0..9 + , - ,dot , BS , Del

That works with both QT5 and GTK2
