### PR TITLE
Details fix

### DIFF
--- a/help/h1.html
+++ b/help/h1.html
@@ -157,7 +157,6 @@
     QSO appears in this list immediately after logging, however the refresh procedure is
     quite slow. To save time, keep this box unchecked. </br>
     The <strong>'Skip over mode and frequency when radio is connected'</strong> is very important if the radio control is active.</br>
-    The <strong>'Show detail window'</strong> option enables an extra window to appear at program start.</br>
     The <strong>'Enable auto search on HamQTH.com/QRZ.COM'</strong> switches on the automated search
     for HamQTH/QRZ callbook data for any worked station. This option does the same as F6 on the
     logging screen, however it can be rather slow depending on the HamQTH.com/QRZ.COM server
@@ -176,11 +175,6 @@
     RX frequency and also propagation mode for logged qso.</br>
     Keys and Shortcuts for NewQSO Window you will find <a href="h20.html#ah16">here</a>.<br><br>
 
-</div>
-<br>
-<img src=img/h25.png border=0><br><br>
-<div align=justify>
-    This window dispays details about new/confirmed zones, IOTA details etc.
 </div>
 
 <p align=center><img src=img/line.png></p>

--- a/help/h20.html
+++ b/help/h20.html
@@ -66,7 +66,7 @@
     </tr>
     <tr>
         <td width="35%">Ctrl-H</td>
-        <td width="65%">Detailed info</td>
+        <td width="65%">Open help</td>
     </tr>
     <tr>
         <td width="35%">Ctrl-I</td>
@@ -322,7 +322,13 @@
     (including province, regions, call districts etc.), WAZ and ITU zones,
     continent, DXCC reference, geographical coordinates (in decimal form),
     distance, azimuth (direction), date and local time of the target point
-    and the salutation corresponding to the local time (GM, GE etc.). <br><br>
+    and the salutation corresponding to the local time (GM, GE etc.).
+    <br><br>
+    <img src=img/h25.png border=0><br><br>
+    <div align=justify>
+    Details window dispays details about new/confirmed zones, IOTA details etc. You can open it from <strong> NewQSo/Window/Details</strong> or with Ctrl+I key.
+    </div>
+    <br><br>
 
     <strong>German DOK:</strong> When entering a german callsign the field State will switch to DOK. 
     Here you can enter the german DOK of the station. You can, too, click on the label 'State' or 'DOK'

--- a/src/fNewQSO.pas
+++ b/src/fNewQSO.pas
@@ -5521,7 +5521,7 @@ begin
   end;
   if ((Shift = [ssCtrl]) and (key = VK_H)) then
   begin
-    acDetails.Execute;
+    ShowHelp;
     key := 0
   end;
   if ((Shift = [ssCtrl]) and (key = VK_M)) then


### PR DESCRIPTION
For some unknown reason Details window opens from Ctrl+i and Ctrl+h keys. Also from NewQSO/Window/details where only Ctrl+i is mentioned.

Help file mentions that there is a checkbox in preferences/NewQSO to make Details open at program start. How ever there is no checkbox!
By default Details opens in fresh empty log, but once closed it keeps closed on next starts.

Change:
	- Details opens from  NewQSO/Window/details and Ctrl+i
	- Ctrl+h opens help
	- shorcut keys help fixed
	- NewQSO (sections: settings and operation) fixed