### PR TITLE
Support for separate operator

### DIFF
--- a/help/h20.html
+++ b/help/h20.html
@@ -149,6 +149,10 @@
         <td width="65%">set QSL_S/QSL Send to N (N = No QSL/No paperQSL)</td>
     </tr>
     <tr>
+        <td width="35%">ALT-O</td>
+        <td width="65%">Set operator call (stored until restart of cqrlog). To reset to configured callsign just set to empty.</td>
+    </tr>
+    <tr>
         <td width="35%">ALT-V</td>
         <td width="65%"><a href="h30.html#m3">Memory up<a></td>
     </tr>
@@ -388,6 +392,11 @@
     In the next column is the reference call sign (the core of a slashed call, ie.
     KH6/OK2CQR). You can change it using Ctrl-R. The purpose is to provide the possibility
     of changeing the reference call if a correction of membership needed.
+    The second column also shows the operator call if it is set to a different call
+    than what is configured as station callsign in preferences. You can change the 
+    operator call tempoarily using the key combination ALT-O. The new operator callsign
+    is stored until restart of cqrlog. To manually reset the operator call back to the
+    station callsign just set an empty value.
     The number in the right corner denotes the CQRLOG version.
     <p align=center><img src=img/line.png></p>
     <a name="ah18"><h2><strong>New QSO (offline logging, ie. from paper log etc.)</strong></h2></a>

--- a/src/cqrlog.lpi
+++ b/src/cqrlog.lpi
@@ -370,6 +370,7 @@
         <Filename Value="fRefCall.pas"/>
         <IsPartOfProject Value="True"/>
         <ComponentName Value="frmRefCall"/>
+        <HasResources Value="True"/>
         <ResourceBaseClass Value="Form"/>
       </Unit39>
       <Unit40>
@@ -860,6 +861,13 @@
         <Filename Value="uConnectionInfo.pas"/>
         <IsPartOfProject Value="True"/>
       </Unit115>
+      <Unit116>
+        <Filename Value="fChangeOperator.pas"/>
+        <IsPartOfProject Value="True"/>
+        <ComponentName Value="frmChangeOperator"/>
+        <HasResources Value="True"/>
+        <ResourceBaseClass Value="Form"/>
+      </Unit116>
     </Units>
   </ProjectOptions>
   <CompilerOptions>

--- a/src/cqrlog.lpr
+++ b/src/cqrlog.lpr
@@ -5,7 +5,7 @@ uses
   cmem,cthreads,uScrollBars,
   Interfaces, // this includes the LCL widgetset
   Forms, sysutils, Classes, fMain, fPreferences, dUtils, fNewQSO, dialogs,
-  fChangeLocator, dData, dDXCC, fMarkQSL, fDXCCStat, fSort, fFilter,
+  fChangeLocator, fChangeOperator, dData, dDXCC, fMarkQSL, fDXCCStat, fSort, fFilter,
   fImportProgress, fImportTest, TAChartLazarusPkg, RunTimeTypeInfoControls,
   fSelectDXCC, fGrayline, fCallbook, fTRXControl, fFreq, fChangeFreq,
   fAdifImport, fSplash, fSearch, fQTHProfiles, fNewQTHProfile, fEnterFreq,

