### PR TITLE
Add screenshot to AppStream metadata

### DIFF
--- a/tools/cqrlog.appdata.xml
+++ b/tools/cqrlog.appdata.xml
@@ -16,5 +16,8 @@
     </p>
   </description>
   <url type="homepage">https://www.cqrlog.com/</url>
+  <screenshots>
+    <screenshot type="default">https://camo.githubusercontent.com/4b8b103448e282e79faa249cc2a3a26e5cfcc25b/68747470733a2f2f6371726c6f672e636f6d2f696d616765732f75736572732f6f6b326371722e706e67</screenshot>
+  </screenshots>
   <update_contact>mail@asciiwolf.com</update_contact>
 </component>


### PR DESCRIPTION
Closes #299.

I have added screenshot that is already present in [README.md](https://github.com/ok2cqr/cqrlog/blob/master/README.md). Strict AppStream validator warns about the picture size, but it is just a warning and everything should work fine.

/cc @ok2cqr