### PR TITLE
Added check for A..Z,0..9,/ for filter callsign column.

### DIFF
--- a/src/fFilter.lfm
+++ b/src/fFilter.lfm
@@ -127,8 +127,8 @@ object frmFilter: TfrmFilter
     AnchorSideRight.Control = lblSortBy
     AnchorSideRight.Side = asrBottom
     Left = 225
-    Height = 17
-    Top = 594
+    Height = 15
+    Top = 592
     Width = 45
     Anchors = [akTop, akRight]
     Caption = 'Profile:'
@@ -139,8 +139,8 @@ object frmFilter: TfrmFilter
     AnchorSideRight.Control = lblSortBy
     AnchorSideRight.Side = asrBottom
     Left = 185
-    Height = 17
-    Top = 634
+    Height = 15
+    Top = 631
     Width = 85
     Anchors = [akTop, akRight]
     Caption = 'Membership:'
@@ -151,8 +151,8 @@ object frmFilter: TfrmFilter
     AnchorSideRight.Control = lblSortBy
     AnchorSideRight.Side = asrBottom
     Left = 208
-    Height = 17
-    Top = 554
+    Height = 15
+    Top = 553
     Width = 62
     Anchors = [akTop, akRight]
     Caption = 'Group by:'
@@ -163,7 +163,7 @@ object frmFilter: TfrmFilter
     AnchorSideRight.Control = cmbSort
     AnchorSideRight.Side = asrBottom
     Left = 221
-    Height = 17
+    Height = 15
     Top = 514
     Width = 49
     Anchors = [akTop, akRight]
@@ -188,12 +188,13 @@ object frmFilter: TfrmFilter
       AnchorSideLeft.Control = gbCallsign
       AnchorSideTop.Control = gbCallsign
       Left = 8
-      Height = 34
+      Height = 33
       Top = 6
       Width = 130
       BorderSpacing.Left = 8
       BorderSpacing.Top = 6
       CharCase = ecUppercase
+      OnChange = edtCallSignChange
       TabOrder = 0
     end
     object rbExactlyCall: TRadioButton
@@ -202,7 +203,7 @@ object frmFilter: TfrmFilter
       AnchorSideTop.Side = asrBottom
       Left = 8
       Height = 23
-      Top = 41
+      Top = 40
       Width = 74
       BorderSpacing.Top = 1
       Caption = 'Exactly'
@@ -216,7 +217,7 @@ object frmFilter: TfrmFilter
       AnchorSideTop.Side = asrBottom
       Left = 8
       Height = 23
-      Top = 64
+      Top = 63
       Width = 73
       Caption = 'Include'
       TabOrder = 2
@@ -270,7 +271,7 @@ object frmFilter: TfrmFilter
       AnchorSideLeft.Control = gbDxcc
       AnchorSideTop.Control = gbDxcc
       Left = 8
-      Height = 34
+      Height = 33
       Top = 13
       Width = 95
       BorderSpacing.Left = 8
@@ -284,7 +285,7 @@ object frmFilter: TfrmFilter
       AnchorSideTop.Side = asrBottom
       Left = 8
       Height = 25
-      Top = 48
+      Top = 47
       Width = 75
       BorderSpacing.Top = 1
       BorderSpacing.InnerBorder = 4
@@ -310,7 +311,7 @@ object frmFilter: TfrmFilter
       AnchorSideTop.Control = edtFreqFrom
       AnchorSideRight.Control = edtFreqFrom
       Left = 10
-      Height = 17
+      Height = 15
       Top = 6
       Width = 35
       Anchors = [akTop, akRight]
@@ -323,8 +324,8 @@ object frmFilter: TfrmFilter
       AnchorSideLeft.Control = Label1
       AnchorSideTop.Control = edtFreqTo
       Left = 10
-      Height = 17
-      Top = 41
+      Height = 15
+      Top = 40
       Width = 17
       Caption = 'to:'
       ParentColor = False
