### PR TITLE
Satellite and/or propagation clear

### DIFF
--- a/src/cqrlog.lpi
+++ b/src/cqrlog.lpi
@@ -39,7 +39,7 @@
     </PublishOptions>
     <RunParams>
       <local>
-        <CommandLineParams Value="--DEBUG=-8"/>
+        <CommandLineParams Value="--DEBUG=0"/>
         <LaunchingApplication PathPlusParams="/usr/X11R6/bin/xterm -T 'Lazarus Run Output' -e $(LazarusDir)/tools/runwait.sh $(TargetCmdLine)"/>
       </local>
       <environment>
@@ -52,7 +52,7 @@
       <Modes Count="1">
         <Mode0 Name="default">
           <local>
-            <CommandLineParams Value="--DEBUG=-8"/>
+            <CommandLineParams Value="--DEBUG=0"/>
             <LaunchingApplication PathPlusParams="/usr/X11R6/bin/xterm -T 'Lazarus Run Output' -e $(LazarusDir)/tools/runwait.sh $(TargetCmdLine)"/>
           </local>
           <environment>

--- a/src/dSatellite.pas
+++ b/src/dSatellite.pas
@@ -30,7 +30,9 @@ type
 
     procedure LoadSatellitesFromFile;
     procedure LoadPropModesFromFile;
+    procedure SetListOfSatellites(cmbSatellite : TComboBox);
     procedure GetListOfSatellites(cmbSatellite : TComboBox; Selected : String = '');
+    procedure SetListOfPropModes(cmbPropMode : TComboBox);
     procedure GetListOfPropModes(cmbPropMode : TComboBox; Selected : String = '');
   end;
 
@@ -66,16 +68,20 @@ begin
   if FileExists(dmData.HomeDir + C_PROP_MODE_LIST) then
     ListOfPropModes.LoadFromFile(dmData.HomeDir + C_PROP_MODE_LIST)
 end;
-
-procedure TdmSatellite.GetListOfSatellites(cmbSatellite : TComboBox; Selected : String = '');
-var
-  i : Integer;
-begin
+procedure TdmSatellite.SetListOfSatellites(cmbSatellite : TComboBox);
+Begin
   cmbSatellite.Clear;
   cmbSatellite.Items.Add('');
   cmbSatellite.ItemIndex := 0;
 
   cmbSatellite.Items.AddStrings(ListOfSatellites);
+end;
+
+procedure TdmSatellite.GetListOfSatellites(cmbSatellite : TComboBox; Selected : String = '');
+var
+  i : Integer;
+begin
+
   for i:=0 to cmbSatellite.Items.Count -1 do
   begin
     if (GetSatShortName(cmbSatellite.Items.Strings[i]) = Selected) then
@@ -85,16 +91,20 @@ begin
     end
   end
 end;
+procedure TdmSatellite.SetListOfPropModes(cmbPropMode : TComboBox);
+Begin
+ cmbPropMode.Clear;
+ cmbPropMode.Items.Add('');
+ cmbPropMode.ItemIndex := 0;
+
+ cmbPropMode.Items.AddStrings(ListOfPropModes);
+end;
 
 procedure TdmSatellite.GetListOfPropModes(cmbPropMode : TComboBox; Selected : String);
 var
   i : Integer;
 begin
-  cmbPropMode.Clear;
-  cmbPropMode.Items.Add('');
-  cmbPropMode.ItemIndex := 0;
 
-  cmbPropMode.Items.AddStrings(ListOfPropModes);
   for i:=0 to cmbPropMode.Items.Count - 1 do
   begin
     if (GetPropShortName(cmbPropMode.Items.Strings[i]) = Selected) then

--- a/src/fNewQSO.lfm
+++ b/src/fNewQSO.lfm
@@ -2138,7 +2138,7 @@ object frmNewQSO: TfrmNewQSO
   OnKeyUp = FormKeyUp
   OnShow = FormShow
   OnWindowStateChange = FormWindowStateChange
-  LCLVersion = '2.0.4.0'
+  LCLVersion = '2.0.8.0'
   object sbNewQSO: TStatusBar
     AnchorSideBottom.Side = asrBottom
     Left = 0
@@ -3557,11 +3557,11 @@ object frmNewQSO: TfrmNewQSO
           Height = 135
           Top = 376
           Width = 938
-          ActivePage = tabDXCCStat
+          ActivePage = tabSatellite
           Align = alBottom
           Anchors = [akTop, akLeft, akRight, akBottom]
           BorderSpacing.Top = 40
-          TabIndex = 0
+          TabIndex = 1
           TabOrder = 28
           object tabDXCCStat: TTabSheet
             Caption = 'DXCC statistic'
@@ -3703,8 +3703,8 @@ object frmNewQSO: TfrmNewQSO
               Left = 8
               Height = 23
               Hint = 'Use RX frequency from the Satellite tab instead of Frequency for DX spots'
