### PR TITLE
Rig/RotCtrl ignore empty parameters

### DIFF
--- a/src/dUtils.pas
+++ b/src/dUtils.pas
@@ -4054,9 +4054,12 @@ begin
     exit;
   end;
 
-  Result := '-m ' + cqrini.ReadString(section, 'model', '') + ' ' +
-    '-r ' + cqrini.ReadString(section, 'device', '') + ' ' +
-    '-t ' + cqrini.ReadString(section, 'RigCtldPort', '4532') + ' ';
+  //if parameter data is empty ignore parameter
+  Result:='-m ' + cqrini.ReadString(section, 'model', '') + ' ';
+  if  (trim(cqrini.ReadString(section, 'device', ''))<>'') then
+         Result:=Result+'-r ' + cqrini.ReadString(section, 'device', '') + ' ';
+  if  (trim(cqrini.ReadString(section, 'RigCtldPort', ''))<>'') then
+         Result:=Result+'-t ' + cqrini.ReadString(section, 'RigCtldPort', '') + ' ';
   Result := Result + cqrini.ReadString(section, 'ExtraRigCtldArgs', '') + ' ';
 
   case cqrini.ReadInteger(section, 'SerialSpeed', 0) of
@@ -4159,9 +4162,12 @@ begin
     exit;
   end;
 
-  Result := '-m ' + cqrini.ReadString(section, 'model', '') + ' ' +
-    '-r ' + cqrini.ReadString(section, 'device', '') + ' ' +
-    '-t ' + cqrini.ReadString(section, 'RotCtldPort', '4533') + ' ';
+   //if parameter data is empty ignore parameter
+  Result:='-m ' + cqrini.ReadString(section, 'model', '') + ' ';
+  if  (trim(cqrini.ReadString(section, 'device', ''))<>'') then
+         Result:=Result+'-r ' + cqrini.ReadString(section, 'device', '') + ' ';
+  if  (trim(cqrini.ReadString(section, 'RotCtldPort', ''))<>'') then
+         Result:=Result+'-t ' + cqrini.ReadString(section, 'RotCtldPort', '') + ' ';
   Result := Result + cqrini.ReadString(section, 'ExtraRotCtldArgs', '') + ' ';
 
   case cqrini.ReadInteger(section, 'SerialSpeed', 0) of


### PR DESCRIPTION
    If parameter r,t has no value ignore whole parameter. Without doing this parameter appears without value and causes rig/rotctlr start to fail.

    For example using FLrig (-m4) the device column must be empty to get defaults or user must understand that device is in this case "ipaddres:port" combination, not any /dev/ device.
    If he leaves device empty lonely "-r" will appear in parameter string and rigctld does not start at all.

Squashed commit of the following:

commit 0f730f0019cb790751854a7bb5fce021ff80a507
Author: OH1KH <oh1kh@sral.fi>
Date:   Tue Aug 4 12:29:05 2020 +0300

    Bugfix paramater -m cannot be empty, needs no checking

commit 220f6137302624be99a723d5e67d93a16bca257c
Author: OH1KH <oh1kh@sral.fi>
Date:   Tue Aug 4 12:08:12 2020 +0300

    Rig/RotCtrl ignore empty parameters

    If parameter r,m,t has no value ignore whole parameter. Without doing this parameter appears without value and causes rig/rotctlr start to fail.

    For example using FLrig (-m4) the device column must be empty to get defaults or user must understand that device is in this case "ipaddres:port" combination, not any /dev/ device.
    If he leaves device empty lonely "-r" vill appear in parameter string and rigctld does not start at all.

    Squashed commit of the following:

    commit 54b3cd47346347adf706dac7b1ea3bbff67b1206
    Author: OH1KH <oh1kh@sral.fi>
    Date:   Tue Aug 4 12:07:04 2020 +0300

        removed unused tmp

    commit ed922aba8cbc11b037d9a7bd34a90ea493f1ab3f
    Author: OH1KH <oh1kh@sral.fi>
    Date:   Tue Aug 4 12:04:03 2020 +0300

        Ignore rig/rotctd parameter if value is empty