@@ -334,7 +335,7 @@ object frmFilter: TfrmFilter
       AnchorSideRight.Control = gbFreq
       AnchorSideRight.Side = asrBottom
       Left = 51
-      Height = 34
+      Height = 33
       Top = 6
       Width = 95
       Anchors = [akTop, akRight]
@@ -347,8 +348,8 @@ object frmFilter: TfrmFilter
       AnchorSideTop.Control = edtFreqFrom
       AnchorSideTop.Side = asrBottom
       Left = 51
-      Height = 34
-      Top = 41
+      Height = 33
+      Top = 40
       Width = 95
       BorderSpacing.Top = 1
       TabOrder = 1
@@ -397,7 +398,7 @@ object frmFilter: TfrmFilter
       AnchorSideLeft.Control = gbDate
       AnchorSideTop.Control = gbDate
       Left = 6
-      Height = 17
+      Height = 15
       Top = 6
       Width = 39
       Anchors = [akTop, akLeft, akRight]
@@ -413,8 +414,8 @@ object frmFilter: TfrmFilter
       AnchorSideTop.Side = asrBottom
       AnchorSideBottom.Side = asrCenter
       Left = 6
-      Height = 17
-      Top = 48
+      Height = 15
+      Top = 46
       Width = 17
       BorderSpacing.Top = 25
       Caption = 'to:'
@@ -426,7 +427,7 @@ object frmFilter: TfrmFilter
       AnchorSideRight.Control = gbDate
       AnchorSideRight.Side = asrBottom
       Left = 32
-      Height = 34
+      Height = 33
       Top = 19
       Width = 114
       CalendarDisplaySettings = [dsShowHeadings, dsShowDayNames, dsStartMonday]
@@ -448,8 +449,8 @@ object frmFilter: TfrmFilter
       AnchorSideRight.Control = gbDate
       AnchorSideRight.Side = asrBottom
       Left = 32
-      Height = 34
-      Top = 59
+      Height = 33
+      Top = 58
       Width = 114
       CalendarDisplaySettings = [dsShowHeadings, dsShowDayNames, dsStartMonday]
       DateOrder = doYMd
@@ -482,7 +483,7 @@ object frmFilter: TfrmFilter
       AnchorSideLeft.Control = gbLoc
       AnchorSideTop.Control = gbLoc
       Left = 8
-      Height = 34
+      Height = 33
       Top = 6
       Width = 95
       BorderSpacing.Left = 8
@@ -496,7 +497,7 @@ object frmFilter: TfrmFilter
       AnchorSideTop.Side = asrBottom
       Left = 8
       Height = 23
-      Top = 64
+      Top = 63
       Width = 73
       Caption = 'Include'
       TabOrder = 1
@@ -507,7 +508,7 @@ object frmFilter: TfrmFilter
       AnchorSideTop.Side = asrBottom
       Left = 8
       Height = 23
-      Top = 41
+      Top = 40
       Width = 74
       BorderSpacing.Top = 1
       Caption = 'Exactly'
@@ -535,7 +536,7 @@ object frmFilter: TfrmFilter
       AnchorSideTop.Side = asrBottom
       Left = 6
       Height = 23
-      Top = 41
+      Top = 40
       Width = 74
       BorderSpacing.Top = 1
       Caption = 'Exactly'
@@ -549,7 +550,7 @@ object frmFilter: TfrmFilter
       AnchorSideTop.Side = asrBottom
       Left = 6
       Height = 23
-      Top = 64
+      Top = 63
       Width = 73
       Caption = 'Include'
       TabOrder = 1
@@ -558,7 +559,7 @@ object frmFilter: TfrmFilter
       AnchorSideLeft.Control = gbQth
       AnchorSideTop.Control = gbQth
       Left = 6
-      Height = 34
+      Height = 33
       Top = 6
       Width = 142
       BorderSpacing.Left = 6
@@ -585,8 +586,8 @@ object frmFilter: TfrmFilter
       AnchorSideTop.Side = asrBottom
       AnchorSideBottom.Side = asrBottom
       Left = 9
