### PR TITLE
Fix for Club membership

### DIFF
--- a/src/fClubSettings.lfm
+++ b/src/fClubSettings.lfm
@@ -297,7 +297,7 @@ object frmClubSettings: TfrmClubSettings
       Items.Strings = (
         'award'
         'qth'
-        'comm. for QSO'
+        'remarks'
         'name'
         'county'
         'grid'

--- a/src/fNewQSO.pas
+++ b/src/fNewQSO.pas
@@ -6739,7 +6739,7 @@ begin
       edtQTH.Text := StoreText;
     edtQTHExit(nil);
   end;
-  if (where = 'comm. for QSO') and (Pos(LowerCase(StoreText),LowerCase(edtRemQSO.text))=0) then
+  if (where = 'remarks') and (Pos(LowerCase(StoreText),LowerCase(edtRemQSO.text))=0) then
   begin
     if edtRemQSO.Text <> ''  then
       edtRemQSO.Text := edtRemQSO.Text + ' ' + StoreText

--- a/src/fRebuildMembStat.pas
+++ b/src/fRebuildMembStat.pas
@@ -117,7 +117,7 @@ procedure TfrmRebuildMembStat.btnStartClick(Sender: TObject);
     dmData.Q.SQL.Text := 'update cqrlog_main set club_nr'+nr+' = '+QuotedStr('');
     dmData.Q.ExecSQL;
     dmData.Q.SQL.Clear;
-    dmData.Q.SQL.Add('update cqrlog_main q left join club'+nr+' c on q.'+Club.MainFieled+
+    dmData.Q.SQL.Add('update cqrlog_main q inner join club'+nr+' c on q.'+Club.MainFieled+
                      '= c.'+Club.ClubField);
     dmData.Q.SQL.Add(' and c.fromdate <= q.qsodate and c.todate >= q.qsodate');
     dmData.Q.SQL.Add('set q.club_nr'+nr+' = c.club_nr');
@@ -128,7 +128,7 @@ procedure TfrmRebuildMembStat.btnStartClick(Sender: TObject);
     dmData.Q.SQL.Clear;
     if (Club.StoreField <> '') and (Club.StoreText <> '') then
     begin
-      dmData.Q.SQL.Add('update cqrlog_main q left join club'+nr+' c on q.'+Club.MainFieled+
+      dmData.Q.SQL.Add('update cqrlog_main q inner join club'+nr+' c on q.'+Club.MainFieled+
                        '= c.'+Club.ClubField);
       dmData.Q.SQL.Add(' and c.fromdate <= q.qsodate and c.todate >= q.qsodate');
       dmData.Q.SQL.Add(' set '+Club.StoreField+'='+StoreText(Club));

--- a/src/uVersion.pas
+++ b/src/uVersion.pas
@@ -9,7 +9,7 @@ const
   cMINOR      = 4;
   cRELEAS     = 0;
   cBUILD      = 1;
-  cBUILD_DATE = '2019-11-09';
+  cBUILD_DATE = '2019-10-23';
 
 implementation
 


### PR DESCRIPTION
1) fixed a bug in Club marking fied selection that I myself had done when trying to make "comment for qso" look similar in all places. At membership settings it must be named by the DB column name "remarks" (that may confuse user) so returned it to that.

2)QSO list/Statistics/Membership tracking/Rebuild membership statistices is fixed. It did set all empty marking fieds filled with club (first club's if several) mark. Now sets just ones that really are club members.

Thanks to Andreas, DL7OAP, who saved lot of my time suggesting fix. Otherwise I should have learned myself (better) for sql join to find out what is the root cause.

Squashed commit of the following:

commit e3d93ae52ec9b1444e1dac47eef61b1810c2d1dc
Author: OH1KH <oh1kh@sral.fi>
Date:   Fri Oct 23 10:11:01 2020 +0300

    Version date change

commit c8569e4051faaf0f53847913cc3b2bbfdbbe61b5
Author: OH1KH <oh1kh@sral.fi>
Date:   Thu Oct 22 17:55:34 2020 +0300

    Changed left join to inner join to get proper results

commit b52c5ef945d2ada6032b5e42e4a93b374e5041fd
Author: OH1KH <oh1kh@sral.fi>
Date:   Wed Oct 21 18:52:44 2020 +0300

    Fix for Club membership recreation

    Club settings selector (where to place membership marking) had "comm. for qso"

    I have messed it up a long ago when I changed terms "remarks" to "comment to qso" in several places to make similar outlook everywhere.
    I did not know that this selector in club settings must have same name as cqrlog_main database field "remarks" that shows up at NewQSO with label "Comment for qso" (which is confusing)

    Fixed.
 

    That fix still leaves recreation to fail (every qso is marked as club qso). So there is another bug also.