### PR TITLE
Fixes false propagation 'TR̈́' with WSJT-X loggings

### DIFF
--- a/src/dSatellite.pas
+++ b/src/dSatellite.pas
@@ -130,12 +130,16 @@ function TdmSatellite.GetPropLongName(Propagation : String) : String;
 var
   i : integer;
 begin
+  Result:='';
   for i:=0 to ListOfPropModes.Count-1 do
   begin
     if (Pos(Propagation, ListOfPropModes[i]) = 1) then
-        break;
+     Begin
+       Result := ListOfPropModes[i];
+       break;
+     end;
   end;
-  Result := ListOfPropModes[i];
+
 end;
 
 function TdmSatellite.GetShortName(StringItem : String) : String;

--- a/src/fNewQSO.pas
+++ b/src/fNewQSO.pas
@@ -3003,10 +3003,14 @@ begin
                       1,2,3,4   :  edtContestSerialReceived.Text := copy( edtContestSerialReceived.Text,1,6); //Max Db length=6
                  end;
            end;
-           //----------------------------------------------------
+           //----------this is not yet in wsjt-x 2.2.2 and JTDX 2.1.0rc151------------------
            propmode:= trim(StrBuf(index));
            if dmData.DebugLevel>=1 then Writeln('Prop Mode :', propmode);
-           cmbPropagation.Text := dmSatellite.GetPropLongName(propmode);
+           if (cmbPropagation.Text='') then
+                 Begin
+                  cmbPropagation.Text := dmSatellite.GetPropLongName(propmode);
+                  if dmData.DebugLevel>=1 then Writeln('Prop Mode added!');
+                 end;
            //----------------------------------------------------
            if dmData.DebugLevel>=1 then Writeln(' WSJTX decode #5 logging: press save');
            SaveRemote;


### PR DESCRIPTION
This fixes false wsjt-x logging of propagation mode TR.

GetPropMode now returns empty string if no hit is found. That helps wsjt-x logging propmode that is a future implementation and does not yet exist in v2.2.2 (and JTDX 2.1.0) causing nonsense content of propmode that was leading to prop TR (last on the list).

Also if user has manually set propagation mode wsjt-x logging does not override it even when get proper propagation mode from wsjtx UDP message nr5.
