### PR TITLE
Multicast support for wsjt-remote

### DIFF
--- a/help/h1.html
+++ b/help/h1.html
@@ -593,6 +593,8 @@ There are no known dependencies issues.<br><br>
     <br>Default values are <strong>127.0.0.1</strong> or <strong>localhost</strong> for address and <strong>2237</strong> for port. These are set in wsjt-x settings/reporting and if changed there, must also to be changed here.
     <br>
     Address can also be other PC's IP address if wsjt-x is running in different networked PC than cqrlog, or even 0.0.0.0 when cqrlog listens all transmits from every wsjt-x in network.
+    <br><br>You can also use a multicast address for both <b>wsjt-x/settings/Reporting/UDP Server</b> and <b>cqrlog/preferences/fldigi/wsjt interface/wsjt addr</b>. Cqrlog will handle ip addresses starting with "239." as multicast addresses.
+    <br>With multicast you are able to run several programs listening to wsjt-x udp broadcasts at same time. To start with multicast try multicast group address "239.255.0.0" for both cqrlog and wsjt-x (and also other programs needed to listen wsjt-x)
     <br><br>
     Using <strong> WB4 chk starts from</strong> it is possible to limit log search starting from given date for callsign and/or locator.
     <br>Setting checkbox will apply given date as start date. Otherwise, when unchecked, whole log is searched through.


### PR DESCRIPTION
 -if wsjt address is set from 239.0.0.0/8 subnet UDP multicast support is enabled

Main purposeis that this allows multiple programs to receive decode information from one wsjt-x.
On the other hand multiple wsjt-xs can send information to cqrlog, but cqrlog can not handle multiple wsjt clients properly (maybe some day...)

Squashed commit of the following:

commit 4094db2e5b7ce5b0a7c03cd4b460873d5eef2fb8
Author: OH1KH <oh1kh@sral.fi>
Date:   Thu Jul 30 17:27:04 2020 +0300

    Some cleanup

commit fbd289e3bc5ddda5403a540d3220c0e65f7fdb0b
Author: OH1KH <oh1kh@sral.fi>
Date:   Thu Jul 30 16:24:11 2020 +0300

    help update

commit c807ebe8367e333ef48cdb3f1903c1c57de1a25a
Author: OH1KH <oh1kh@sral.fi>
Date:   Thu Jul 30 11:22:29 2020 +0300

    Adding UDP multicast feature to wsjtx remote if address is from 239.0.0.0/8 subnet.Works, but needs further testing