-      Height = 17
-      Top = 47
+      Height = 15
+      Top = 46
       Width = 22
       BorderSpacing.Left = 1
       Caption = 'VIA'
@@ -598,8 +599,8 @@ object frmFilter: TfrmFilter
       AnchorSideBottom.Control = cmbQSL_R
       AnchorSideBottom.Side = asrBottom
       Left = 155
-      Height = 17
-      Top = 61
+      Height = 15
+      Top = 63
       Width = 9
       Anchors = [akRight, akBottom]
       BorderSpacing.Top = 1
@@ -612,7 +613,7 @@ object frmFilter: TfrmFilter
       AnchorSideRight.Control = cmbLoTW_qsls
       AnchorSideRight.Side = asrBottom
       Left = 360
-      Height = 17
+      Height = 15
       Top = 45
       Width = 36
       Anchors = [akTop, akRight]
@@ -624,7 +625,7 @@ object frmFilter: TfrmFilter
       AnchorSideLeft.Control = gbQsl
       AnchorSideTop.Control = gbQsl
       Left = 8
-      Height = 34
+      Height = 33
       Top = 13
       Width = 120
       BorderSpacing.Left = 8
@@ -745,7 +746,7 @@ object frmFilter: TfrmFilter
       AnchorSideRight.Control = cmbeQSL_qsls
       AnchorSideRight.Side = asrBottom
       Left = 247
-      Height = 17
+      Height = 15
       Top = 45
       Width = 33
       Anchors = [akTop, akRight]
@@ -758,7 +759,7 @@ object frmFilter: TfrmFilter
       AnchorSideTop.Control = cmbQSL_S
       AnchorSideRight.Side = asrBottom
       Left = 156
-      Height = 17
+      Height = 15
       Top = 14
       Width = 8
       Anchors = [akTop, akRight]
@@ -774,7 +775,7 @@ object frmFilter: TfrmFilter
       AnchorSideRight.Control = lblEqsl
       AnchorSideRight.Side = asrBottom
       Left = 272
-      Height = 17
+      Height = 15
       Top = 14
       Width = 8
       Anchors = [akTop, akRight]
@@ -790,7 +791,7 @@ object frmFilter: TfrmFilter
       AnchorSideRight.Control = lblLoTW
       AnchorSideRight.Side = asrBottom
       Left = 388
-      Height = 17
+      Height = 15
       Top = 14
       Width = 8
       Anchors = [akTop, akRight]
@@ -807,8 +808,8 @@ object frmFilter: TfrmFilter
       AnchorSideBottom.Control = cmbQSL_R
       AnchorSideBottom.Side = asrBottom
       Left = 271
-      Height = 17
-      Top = 61
+      Height = 15
+      Top = 63
       Width = 9
       Anchors = [akRight, akBottom]
       BorderSpacing.Top = 1
@@ -823,8 +824,8 @@ object frmFilter: TfrmFilter
       AnchorSideBottom.Control = cmbQSL_R
       AnchorSideBottom.Side = asrBottom
       Left = 387
-      Height = 17
-      Top = 61
+      Height = 15
+      Top = 63
       Width = 9
       Anchors = [akRight, akBottom]
       BorderSpacing.Top = 1
@@ -850,7 +851,7 @@ object frmFilter: TfrmFilter
       AnchorSideLeft.Control = gbContinent
       AnchorSideTop.Control = gbContinent
       Left = 6
-      Height = 34
+      Height = 33
       Top = 0
       Width = 95
       BorderSpacing.Left = 6
@@ -874,7 +875,7 @@ object frmFilter: TfrmFilter
       AnchorSideLeft.Control = gbIota
       AnchorSideTop.Control = gbIota
       Left = 6
-      Height = 34
+      Height = 33
       Top = 6
       Width = 142
       BorderSpacing.Left = 6
@@ -888,7 +889,7 @@ object frmFilter: TfrmFilter
       AnchorSideTop.Side = asrBottom
       Left = 6
       Height = 23
