### PR TITLE
Fix export order (ADIF/HTML)

### DIFF
--- a/src/frExportPref.lfm
+++ b/src/frExportPref.lfm
@@ -30,7 +30,7 @@ object fraExportPref: TfraExportPref
     Top = 477
     Width = 197
     AutoSize = False
-    Caption = 'Most recent entries on top'
+    Caption = 'Oldest entries on top'
     TabOrder = 135
   end
   object chkExCont: TCheckBox


### PR DESCRIPTION
Checking "Most recent qsos first" at export causes ExAscTime to be true.
Then oldest qsos are on top of export:

ExAscTime   := cqrini.ReadBool('Export','AscTime',False);
if ExAscTime then
      dmData.Q.SQL.Text := 'SELECT * FROM view_cqrlog_main_by_qsodate_asc'

Term "ascending order", "ASC", by qso date means rising date value that is "from oldest date to latest date".

Easiest fix is to fix the form text from "Most recent" to "Oldest". Then the text equals to source code and does what expoected.