--- a/src/dData.lfm
+++ b/src/dData.lfm
@@ -700,13 +700,13 @@ object dmData: TdmData
     Script.Strings = (
       'CREATE VIEW view_cqrlog_main_by_qsodate AS SELECT id_cqrlog_main,qsodate,time_on,time_off,callsign, freq,mode,rst_s,rst_r,name,qth,qsl_s,qsl_r,qsl_via,iota,pwr,itu,waz,loc,my_loc,county,'
       'award,remarks, band, dxcc_id.dxcc_ref AS dxcc_ref ,qso_dxcc, profile,idcall, state, lotw_qslsdate, lotw_qslrdate,lotw_qsls, lotw_qslr, cont, qsls_date,qslr_date,club_nr1,club_nr2,club_nr3,'
-      'club_nr4, club_nr5, eqsl_qsl_sent, eqsl_qslsdate, eqsl_qsl_rcvd,eqsl_qslrdate,concat(qsl_r,lotw_qslr,eqsl_qsl_rcvd) as qslr,dxcc_id.country, rxfreq, satellite, prop_mode, srx, stx, srx_string, stx_string, contestname, dok FROM cqrlog_main JOIN dxcc_id ON dxcc_id.adif = cqrlog_main.adif order by qsodate DESC, time_on DESC;'
+      'club_nr4, club_nr5, eqsl_qsl_sent, eqsl_qslsdate, eqsl_qsl_rcvd,eqsl_qslrdate,concat(qsl_r,lotw_qslr,eqsl_qsl_rcvd) as qslr,dxcc_id.country, rxfreq, satellite, prop_mode, srx, stx, srx_string, stx_string, contestname, dok, operator FROM cqrlog_main JOIN dxcc_id ON dxcc_id.adif = cqrlog_main.adif order by qsodate DESC, time_on DESC;'
       'CREATE VIEW view_cqrlog_main_by_qsodate_asc AS SELECT id_cqrlog_main,qsodate,time_on,time_off,callsign, freq,mode,rst_s,rst_r,name,qth,qsl_s,qsl_r,qsl_via,iota,pwr,itu,waz,loc,my_loc,county,'
       'award,remarks, band, dxcc_id.dxcc_ref AS dxcc_ref ,qso_dxcc, profile,idcall, state, lotw_qslsdate, lotw_qslrdate,lotw_qsls, lotw_qslr, cont, qsls_date,qslr_date,club_nr1,club_nr2,club_nr3,'
-      'club_nr4,club_nr5,eqsl_qsl_sent,eqsl_qslsdate,eqsl_qsl_rcvd,eqsl_qslrdate,concat(qsl_r,lotw_qslr,eqsl_qsl_rcvd) as qslr,dxcc_id.country, rxfreq, satellite, prop_mode, srx, stx, srx_string, stx_string, contestname, dok FROM cqrlog_main JOIN dxcc_id ON dxcc_id.adif = cqrlog_main.adif order by qsodate ASC, time_on ASC;'
+      'club_nr4,club_nr5,eqsl_qsl_sent,eqsl_qslsdate,eqsl_qsl_rcvd,eqsl_qslrdate,concat(qsl_r,lotw_qslr,eqsl_qsl_rcvd) as qslr,dxcc_id.country, rxfreq, satellite, prop_mode, srx, stx, srx_string, stx_string, contestname, dok, operator FROM cqrlog_main JOIN dxcc_id ON dxcc_id.adif = cqrlog_main.adif order by qsodate ASC, time_on ASC;'
       'CREATE VIEW view_cqrlog_main_by_callsign AS SELECT id_cqrlog_main,qsodate,time_on,time_off,callsign, freq,mode,rst_s,rst_r,name,qth,qsl_s,qsl_r,qsl_via,iota,pwr,itu,waz,loc,my_loc,county,'
       'award,remarks, band, dxcc_id.dxcc_ref AS dxcc_ref ,qso_dxcc, profile,idcall, state, lotw_qslsdate, lotw_qslrdate,lotw_qsls, lotw_qslr, cont, qsls_date,qslr_date,club_nr1,club_nr2,club_nr3,'
-      'club_nr4,club_nr5,eqsl_qsl_sent,eqsl_qslsdate,eqsl_qsl_rcvd,eqsl_qslrdate,concat(qsl_r,lotw_qslr,eqsl_qsl_rcvd) as qslr,dxcc_id.country, rxfreq, satellite, prop_mode, srx, stx, srx_string, stx_string, contestname, dok FROM cqrlog_main JOIN dxcc_id ON dxcc_id.adif = cqrlog_main.adif order by callsign;'
+      'club_nr4,club_nr5,eqsl_qsl_sent,eqsl_qslsdate,eqsl_qsl_rcvd,eqsl_qslrdate,concat(qsl_r,lotw_qslr,eqsl_qsl_rcvd) as qslr,dxcc_id.country, rxfreq, satellite, prop_mode, srx, stx, srx_string, stx_string, contestname, dok, operator FROM cqrlog_main JOIN dxcc_id ON dxcc_id.adif = cqrlog_main.adif order by callsign;'
     )
     Terminator = ';'
     CommentsinSQL = True