-      Top = 64
+      Top = 63
       Width = 73
       Caption = 'Include'
       TabOrder = 1
@@ -899,7 +900,7 @@ object frmFilter: TfrmFilter
       AnchorSideTop.Side = asrBottom
       Left = 6
       Height = 23
-      Top = 41
+      Top = 40
       Width = 74
       BorderSpacing.Top = 1
       Caption = 'Exactly'
@@ -914,7 +915,7 @@ object frmFilter: TfrmFilter
       AnchorSideRight.Side = asrBottom
       Left = 6
       Height = 23
-      Top = 87
+      Top = 86
       Width = 124
       BorderSpacing.Left = 6
       Caption = 'Only IOTA qsos'
@@ -940,7 +941,7 @@ object frmFilter: TfrmFilter
       AnchorSideTop.Side = asrBottom
       Left = 5
       Height = 23
-      Top = 47
+      Top = 46
       Width = 74
       Caption = 'Exactly'
       Checked = True
@@ -953,7 +954,7 @@ object frmFilter: TfrmFilter
       AnchorSideTop.Side = asrBottom
       Left = 5
       Height = 23
-      Top = 70
+      Top = 69
       Width = 73
       Caption = 'Include'
       TabOrder = 1
@@ -963,7 +964,7 @@ object frmFilter: TfrmFilter
       AnchorSideLeft.Side = asrCenter
       AnchorSideTop.Control = gbRemarks
       Left = 5
-      Height = 34
+      Height = 33
       Top = 13
       Width = 142
       BorderSpacing.Top = 13
@@ -990,7 +991,7 @@ object frmFilter: TfrmFilter
       AnchorSideTop.Side = asrBottom
       Left = 6
       Height = 23
-      Top = 41
+      Top = 40
       Width = 74
       BorderSpacing.Top = 1
       Caption = 'Exactly'
@@ -1004,7 +1005,7 @@ object frmFilter: TfrmFilter
       AnchorSideTop.Side = asrBottom
       Left = 6
       Height = 23
-      Top = 64
+      Top = 63
       Width = 73
       Caption = 'Include'
       TabOrder = 1
@@ -1013,7 +1014,7 @@ object frmFilter: TfrmFilter
       AnchorSideLeft.Control = gbAward
       AnchorSideTop.Control = gbAward
       Left = 6
-      Height = 34
+      Height = 33
       Top = 6
       Width = 142
       BorderSpacing.Left = 6
@@ -1038,7 +1039,7 @@ object frmFilter: TfrmFilter
       AnchorSideLeft.Control = gbMyLoc
       AnchorSideTop.Control = gbMyLoc
       Left = 8
-      Height = 34
+      Height = 33
       Top = 6
       Width = 95
       BorderSpacing.Left = 8
@@ -1052,7 +1053,7 @@ object frmFilter: TfrmFilter
       AnchorSideTop.Side = asrBottom
       Left = 8
       Height = 23
-      Top = 64
+      Top = 63
       Width = 73
       Caption = 'Include'
       TabOrder = 1
@@ -1063,7 +1064,7 @@ object frmFilter: TfrmFilter
       AnchorSideTop.Side = asrBottom
       Left = 8
       Height = 23
-      Top = 41
+      Top = 40
       Width = 74
       BorderSpacing.Top = 1
       Caption = 'Exactly'
@@ -1089,7 +1090,7 @@ object frmFilter: TfrmFilter
       AnchorSideTop.Control = edtWAZ
       AnchorSideRight.Control = edtWAZ
       Left = 13
-      Height = 17
+      Height = 15
       Top = 6
       Width = 30
       Anchors = [akTop, akRight]
@@ -1101,8 +1102,8 @@ object frmFilter: TfrmFilter
       AnchorSideLeft.Control = Label8
       AnchorSideTop.Control = edtITU
       Left = 13