-              Top = 106
-              Width = 233
+              Top = 114
+              Width = 226
               BorderSpacing.Top = 35
               Caption = 'Use RX frequency for DX spots'
               Color = clNone

--- a/src/fTRXControl.lfm
+++ b/src/fTRXControl.lfm
@@ -153,7 +153,7 @@ object frmTRXControl: TfrmTRXControl
   OnKeyDown = FormKeyDown
   OnKeyUp = FormKeyUp
   OnShow = FormShow
-  LCLVersion = '2.0.4.0'
+  LCLVersion = '2.0.8.0'
   object gbMode: TGroupBox
     AnchorSideLeft.Control = gbVfo
     AnchorSideTop.Control = gbVfo

--- a/src/fTRXControl.pas
+++ b/src/fTRXControl.pas
@@ -1308,6 +1308,7 @@ end;
 function TfrmTRXControl.GetModeFreqNewQSO(var mode,freq : String) : Boolean;
 begin
   Result := False;
+  if not Assigned(radio) then exit; //without this sets old freq as mode (!) if switched from radio to non existing radio
   if not ((lblFreq.Caption = empty_freq) or (lblFreq.Caption = '')) then
     Result := True
   else

--- a/src/fXfldigi.lfm
+++ b/src/fXfldigi.lfm
@@ -1,7 +1,7 @@
 object frmxfldigi: Tfrmxfldigi
-  Left = 39
+  Left = 57
   Height = 193
-  Top = 15
+  Top = 39
   Width = 347
   Caption = 'fldigi xmlrpc'
   ClientHeight = 193
@@ -10,7 +10,7 @@ object frmxfldigi: Tfrmxfldigi
   OnCreate = FormCreate
   OnHide = FormHide
   OnShow = FormShow
-  LCLVersion = '2.0.4.0'
+  LCLVersion = '2.0.8.0'
   object lbCall: TLabel
     Left = 8
     Height = 15
@@ -26,7 +26,7 @@ object frmxfldigi: Tfrmxfldigi
     Left = 88
     Height = 15
     Top = 32
-    Width = 56
+    Width = 67
     AutoSize = False
     Caption = '-Freq'
     Color = clDefault

--- a/src/fXfldigi.pas
+++ b/src/fXfldigi.pas
@@ -222,7 +222,7 @@ var
    opmode :string;
    SockOK :Boolean;
    Drop   :integer;
-   tmp    :Currency;
+   tmp    :extended;
 
 begin
   frmNewQSO.tmrFldigi.Enabled := false;
@@ -242,13 +242,18 @@ begin
                   if pos(',', mhz) > 0 then mhz[pos(',', mhz)] := FormatSettings.DecimalSeparator;
                   if dmDXCluster.GetBandFromFreq(mhz,True) <> '' then
                     Begin
-                      if TryStrToCurr(mhz,tmp) then
+                      if TryStrToFloat(mhz,tmp) then
                         begin
                          tmp := tmp/1000;
-                         frequency := CurrToStr(tmp);
+                         frequency :=FloatToStrF(tmp,ffFixed,8,5);
+                          if (dmUtils.GetBandFromFreq(frequency) <> frmNewQSO.old_t_band) then
+                             Begin
+                              frmNewQSO.old_t_band := dmUtils.GetBandFromFreq(frequency);
+                              frmNewQSO.btnClearSatelliteClick(nil); //if band changes sat and prop cleared
+                             end;
                         end;
                     end;
-                end;
+                  end;
             2 : frequency := cqrini.ReadString('fldigi','deffreq','3.600')
      end;
      if dmData.DebugLevel>=1 then Writeln('Qrg :', frequency);


### PR DESCRIPTION
Satellite and/or propagation selection is cleared only from clear-button (at tab) or band change. Either manual, CAT driven (change from rig knobs), wsjtx or fldigi-xmlrpc remotes.

Having set propagation for example ES it was keeping there when logging qsos but as soon as one qso was cancelled (2xESC or new try with wsjtx) propagation was always cleared.
Now it is not and I think it is better this way. You can not always get qso that you have started to log in.

I do not work satellite qsos at the moment, but I believe that clearing satellite name has the same rules: only if band changes (then usually satellite changes too, I think).

Fldigi-xmlrpc and wsjtx remote frequency conversion is cleaned a bit.

Found interesting bug (cosmetic). If you have just one radio and the other is undefined then change from TRXControl radio buttons from radio to not defined radio causes NewQSO frequency column content to be copied to NewQSO mode column! Fixed.

Squashed commit of the following:

commit d368846148694c02264245d9f9d26f1c6df755b4
Author: OH1KH <oh1kh@sral.fi>
Date:   Thu May 28 08:47:52 2020 +0300

    Band change in fldigiXMLRPC and wsjtx clears satellite and propagation

commit c5c1b38a14802d9744c3e2a1612b657cab8f2826
Author: OH1KH <oh1kh@sral.fi>
Date:   Thu May 28 07:43:27 2020 +0300

    Sat and Prop clears only from button or band change. Fix of (cosmetic) bug when radio change