--- a/src/fAdifImport.pas
+++ b/src/fAdifImport.pas
@@ -83,6 +83,7 @@ type TnewQSOEntry=record   //represents a new qso entry in the log
       PROP_MODE : String[30];
       SAT_NAME : String[30];
       FREQ_RX  : String[30];
+      OP:String[30];
      end;
 type
 
@@ -318,7 +319,8 @@ function TfrmAdifImport.fillTypeVariableWithTagData(h:longint;var data:string;va
       h_AWARD:d.AWARD:=data;
       h_PROP_MODE:d.PROP_MODE:=data;
       h_SAT_NAME:d.SAT_NAME:=data;
-      h_FREQ_RX:d.FREQ_RX:=data
+      h_FREQ_RX:d.FREQ_RX:=data;
+      h_OP:d.OP:=data
     else begin
         { writeln('Unnamed...>',pom,'<');fillTypeVariableWithTagData:=false;exit;}
       end;
@@ -430,6 +432,8 @@ begin
     d.COMMENT := copy(d.COMMENT, 1, 200);
 
     d.MODE := UpperCase(d.MODE);
+
+    d.OP := UpperCase(d.OP);
 
     if not dmUtils.IsAdifOK(d.QSO_DATE,d.TIME_ON,d.TIME_OFF,d.CALL,d.FREQ,d.MODE,d.RST_SENT,
                             d.RST_RCVD,d.IOTA,d.ITUZ,d.CQZ,d.GRIDSQUARE,d.MY_GRIDSQUARE,
@@ -583,13 +587,14 @@ begin
                    'rst_s,rst_r,name,qth,qsl_s,qsl_r,qsl_via,iota,pwr,itu,waz,loc,my_loc,'+
                    'remarks,county,adif,idcall,award,band,state,cont,profile,lotw_qslsdate,lotw_qsls,'+
                    'lotw_qslrdate,lotw_qslr,qsls_date,qslr_date,eqsl_qslsdate,eqsl_qsl_sent,'+
-                   'eqsl_qslrdate,eqsl_qsl_rcvd, prop_mode, satellite, rxfreq, stx, srx, stx_string, srx_string, contestname, dok) values('+
+                   'eqsl_qslrdate,eqsl_qsl_rcvd, prop_mode, satellite, rxfreq, stx, srx, stx_string,'+
+                   'srx_string, contestname, dok, operator) values('+
                    ':qsodate,:time_on,:time_off,:callsign,:freq,:mode,:rst_s,:rst_r,:name,:qth,'+
                    ':qsl_s,:qsl_r,:qsl_via,:iota,:pwr,:itu,:waz,:loc,:my_loc,:remarks,:county,:adif,'+
                    ':idcall,:award,:band,:state,:cont,:profile,:lotw_qslsdate,:lotw_qsls,:lotw_qslrdate,'+
                    ':lotw_qslr,:qsls_date,:qslr_date,:eqsl_qslsdate,:eqsl_qsl_sent,:eqsl_qslrdate,'+
                    ':eqsl_qsl_rcvd, :prop_mode, :satellite, :rxfreq, :stx, :srx, :stx_string, :srx_string,'+
-                   ':contestname,:dok)';
+                   ':contestname,:dok,:operator)';
     if dmData.DebugLevel >=1 then Writeln(Q1.SQL.Text);
     Q1.Prepare;
     Q1.Params[0].AsString   := d.QSO_DATE;
@@ -714,6 +719,10 @@ begin
     Q1.Params[44].AsString := d.SRX_STRING;
     Q1.Params[45].AsString := d.CONTEST_ID;
     Q1.Params[46].AsString := d.DARC_DOK;
+    if (d.OP <> '') then
+      Q1.Params[47].AsString := d.OP
+    else
+      Q1.Params[47].Clear;
 
     if dmData.DebugLevel >=1 then Writeln(Q1.SQL.Text);
     Q1.ExecSQL;

--- a/src/fChangeLocator.pas
+++ b/src/fChangeLocator.pas
@@ -46,7 +46,13 @@ end;
 
 procedure TfrmChangeLocator.btnOKClick(Sender: TObject);
 begin
-  ModalResult := mrOK
+   if dmUtils.isLocOK(edtLocator.Text) then
+    ModalResult := mrOK
+    else
+     Begin
+        edtLocator.Text:='ERROR!';
+        edtLocator.SelStart := Length(edtLocator.Text);
+     end;
 end;
 
 procedure TfrmChangeLocator.edtLocatorChange(Sender: TObject);

--- a/src/fChangeOperator.lfm
+++ b/src/fChangeOperator.lfm
@@ -1,43 +1,43 @@
-object frmChangeLocator: TfrmChangeLocator
+object frmChangeOperator: TfrmChangeOperator
   Left = 657
   Height = 108
   Top = 416
   Width = 236
   HorzScrollBar.Page = 239
   VertScrollBar.Page = 88
-  ActiveControl = edtLocator
+  ActiveControl = edtOperator
   AutoSize = True
   BorderIcons = [biSystemMenu]
   BorderStyle = bsDialog
   BorderWidth = 10
-  Caption = 'Change locator'
+  Caption = 'Change operator'
   ClientHeight = 108
   ClientWidth = 236
   Position = poMainFormCenter
   LCLVersion = '2.0.2.0'
-  object lblEnterLocator: TLabel
+  object lblEnterOperator: TLabel
     Left = 8
     Height = 17
     Top = 8
     Width = 120
-    Caption = 'Enter your locator:'
+    Caption = 'Enter your operator:'
     ParentColor = False
   end
-  object edtLocator: TEdit
-    AnchorSideTop.Control = lblEnterLocator
+  object edtOperator: TEdit
+    AnchorSideTop.Control = lblEnterOperator
     AnchorSideTop.Side = asrBottom
     Left = 8
     Height = 34
     Top = 27
     Width = 216
     BorderSpacing.Top = 2
-    MaxLength = 6
-    OnChange = edtLocatorChange
-    OnKeyPress = edtLocatorKeyPress
+    MaxLength = 20
+    OnChange = edtOperatorChange
+    OnKeyPress = edtOperatorKeyPress
     TabOrder = 0
   end
   object btnOK: TButton
-    AnchorSideTop.Control = edtLocator
+    AnchorSideTop.Control = edtOperator
     AnchorSideTop.Side = asrBottom
     Left = 8
     Height = 41
@@ -52,7 +52,7 @@ object frmChangeLocator: TfrmChangeLocator
     TabOrder = 1
   end
   object btnStorno: TButton
-    AnchorSideTop.Control = edtLocator
+    AnchorSideTop.Control = edtOperator
     AnchorSideTop.Side = asrBottom
     Left = 160
     Height = 41

--- a/src/fChangeOperator.pas
+++ b/src/fChangeOperator.pas
@@ -1,0 +1,58 @@
+unit fChangeOperator;
+
+{$mode objfpc}{$H+}
+
+interface
+
+uses
+  Classes, SysUtils, LResources, Forms, Controls, Graphics, Dialogs, StdCtrls,
+  Buttons;
+
+type
+
+  { TfrmChangeOperator }
+
+  TfrmChangeOperator = class(TForm)
+    btnOK: TButton;
+    btnStorno: TButton;
+    edtOperator: TEdit;
+    lblEnterOperator: TLabel;
+    procedure btnOKClick(Sender: TObject);
+    procedure edtOperatorChange(Sender: TObject);
+    procedure edtOperatorKeyPress(Sender: TObject; var Key: char);
+  private
+    { private declarations }
+  public
+    { public declarations }
+  end;
+
+var
+  frmChangeOperator: TfrmChangeOperator;
+
+implementation
+{$R *.lfm}
+
+{ TfrmChangeOperator }
+uses dUtils;
+
+procedure TfrmChangeOperator.edtOperatorKeyPress(Sender: TObject; var Key: char);
+begin
+  if (key = #13) then
+  begin
+    btnOK.Click;
+    Key := #0
+  end
+end;
+
+procedure TfrmChangeOperator.btnOKClick(Sender: TObject);
+begin
+  ModalResult := mrOK
+end;
+
+procedure TfrmChangeOperator.edtOperatorChange(Sender: TObject);
+begin
+  edtOperator.SelStart := Length(edtOperator.Text);
+end;
+
+end.
+

--- a/src/fEDIExport.pas
+++ b/src/fEDIExport.pas
@@ -165,6 +165,8 @@ var
   dupe       : String;
   cont, WAZ, posun, ITU, lat, long, pfx, country: string;
   message : String;
+  Operators : TStringList;
+  OpString : String;
 begin
   SaveSettings;
   date := dmUtils.GetDateTime(0);
@@ -230,6 +232,8 @@ begin
   dxccs := TStringList.Create;
   new_dxcc := '';
   callsign_list := TStringList.Create;
+  Operators := TStringList.Create;
+  OpString := '';
   try try
     dmData.trQ.StartTransaction;
     dmData.Q.Open;
@@ -302,6 +306,9 @@ begin
       else
               callsign_list.Add(dmData.Q.FieldByName('callsign').AsString);
 
+      if (dmData.Q.FieldByName('operator').AsString <> '') and (Operators.IndexOf(dmData.Q.FieldByName('operator').AsString) < 0) then
+         Operators.Add(dmData.Q.FieldByName('operator').AsString);
+
       s.Add(RightStr(StringReplace(dmData.Q.FieldByName('qsodate').AsString,'-','',[rfReplaceAll, rfIgnoreCase]),6)+';'+
             StringReplace(dmData.Q.FieldByName('time_on').AsString,':','',[rfReplaceAll, rfIgnoreCase])+';'+
             dmData.Q.FieldByName('callsign').AsString+';'+
@@ -336,6 +343,12 @@ begin
     dmData.trQ.Rollback;
     dmData.Q.Close
   end;
+  for j:=0 to pred(Operators.Count) do
+  begin
+     OpString := OpString+Operators[j];
+     if (j >= 0) and (j < (Operators.Count-1)) then
+        OpString:=OpString+';'
+  end;
   try
     AssignFile(f,edtFileName.Text);
     Rewrite(f);
@@ -351,7 +364,8 @@ begin
     Writeln(f,'PBand='+EdiBand(dmData.qCQRLOG.FieldByName('band').AsString));
     Writeln(f,'PClub='+club);
     Writeln(f,'RName='+myname);
-    Writeln(f,'RCall='+mycall);
+    if (Operators.Count = 0) then
+      Writeln(f,'RCall='+mycall);
     Writeln(f,'RAdr1='+mailingaddress);
     Writeln(f,'RAdr2='+zipcity);
     Writeln(f,'RPoCo=');
@@ -359,7 +373,10 @@ begin
     Writeln(f,'RCoun='+country);
     Writeln(f,'RPhon=');
     Writeln(f,'RHBBS='+email);
-    Writeln(f,'MOpe1=');
+    if (Operators.Count > 0) then
+      Writeln(f,'MOpe1='+OpString)
+    else
+      Writeln(f,'MOpe1=');
     Writeln(f,'MOpe2=');
     Writeln(f,'STXEq='+edtTxEquipment.Text);
     Writeln(f,'SPowe='+edtTxPower.Text);

--- a/src/fExportProgress.pas
+++ b/src/fExportProgress.pas
@@ -187,7 +187,10 @@ var
                      QSLSDate,QSLRDate,eQslS,eQslSDate,eQslR,eQslRDate,PropMode, Satellite, RxFreq, stx,
                      srx, stx_string, srx_string, contestname, Darc_Dok : String);
 
+  var
+     station_callsign : String;
   begin
+    station_callsign := cqrini.ReadString('Station', 'Call', '');
     leng := 0;
     if ExDate then
     begin
@@ -210,6 +213,9 @@ var
         SaveTag(tmp,leng);
       end;
     end;
+
+    SaveTag(dmUtils.StringToADIF('<STATION_CALLSIGN', station_callsign), leng);
+
     if ExCall then
       SaveTag(dmUtils.StringToADIF('<CALL',dmUtils.RemoveSpaces(call)),leng);
     if ExMode then
@@ -302,7 +308,10 @@ var
       if dmUtils.IsLocOK(MyLoc) then
         SaveTag(dmUtils.StringToADIF('<MY_GRIDSQUARE',dmUtils.StdFormatLocator(MyLoc)),leng);
    if ExOperator then
-      SaveTag(dmUtils.StringToADIF('<OPERATOR',cqrini.ReadString('Station', 'Call', '')),leng);
+   begin
+      if (Op <> '') and (Op <> station_callsign) then
+         SaveTag(dmUtils.StringToADIF('<OPERATOR', Op) ,leng);
+   end;
    if ExDistance then
     begin
       dmUtils.DistanceFromLocator(dmUtils.CompleteLoc(MyLoc),Loc,qrb,qrc);
@@ -519,7 +528,7 @@ begin   //TfrmExportProgress
                  Source.Fields[17].AsString,  //waz
                  Source.Fields[18].AsString, //loc
                  Source.Fields[19].AsString, //myloc
-                 cqrini.ReadString('Station', 'Call', ''), //operator
+                 Source.FieldByName('operator').AsString, //operator
                  Source.Fields[20].AsString, //county
                  Source.Fields[21].AsString, //award
                  Source.Fields[22].AsString, //remarks
@@ -771,12 +780,9 @@ var
 
     if ExOperator then
     begin
-      tmp := cqrini.ReadString('Station', 'Call', '');
-      if tmp = '' then
-        Op := '&nbsp;'
-      else
-        Op := tmp;
-      Writeln(f,SetData('WOperator', '10' ,tmp));
+      if (Op = '') then
+         Op := '&nbsp;';
+      Writeln(f,SetData( 'WOperator', '10',Op));
     end;
 
     if ExDistance then
@@ -1308,7 +1314,7 @@ begin
                Source.Fields[17].AsString,  //waz
                Source.Fields[18].AsString, //loc
                Source.Fields[19].AsString, //myloc
-               cqrini.ReadString('Station', 'Call', ''), //operator
+               Source.FieldByName('operator').AsString, //operator
                Source.Fields[20].AsString, //county
                Source.Fields[21].AsString, //award
                Source.Fields[22].AsString, //remarks

--- a/src/uADIFhash.pas
+++ b/src/uADIFhash.pas
@@ -54,4 +54,5 @@ const h_AWARD = 53520;
 const h_PROP_MODE = 17551;
 const h_SAT_NAME = 39545;
 const h_FREQ_RX = 2926;
+const h_OP = 16130;
 


### PR DESCRIPTION
This adds support for (tempoarily) setting an operator callsign
via ALT+O. This is stored in a separate table column if it differs
from the configured station callsign.
I is exported to ADIF and cbr/edi files.
Squashed commit of the following:

commit 4d9302d89ebc8d5f4f3fb0c891283310c9391e60
Author: phl0 <florian@florian-wolters.de>
Date:   Thu Sep 10 02:03:51 2020 +0200

    operator support for cabrillo exports

commit ffed1b5a7cd61147305ee0afd15db4e0ce80f752
Author: phl0 <florian@florian-wolters.de>
Date:   Thu Sep 10 01:31:42 2020 +0200

    Add operators to edi exports

commit 56ab0e5f36dfff54a8ffae05565344cb8fb717d5
Author: phl0 <florian@florian-wolters.de>
Date:   Wed Sep 9 16:36:06 2020 +0200

    Retain operator call on QSO edit

commit db6d23109834c8258fa87e418c004dcb253e2235
Author: phl0 <florian@florian-wolters.de>
Date:   Wed Sep 9 16:26:31 2020 +0200

    Add ADIF import functions for operator call

commit 9fa74745c564cf9215fd8878419b2c1042b5c1a5
Author: phl0 <florian@florian-wolters.de>
Date:   Wed Sep 9 16:07:43 2020 +0200

    Add export functions for operator callsign

commit c04387a4f2d0ce014aac1b1b137f2f80ecb190d7
Author: phl0 <florian@florian-wolters.de>
Date:   Wed Sep 9 15:46:38 2020 +0200

    Store Op only if different from configured callsign

commit b00e6ae48dcba47a9db071d7ffb5c52885672ad0
Merge: 11d851e d99e17f
Author: phl0 <florian@florian-wolters.de>
Date:   Tue Sep 8 12:21:13 2020 +0200

    Merge remote-tracking branch 'upstream/master' into operator

commit 11d851e7c66b9f3d91289ced4a5b0d6d857ab2e8
Merge: 7e80390 2d4445b
Author: phl0 <florian@florian-wolters.de>
Date:   Mon Sep 7 12:22:26 2020 +0200

    Merge remote-tracking branch 'upstream/master' into operator

commit 7e803907de50a5c3b774e31f63ce9ecf34696c4d
Author: Florian Wolters <florian@florian-wolters.de>
Date:   Sun Sep 6 10:55:47 2020 +0200

    Update documentation

commit 6d0dbfc2e8889b4a65b1675ea2bebdc53a7ec252
Author: phl0 <florian@florian-wolters.de>
Date:   Fri Sep 4 10:47:08 2020 +0200

    Slight formatting stuff

commit 620b1713ab33884a0291198d26484612bd195a95
Author: OH1KH <oh1kh@sral.fi>
Date:   Thu Sep 3 17:01:10 2020 +0300

    additions 2

     - N1MM now gets "operator" with same rules as wsjt-x
     - change loc (6)  and change operator (20)  now has input limit
     - fChangeOperator should be now part of project (diff shows not..will check after commit)
     - cabrillo export now has header "OPERATORS:"
       by cabrillo definitions it can show operators and host:
       OPERATORS: OH1KH,@OH1KH  (when no operator defined)
       OPERATORS: OH1KJ,@OH1KH
       OPERATORS: OH1KH,OH1KJ,@OH1KH
       The last case must be mentioned in HELP that operator (Alt+O) input can be more than one callsign by comma separated (in limit of 20 char).

commit ffd3ba2f0bceeccf2e8a4b8ad7be9c66a2209893
Author: OH1KH <oh1kh@sral.fi>
Date:   Thu Sep 3 12:03:59 2020 +0300

    Some additions
    - fixed status line sizes: shorter text for My grid and ref.call
    - added Operator to status line
    - shows up if different than station call
    - if changed to empty input replaces station call to be also operator
    - wsjtx  logging "operator" sets cqrlog operator but only if previous value was station call.
    - fixed ctrl+l (myLoc) has now input validate. Allows just 6 char input now

commit 7f6db3909ecbe3c5dc397196309c0605806b0f0b
Author: phl0 <florian@florian-wolters.de>
Date:   Wed Sep 2 13:31:02 2020 +0200

    Add forgotten files ... :/

commit f0b1c7b94f9bf8e43005b19c5dcde18c9f5d9081
Author: phl0 <florian@florian-wolters.de>
Date:   Wed Sep 2 13:30:06 2020 +0200

    Add Operator short cut/ popup to save and Edit QSO functions

commit 9de6a7447293813840029e93c98ba4da844b10b5
Author: phl0 <florian@florian-wolters.de>
Date:   Wed Sep 2 08:52:35 2020 +0200

    Add column for operator to main DB