-      Height = 17
-      Top = 41
+      Height = 15
+      Top = 40
       Width = 26
       Anchors = [akTop, akLeft, akRight]
       Caption = 'ITU'
@@ -1113,7 +1114,7 @@ object frmFilter: TfrmFilter
       AnchorSideRight.Control = gbZones
       AnchorSideRight.Side = asrBottom
       Left = 101
-      Height = 34
+      Height = 33
       Top = 6
       Width = 45
       Anchors = [akTop, akRight]
@@ -1127,8 +1128,8 @@ object frmFilter: TfrmFilter
       AnchorSideTop.Control = edtWAZ
       AnchorSideTop.Side = asrBottom
       Left = 101
-      Height = 34
-      Top = 41
+      Height = 33
+      Top = 40
       Width = 45
       BorderSpacing.Top = 1
       CharCase = ecUppercase
@@ -1140,8 +1141,8 @@ object frmFilter: TfrmFilter
     AnchorSideTop.Control = cmbGroupBy
     AnchorSideTop.Side = asrBottom
     Left = 276
-    Height = 34
-    Top = 594
+    Height = 33
+    Top = 592
     Width = 360
     BorderSpacing.Top = 6
     ItemHeight = 0
@@ -1165,7 +1166,7 @@ object frmFilter: TfrmFilter
       AnchorSideLeft.Control = gbCounty
       AnchorSideTop.Control = gbCounty
       Left = 6
-      Height = 34
+      Height = 33
       Top = 6
       Width = 142
       BorderSpacing.Left = 6
@@ -1178,7 +1179,7 @@ object frmFilter: TfrmFilter
       AnchorSideTop.Side = asrBottom
       Left = 6
       Height = 23
-      Top = 41
+      Top = 40
       Width = 74
       BorderSpacing.Top = 1
       Caption = 'Exactly'
@@ -1192,7 +1193,7 @@ object frmFilter: TfrmFilter
       AnchorSideTop.Side = asrBottom
       Left = 6
       Height = 23
-      Top = 64
+      Top = 63
       Width = 73
       Caption = 'Include'
       TabOrder = 2
@@ -1203,8 +1204,8 @@ object frmFilter: TfrmFilter
     AnchorSideTop.Control = cmbProfile
     AnchorSideTop.Side = asrBottom
     Left = 276
-    Height = 33
-    Top = 634
+    Height = 32
+    Top = 631
     Width = 360
     BorderSpacing.Top = 6
     ItemHeight = 0
@@ -1230,8 +1231,8 @@ object frmFilter: TfrmFilter
     AnchorSideTop.Control = cmbSort
     AnchorSideTop.Side = asrBottom
     Left = 276
-    Height = 34
-    Top = 554
+    Height = 33
+    Top = 553
     Width = 200
     BorderSpacing.Top = 6
     ItemHeight = 0
@@ -1304,7 +1305,7 @@ object frmFilter: TfrmFilter
       AnchorSideTop.Control = gbState
       AnchorSideRight.Side = asrBottom
       Left = 6
-      Height = 34
+      Height = 33
       Top = 0
       Width = 95
       BorderSpacing.Left = 6
@@ -1317,7 +1318,7 @@ object frmFilter: TfrmFilter
     AnchorSideLeft.Side = asrBottom
     AnchorSideTop.Control = gbPower
     Left = 276
-    Height = 34
+    Height = 33
     Top = 514
     Width = 200
     BorderSpacing.Left = 100
@@ -1364,8 +1365,8 @@ object frmFilter: TfrmFilter
       AnchorSideLeft.Control = Label19
       AnchorSideTop.Control = edtPwrTo
       Left = 13
-      Height = 17
-      Top = 40
+      Height = 15
+      Top = 39
       Width = 17
       Caption = 'to:'
       ParentColor = False
@@ -1375,8 +1376,8 @@ object frmFilter: TfrmFilter
       AnchorSideTop.Control = edtPwrFrom
       AnchorSideTop.Side = asrBottom
       Left = 61
