### PR TITLE
Also read propmode from wsjt-x

### DIFF
--- a/src/dSatellite.pas
+++ b/src/dSatellite.pas
@@ -27,6 +27,7 @@ type
   public
     function  GetSatShortName(Satellite : String) : String;
     function  GetPropShortName(Propagation : String) : String;
+    function  GetPropLongName(Propagation : String) : String;
 
     procedure LoadSatellitesFromFile;
     procedure LoadPropModesFromFile;
@@ -123,6 +124,18 @@ end;
 function TdmSatellite.GetPropShortName(Propagation : String) : String;
 begin
   Result := GetShortName(Propagation)
+end;
+
+function TdmSatellite.GetPropLongName(Propagation : String) : String;
+var
+  i : integer;
+begin
+  for i:=0 to ListOfPropModes.Count-1 do
+  begin
+    if (Pos(Propagation, ListOfPropModes[i]) = 1) then
+        break;
+  end;
+  Result := ListOfPropModes[i];
 end;
 
 function TdmSatellite.GetShortName(StringItem : String) : String;

--- a/src/fNewQSO.pas
+++ b/src/fNewQSO.pas
@@ -2370,6 +2370,7 @@ var
   OpCall : String;
   ExchR  : String;
   ExchS  : String;
+  propmode  : String;
 
   Procedure MoveIndex(m:integer);    //within Buf limits
   Begin
@@ -2773,16 +2774,17 @@ begin
           //----------------------------------------------------
           //ClearAll;          THis removes QRZ data, not accepted!
           cbOffline.Checked := True;
-          call  := '';
-          sname := '';
-          qth   := '';
-          loc   := '';
-          mhz   := '';
-          mode  := '';
-          rstS  := '';
-          rstR  := '';
-          note  := '';
-          pwr   := '';
+          call     := '';
+          sname    := '';
+          qth      := '';
+          loc      := '';
+          mhz      := '';
+          mode     := '';
+          rstS     := '';
+          rstR     := '';
+          note     := '';
+          pwr      := '';
+          propmode := '';
           edtDate.Clear;
           //----------------------------------------------------
            if TryJulianDateToDateTime(int64Buf(index),DTim)  then  //date
@@ -2988,6 +2990,10 @@ begin
                       1,2,3,4   :  edtContestSerialReceived.Text := copy( edtContestSerialReceived.Text,1,6); //Max Db length=6
                  end;
            end;
+           //----------------------------------------------------
+           propmode:= trim(StrBuf(index));
+           if dmData.DebugLevel>=1 then Writeln('Prop Mode :', propmode);
+           cmbPropagation.Text := dmSatellite.GetPropLongName(propmode);
            //----------------------------------------------------
            if dmData.DebugLevel>=1 then Writeln(' WSJTX decode #5 logging: press save');
            SaveRemote;


### PR DESCRIPTION
I added the propmode to wsjt-x logs and exports via UDP. This is the cqrlog end to also read propmode and log accordingly.
wsjt-x PR is here:

https://sourceforge.net/p/wsjt/wsjtx/merge-requests/6/