### PR TITLE
Fix to DXCluster help

### DIFF
--- a/help/h1.html
+++ b/help/h1.html
@@ -343,7 +343,8 @@ This is also possible with "notify-send". The display duration is set in ms (-t 
 </p>
 <p>
 <strong>Show country name in the DX cluster spot</strong> - next to every spot, you will se the coutry name of the DX station<br>
-<strong>Send these commands to telnet DXCluster when connected</strong> - one or several commands with comma separated can be sent to DXCluster after connect is initialized.<br>
+<strong>Send these commands to telnet DXCluster when connected</strong> - one or several commands with comma separated can be sent to DXCluster after connect is initialized.
+ If your command(s) have space(s) between, like "<strong>acc/spot by_zone 14,15,16 and not (on hf/data or on hf/rtty)</strong>" it is recommended to close each command between double quotes.<br>
 <strong>Connect to DX cluster after program startup</strong> - after log is opened, cqrlog will connect to your default cluster. Please remember that
 username and password(if needed) have to be filled in the cluster list.
 </p>


### PR DESCRIPTION
It seems that cmds.StrictDelimiter := true does not work as it should allowing also space to be delimiter with the defined delimiter character then help file is changed so that user understands to use double quotes if his command string contains spaces between.

A Lazarus bug, perhaps?