### PR TITLE
Added help shorcut key Ctrl+H to 'QSO list'

### DIFF
--- a/help/h20.html
+++ b/help/h20.html
@@ -49,12 +49,8 @@
         <td width="35%">F11</td>
         <td width="65%">QRZ/HamQTH Callbook (call in the field)</td>
     </tr>
-    </tr>
+    <tr>
      <td> </td>
-    <tr>
-    <tr>
-        <td width="35%">Ctrl-1 ... Ctrl-9</td>
-        <td width="65%">Set split on trx with 1 ... 9 kHz via VFO A and VFO B</td>
     </tr>
     <tr>
         <td width="35%">Ctrl-A</td>
@@ -66,7 +62,7 @@
     </tr>
     <tr>
         <td width="35%">Ctrl-H</td>
-        <td width="65%">Open help</td>
+        <td width="65%">Show help</td>
     </tr>
     <tr>
         <td width="35%">Ctrl-I</td>
@@ -120,17 +116,13 @@
         <td width="35%">Ctrl-Z</td>
         <td width="65%">Scroll back DXCluster commands (5 stored)</td>
     </tr>
-    </tr>
-     <td> </td>
     <tr>
+     <td> </td>
+    </tr>
     <tr>
         <td width="35%">ALT-F2</td>
         <td width="65%">execute New QSO</td>
     </tr>
-     <td> </td>
-    <tr>
-    </tr>
-
     <tr>
         <td width="35%">ALT-B</td>
         <td width="65%"><a href="h30.html#m3">Memory down</a></td>
@@ -235,6 +227,10 @@
     <tr>
         <td width="35%">Ctrl-F</td>
         <td width="65%">Search</td>
+    </tr>
+    <tr>
+        <td width="35%">Ctrl-H</td>
+        <td width="65%">Show help</td>
     </tr>
     <tr>
         <td width="35%">Ctrl-P</td>

--- a/src/fMain.lfm
+++ b/src/fMain.lfm
@@ -1667,7 +1667,7 @@ object frmMain: TfrmMain
       Caption = 'Help'
       RightJustify = True
       object mnuHelpIndex: TMenuItem
-        Caption = 'Help index'
+        Caption = 'Help index Alt+H'
         Bitmap.Data = {
           36040000424D3604000000000000360000002800000010000000100000000100
           2000000000000004000064000000640000000000000000000000560151001806

--- a/src/fMain.pas
+++ b/src/fMain.pas
@@ -812,7 +812,12 @@ begin
   begin
     mnuDoNotSendClick(nil);
     key := 0
-  end
+  end;
+   if ((Shift = [ssCtrl]) and (key = VK_H)) then
+  begin
+    ShowHelp;
+    key := 0
+  end;
 end;
 
 procedure TfrmMain.mnuOQRSClick(Sender : TObject);


### PR DESCRIPTION
Added Ctrl+H for Help in "Qso list". Now it has similar action as in New QSO.
Also Alt+H works for help in  both.

"QSO list" F1 key may now be used for other purposes than help (code exists still there at the moment)

Fixed shortcut keys help.
Removed line "Ctrl-1 ... Ctrl-9  Set split on trx ..." as the split code  is commented out from source and does not work at he moment.