### PR TITLE
add ADIF Tag BAND_RX in ADIF Export

### DIFF
--- a/src/fExportProgress.pas
+++ b/src/fExportProgress.pas
@@ -410,6 +410,7 @@ var
        end;
     if (ExRxFreq and ((RxFreq <> '0') and (RxFreq <> ''))) then
        SaveTag(dmUtils.StringToADIF('<FREQ_RX',RxFreq),leng);
+       SaveTag(dmUtils.StringToADIF('<BAND_RX',dmUtils.GetAdifBandFromFreq(RxFreq)),leng);
     if (ExDarcDok and (Darc_Dok <> '')) then
        SaveTag(dmUtils.StringToADIF('<DARC_DOK',Darc_Dok),leng);
 


### PR DESCRIPTION
Add ADIF Tag BAND_RX like it is done for the normal FREQ and BAND Tag. BAND_RX is relevant for the qslshop.de when you want to send QSL cards for satellite qso's. 