### PR TITLE
Don't set RX frequency if offline mode is active

### DIFF
--- a/src/fTRXControl.pas
+++ b/src/fTRXControl.pas
@@ -375,7 +375,8 @@ begin
       if not TryStrToFloat(cqrini.ReadString('NewQSO','RXLO',''),rxlo) then
         rxlo := 0;
       if (f + rxlo <> 0) then
-        frmNewQSO.edtRXFreq.Text := FloatToStr((f + rxlo));
+        if not frmNewQSO.cbOffline.Checked then
+          frmNewQSO.edtRXFreq.Text := FloatToStr((f + rxlo));
     end;
   end
   else


### PR DESCRIPTION
If LO is active it also overwrites the RX frequency field with the LO QRG even in offline mode.
Setting this field should be ignored if we log offline.