### PR TITLE
NewQSO locator column edit.

### DIFF
--- a/help/h20.html
+++ b/help/h20.html
@@ -33,7 +33,7 @@
 <table width="99%" border="0" cellpadding="4" cellspacing="0">
     <tbody>
     <tr>
-        <td width="35%">2x ESC</td>
+        <td width="35%">2x ESC or Ctrl+F2</td>
         <td width="65%">Empty all fields and prepare program for a new QSO</td>
     </tr>
     <tr>

--- a/src/fNewQSO.lfm
+++ b/src/fNewQSO.lfm
@@ -3033,6 +3033,7 @@ object frmNewQSO: TfrmNewQSO
           OnEnter = edtGridEnter
           OnExit = edtGridExit
           OnKeyDown = edtGridKeyDown
+          OnKeyPress = edtGridKeyPress
           ParentShowHint = False
           ShowHint = True
           TabOrder = 7

--- a/src/fNewQSO.pas
+++ b/src/fNewQSO.pas
@@ -408,6 +408,7 @@ type
     procedure edtEndTimeEnter(Sender: TObject);
     procedure edtGridChange(Sender: TObject);
     procedure edtGridEnter(Sender: TObject);
+    procedure edtGridKeyPress(Sender: TObject; var Key: char);
     procedure edtHisRSTExit(Sender: TObject);
     procedure edtHisRSTKeyPress(Sender : TObject; var Key : char);
     procedure edtITUEnter(Sender: TObject);
@@ -3515,39 +3516,6 @@ begin
   end;
 end;
 
-procedure TfrmNewQSO.edtGridExit(Sender: TObject);
-begin
-  if dmUtils.isLocOK(edtGrid.Text) then
-    begin
-     CalculateDistanceEtc;
-     sbtnLocatorMap.Visible := True;
-    end
-   else
-    begin
-     edtGrid.Font.Color:=clRed;
-     edtGrid.Font.Style:= [fsBold];
-    end;
-end;
-
-procedure TfrmNewQSO.edtGridKeyDown(Sender: TObject; var Key: Word;
-  Shift: TShiftState);
-begin
-  if (key = 40) then  //down arrow
-  begin
-    edtPWR.SetFocus;
-    key := 0;
-  end;
-  if (key = 38) then //up arrow
-  begin
-    edtQTH.SetFocus;
-    key := 0;
-  end;
-  if ((key = VK_SPACE) and UseSpaceBar) then
-  begin
-    edtPWR.SetFocus;
-    key := 0
-  end
-end;
 
 procedure TfrmNewQSO.edtHisRSTEnter(Sender: TObject);
 begin
@@ -4240,15 +4208,63 @@ end;
 
 procedure TfrmNewQSO.edtGridChange(Sender: TObject);
 begin
+  // this check is mainly for exports from remote.
+  // keying has own checking
   edtGrid.Text := dmUtils.StdFormatLocator(edtGrid.Text);
   edtGrid.SelStart := Length(edtGrid.Text);
 end;
 
 procedure TfrmNewQSO.edtGridEnter(Sender: TObject);
 begin
-  edtGrid.Font.Color:=clDefault;
-  edtGrid.Font.Style:= [];
   edtGrid.SelectAll
+end;
+
+procedure TfrmNewQSO.edtGridExit(Sender: TObject);
+begin
+  if dmUtils.isLocOK(edtGrid.Text) then
+    begin
+     CalculateDistanceEtc;
+     sbtnLocatorMap.Visible := True;
+    end
+end;
+
+procedure TfrmNewQSO.edtGridKeyDown(Sender: TObject; var Key: Word;
+  Shift: TShiftState);
+begin
+  if (key = 40) then  //down arrow
+  begin
+    edtPWR.SetFocus;
+    key := 0;
+  end;
+  if (key = 38) then //up arrow
+  begin
+    edtQTH.SetFocus;
+    key := 0;
+  end;
+  if ((key = VK_SPACE) and UseSpaceBar) then
+  begin
+    edtPWR.SetFocus;
+    key := 0
+  end
+end;
+procedure TfrmNewQSO.edtGridKeyPress(Sender: TObject; var Key: char);
+begin
+  //pass only format AB12cd34ef and BS/DEL keys
+  if (( Key<>#$8 ) and ( Key<>#$7F)) then
+  begin
+    case length(edtGrid.Text) of
+      0,1  :  if Key in ['a'..'z'] then Key:= chr(ord(Key) - $20) else
+                  if not (Key in ['A'..'Z']) then Key:= #0;
+      2,3  :  if not (Key in ['0'..'9']) then Key:= #0;
+      4,5  :  if Key in ['A'..'Z'] then Key:= chr(ord(Key) + $20) else
+                 if not (Key in ['a'..'z']) then Key:= #0;
+      6,7  :  if not (Key in ['0'..'9']) then Key:=  #0;
+      8,9  :  if Key in ['A'..'Z'] then Key:= chr(ord(Key) + $20) else
+                 if not (Key in ['a'..'z']) then Key:= #0;
+      else
+        Key:=#0;
+    end;
+  end;
 end;
 
 procedure TfrmNewQSO.acQSOListExecute(Sender: TObject);
@@ -5650,7 +5666,8 @@ end;
 
 procedure TfrmNewQSO.sbtnLocatorMapClick(Sender: TObject);
 begin
-  dmUtils.ShowLocatorMapInBrowser(dmUtils.CompleteLoc(edtGrid.Text))
+  if dmUtils.isLocOK(edtGrid.Text) then  //there may be case where Grid is empty and button is visible
+    dmUtils.ShowLocatorMapInBrowser(dmUtils.CompleteLoc(edtGrid.Text))
 end;
 
 procedure TfrmNewQSO.tmrESCTimer(Sender: TObject);


### PR DESCRIPTION
Removed some what randomly working red coloring from false locators.(Could not find a way to repeat wrong action).
Added check for typing input that forces to format AB12cd34ef. For remote received locator just first 4 upcase, rest lowcase filter (no num/char checks) exist.

Found undocumented shortcut Ctrl+F2 to clear NewQSO. Added to shortcut help.

Squashed commit of the following:

commit ea1f51e44a0f8119e5c69d36ee21438375467c29
Author: OH1KH <oh1kh@sral.fi>
Date:   Thu Jun 4 09:32:30 2020 +0300

    Comment change while testing

commit a791d4e9a62c5eaa5e18f3eb959901dee7f95c70
Author: OH1KH <oh1kh@sral.fi>
Date:   Wed Jun 3 10:05:49 2020 +0300

    Removed edtGrid focusing and sometimes false working red warning color

commit f025106a5e354402e14b85adbbfaea8077cd40ba
Author: OH1KH <oh1kh@sral.fi>
Date:   Wed Jun 3 09:36:32 2020 +0300

    1st changes in edtGrid