-      Height = 34
-      Top = 40
+      Height = 33
+      Top = 39
       Width = 95
       TabOrder = 0
     end
@@ -1385,7 +1386,7 @@ object frmFilter: TfrmFilter
       AnchorSideRight.Control = gbPower
       AnchorSideRight.Side = asrBottom
       Left = 61
-      Height = 34
+      Height = 33
       Top = 6
       Width = 95
       Anchors = [akTop, akRight]
@@ -1397,7 +1398,7 @@ object frmFilter: TfrmFilter
       AnchorSideTop.Control = edtPwrFrom
       AnchorSideRight.Control = edtPwrFrom
       Left = 13
-      Height = 17
+      Height = 15
       Top = 6
       Width = 35
       Anchors = [akTop, akRight]
@@ -1423,7 +1424,7 @@ object frmFilter: TfrmFilter
       AnchorSideLeft.Control = gbBand
       AnchorSideTop.Control = gbBand
       Left = 6
-      Height = 34
+      Height = 33
       Top = 6
       Width = 100
       BorderSpacing.Left = 6
@@ -1437,8 +1438,8 @@ object frmFilter: TfrmFilter
       AnchorSideTop.Control = cmbBandSelector
       AnchorSideTop.Side = asrBottom
       Left = 6
-      Height = 51
-      Top = 46
+      Height = 45
+      Top = 45
       Width = 134
       BorderSpacing.Top = 6
       Caption = 'Select band for Freq'#10'FROM and TO preset'#10'values.'
@@ -1453,7 +1454,7 @@ object frmFilter: TfrmFilter
     Left = 479
     Height = 23
     Top = 514
-    Width = 154
+    Width = 155
     BorderSpacing.Left = 3
     Caption = 'Reverse filter (NOT)'
     TabOrder = 27
@@ -1475,7 +1476,7 @@ object frmFilter: TfrmFilter
       AnchorSideLeft.Control = gbContestEx
       AnchorSideTop.Control = gbContestEx
       Left = 6
-      Height = 34
+      Height = 33
       Hint = 'search for contest send serial number'
       Top = 6
       Width = 60
@@ -1490,9 +1491,9 @@ object frmFilter: TfrmFilter
       AnchorSideTop.Control = edtSTX
       AnchorSideTop.Side = asrBottom
       Left = 6
-      Height = 34
+      Height = 33
       Hint = 'search for contest received serial number'
-      Top = 41
+      Top = 40
       Width = 60
       BorderSpacing.Left = 6
       BorderSpacing.Top = 1
@@ -1505,7 +1506,7 @@ object frmFilter: TfrmFilter
       AnchorSideRight.Control = gbContestEx
       AnchorSideRight.Side = asrBottom
       Left = 86
-      Height = 34
+      Height = 33
       Hint = 'search for contest send message exchange'
       Top = 6
       Width = 60
@@ -1521,9 +1522,9 @@ object frmFilter: TfrmFilter
       AnchorSideRight.Control = edtSTXstr
       AnchorSideRight.Side = asrBottom
       Left = 86
-      Height = 34
+      Height = 33
       Hint = 'search for contest received message exchange'
-      Top = 41
+      Top = 40
       Width = 60
       Anchors = [akTop, akRight]
       BorderSpacing.Top = 1
@@ -1537,7 +1538,7 @@ object frmFilter: TfrmFilter
       AnchorSideTop.Control = edtSTX
       AnchorSideTop.Side = asrCenter
       Left = 72
-      Height = 17
+      Height = 15
       Top = 15
       Width = 8
       Alignment = taCenter
@@ -1550,8 +1551,8 @@ object frmFilter: TfrmFilter
       AnchorSideTop.Control = edtSRX
       AnchorSideTop.Side = asrCenter
       Left = 72
-      Height = 17
-      Top = 50
+      Height = 15
+      Top = 49
       Width = 9
       Alignment = taCenter
       Caption = 'R'
