### PR TITLE
Fix cabrillo export

### DIFF
--- a/src/dDXCC.pas
+++ b/src/dDXCC.pas
@@ -113,6 +113,7 @@ type
     function  IsAmbiguous(call : String) : Boolean;
     function  IsPrefix(pref : String; Date : TDateTime) : Boolean;
     function  GetCont(call : String; Date : TDateTime) : String;
+    function  GetCountry(callsign : String; QsoDate : TDateTime) : String;
     function  id_country(znacka: string; us_state : String; datum : TDateTime; var pfx, cont, country, WAZ,
                            posun, ITU, lat, long: string) : Word; overload;
     function  id_country(znacka: string;datum : TDateTime; var pfx, cont, country, WAZ,
@@ -653,6 +654,14 @@ var
 begin
   cont := '';WAZ := '';posun := '';ITU := '';lat := '';long := '';
   Result := id_country(znacka,datum,pfx,country,cont,itu,waz,posun,lat,long)
+end;
+
+function TdmDXCC.GetCountry(callsign : String; QsoDate : TDateTime) : String;
+var
+  cont, WAZ, posun, ITU, lat, long, pfx, country: string;
+begin
+  cont := '';WAZ := '';posun := '';ITU := '';lat := '';long := '';
+  Result := DXCCRefArray[id_country(callsign,qsodate,pfx,country,cont,itu,waz,posun,lat,long)].name
 end;
 
 function TdmDXCC.GetCont(call : String; Date : TDateTime) : String;

--- a/src/fCabrilloExport.pas
+++ b/src/fCabrilloExport.pas
@@ -383,7 +383,8 @@ var
   f,r        : TextFile;
   tmp        : String;
   mycall,call,
-  myloc, loc : String;
+  myloc, loc,
+  mycountry  : String;
   myname     : String;
   mailingaddress, zipcity : String;
   email      : String;
@@ -419,7 +420,7 @@ begin
   date := dmUtils.GetDateTime(0);
   mycall := cqrini.ReadString('Station','Call','');
   cont := '';WAZ := '';posun := '';ITU := '';lat := '';long := '';
-  adif := dmDXCC.id_country(mycall,date,pfx,cont,country,itu,waz,posun,lat,long);
+  mycountry := dmDXCC.GetCountry(mycall, date);
   myloc  := cqrini.ReadString('Station','LOC','');
   if length(myloc) = 4 then myloc := myloc +'ll';
   myname := cqrini.ReadString('Station','Name','');
@@ -666,16 +667,16 @@ begin
     Writeln(f,'GRID-LOCATOR: '+UPcase(myloc)); //non standard upcase required
     Writeln(f,'LOCATION: '+edtCabLocation.Text);
     Writeln(f,'CLAIMED-SCORE: ');
-    Writeln(f,'SPECIFIC: ');
+    // Writeln(f,'SPECIFIC: ');   // Unknown Cabrillo Tag (DF2ET 26.10.2020)
     Writeln(f,'CLUB: '+club);
     if (Operators.Count > 0) then
        Writeln(f,'OPERATORS: '+OpString);
     Writeln(f,'NAME: '+myname);
     Writeln(f,'ADDRESS: '+mailingaddress);
     Writeln(f,'ADDRESS-CITY: '+address[1]);
-    Writeln(f,'ADDRESS-COUNTRY: '+country);
+    Writeln(f,'ADDRESS-COUNTRY: '+mycountry);
     Writeln(f,'ADDRESS-STATE-PROVINCE: ');
-    Writeln(f,'ADDRESS-POSTAL-CODE: '+address[0]);
+    Writeln(f,'ADDRESS-POSTALCODE: '+address[0]);
     Writeln(f,'EMAIL: '+email);
     Writeln(f,'SOAPBOX:'+edtCabSoapBox.Text);
 


### PR DESCRIPTION
After taking part in CQ WW I discovered that the cabrillo export had some issues. The field SPECIFIC does not exist.

![Bildschirmfoto vom 2020-10-26 13-36-14](https://user-images.githubusercontent.com/7112907/97182256-9c53b280-179c-11eb-9a00-dd6fcfea45da.png)

Also the field "country" is not filled correctly. It was always showing the country of the last logged station instead of the one of the operator.

And the "POSTALCODE" field had one hyphen too many.