### PR TITLE
Various fixes

### DIFF
--- a/src/fDBConnect.pas
+++ b/src/fDBConnect.pas
@@ -133,7 +133,7 @@ begin
       ini.WriteBool('Login','SaveToLocal',False);
       ini.WriteString('Login','Server',edtServer.Text);
       ini.WriteString('Login','Port',edtPort.Text);
-      ini.WriteString('Logini','User',edtUser.Text);
+      ini.WriteString('Login','User',edtUser.Text);
 
       if chkSavePass.Checked then
         ini.WriteString('Login','Pass',edtPass.Text)
@@ -173,7 +173,7 @@ begin
       grbLogin.Visible     := True;
       edtServer.Text       := ini.ReadString('Login','Server','127.0.0.1');
       edtPort.Text         := ini.ReadString('Login','Port','3306');
-      edtUser.Text         := ini.ReadString('Logini','User','');
+      edtUser.Text         := ini.ReadString('Login','User','');
       chkSavePass.Checked  := ini.ReadBool('Login','SavePass',False);
 
         if chkSavePass.Checked then

--- a/src/fDBConnect.pas
+++ b/src/fDBConnect.pas
@@ -176,10 +176,10 @@ begin
       edtUser.Text         := ini.ReadString('Login','User','');
       chkSavePass.Checked  := ini.ReadBool('Login','SavePass',False);
 
-        if chkSavePass.Checked then
+      if chkSavePass.Checked then
         edtPass.Text := ini.ReadString('Login','Pass','')
       else
-        edtPass.Text := ini.ReadString('Login','Pass','');
+        edtPass.Text := '';
 
         chkAutoConn.Checked := ini.ReadBool('Login','AutoConnect',False);
       chkSavePassChange(nil);


### PR DESCRIPTION
This fixes two errors in the sources reported by @dg0tm.
The first commit will cause an error on the first (re-)start of cqrlog because it cannot find the value for User as it was previously stored in "Logini" section due to a type.

The second was a useless if which did exactly the same in both cases. 