@@ -1563,8 +1564,8 @@ object frmFilter: TfrmFilter
       AnchorSideTop.Control = edtSRX
       AnchorSideTop.Side = asrBottom
       Left = 29
-      Height = 17
-      Top = 75
+      Height = 15
+      Top = 73
       Width = 15
       Alignment = taCenter
       Caption = 'Nr'
@@ -1576,8 +1577,8 @@ object frmFilter: TfrmFilter
       AnchorSideTop.Control = edtSRXstr
       AnchorSideTop.Side = asrBottom
       Left = 103
-      Height = 17
-      Top = 75
+      Height = 15
+      Top = 73
       Width = 27
       Alignment = taCenter
       Caption = 'Msg'
@@ -1602,7 +1603,7 @@ object frmFilter: TfrmFilter
       AnchorSideLeft.Control = gbContName
       AnchorSideTop.Control = gbContName
       Left = 6
-      Height = 34
+      Height = 33
       Hint = 'contestname, choose ADIF contest_id via combobox or type freestyle max 40 characters'
       Top = 0
       Width = 90
@@ -1849,7 +1850,7 @@ object frmFilter: TfrmFilter
       AnchorSideTop.Side = asrCenter
       Left = 97
       Height = 23
-      Top = 6
+      Top = 5
       Width = 45
       BorderSpacing.Left = 1
       Caption = 'inc'
@@ -1875,8 +1876,8 @@ object frmFilter: TfrmFilter
     AnchorSideTop.Control = cmbGroupBy
     Left = 479
     Height = 23
-    Top = 554
-    Width = 131
+    Top = 553
+    Width = 132
     BorderSpacing.Left = 3
     Caption = 'Remember filter'
     OnChange = chkRememberChange
@@ -1901,7 +1902,7 @@ object frmFilter: TfrmFilter
       AnchorSideLeft.Control = gbDarcDok
       AnchorSideTop.Control = gbDarcDok
       Left = 6
-      Height = 34
+      Height = 33
       Top = 6
       Width = 132
       BorderSpacing.Left = 6
@@ -1914,7 +1915,7 @@ object frmFilter: TfrmFilter
       AnchorSideTop.Side = asrBottom
       Left = 6
       Height = 23
-      Top = 41
+      Top = 40
       Width = 74
       BorderSpacing.Top = 1
       Caption = 'Exactly'
@@ -1928,7 +1929,7 @@ object frmFilter: TfrmFilter
       AnchorSideTop.Side = asrBottom
       Left = 6
       Height = 23
-      Top = 64
+      Top = 63
       Width = 73
       Caption = 'Include'
       TabOrder = 2

--- a/src/fFilter.pas
+++ b/src/fFilter.pas
@@ -147,6 +147,7 @@ type
     procedure btnSelectDXCCClick(Sender: TObject);
     procedure chkRememberChange(Sender: TObject);
     procedure cmbBandSelectorChange(Sender: TObject);
+    procedure edtCallSignChange(Sender: TObject);
     procedure edtLocatorChange(Sender: TObject);
     procedure edtMyLocChange(Sender: TObject);
     procedure FormCreate(Sender: TObject);
@@ -573,6 +574,26 @@ begin
       end;
     end;
 
+end;
+
+procedure TfrmFilter.edtCallSignChange(Sender: TObject);
+var i:    integer;
+    s:    string;
+begin
+  if edtCallSign.Text<>'' then
+   begin
+     s:= '';
+     for i:=1 to length(edtCallSign.Text) do
+       begin
+         case edtCallSign.Text[i] of
+           'A'..'Z' : s:=s+ edtCallSign.Text[i];
+           '0'..'9' : s:=s+ edtCallSign.Text[i];
+                '/' : s:=s+ edtCallSign.Text[i];
+        end;
+       end;
+     edtCallSign.Text:=s;
+     edtCallSign.SelStart := Length(edtCallSign.Text);
+   end;
 end;
 
 


### PR DESCRIPTION
 Callsign is dominant in search and may cause empty results if having lonely space or some other not allowed char by accident.