### PR TITLE
CW macro speed changes with Hamlib keyer

### DIFF
--- a/help/h26.html
+++ b/help/h26.html
@@ -61,6 +61,15 @@
 		<li>%xns - contest exchenge serial number sends 9->N and 0->T</li>
 		<li>%xrs - full contest exchange RST+SerialNR+Message sends 9->N and 0->T.<br>
 		(May be used always instead of %rs as if serNR and Message are empty just sends plain report.)</li>
+		</li><li> + or - in macro text will increase/decrease CW speed by 5WPM/one mark. 
+		<br>"TU +++599--- 001" will send 599 with 15WPM higer speed.
+		<br><br>Hamlib keyer has some limitations with this: 
+		<br> 1) Version of Hamlib must be at least Hamlib 4.1~git Last commit 2020-10-20 03:22:59 2020 +0000 SHA=8a769c
+		<br> 2) Do not use space(s) between text and +(or -) rigctld will add them I.E. "TU+++599---001"
+		<br> 3) Speed change works only with BKIN mode (not F-BKIN) and at the moment new Icom rigs (tested only ic7300)
+		</li>
+		
+
 	    </ul>
             </td>
         </tr>


### PR DESCRIPTION
    Added limited support for speed changes in middle of macro text when using Hamlib keyer.

    1) Version of Hamlib must be at least Hamlib 4.1~git Last commit 2020-10-20 03:22:59 2020 +0000 SHA=8a769c
    2) Do not use space(s) between text and +(or -) rigctld will add them I.E. "TU+++599---001"
    3) Speed change works only with BKIN mode (not F-BKIN) and at the moment new Icom rigs (tested only ic7300)
    4) Test results for icom 7300: Macro string "TU+++5nn---001"
	Speed 28WPM  +15WPM increase for "5nn"
	Rig settings: TX delay 25ms, BKIN delay 7.5d, CW-Key set/Rise time 2ms

	Measured time for 1st dot of "5" is 0.024sec,  2nd 0.027sec.
	Speed change via CAT causes 3ms drop of first element. Not fatal!

    With other keyers this existed already, but forgotten from help file.
    Fixed help file.

    Added speed limit checks for all keyers when using + and -

Squashed commit of the following:

commit f745caa91c839e04d3f474d0b5ef59274edb6a98
Author: OH1KH <oh1kh@sral.fi>
Date:   Wed Oct 21 12:07:30 2020 +0300

    Added some range checking

commit a47b585813654f72bee402601b9ae306dc459985
Author: OH1KH <oh1kh@sral.fi>
Date:   Tue Oct 20 17:22:43 2020 +0300

    CW macro speed changes

    Added limited support for speed changes in middle of macro text when using Hamlib keyer.

    1) Version of Hamlib must be at least Hamlib 4.1~git Last commit 2020-10-20 03:22:59 2020 +0000 SHA=8a769c
    2) Do not use space(s) between text and +(or -) rigctld will add them I.E. "TU+++599---001"
    3) Speed change works only with BKIN mode (not F-BKIN) and at the moment new Icom rigs (tested only ic7300)

    With other keyers this existed already, but forgotten from help file.
    Fixed help file.