### PR TITLE
Fixed My Loc setting with multiple QTH profiles

### DIFF
--- a/src/fNewQSO.pas
+++ b/src/fNewQSO.pas
@@ -750,7 +750,7 @@ type
 var
   frmNewQSO    : TfrmNewQSO;
 
-  EscFirstTime : Boolean = True;
+  EscFirstPressDone : Boolean = True;
   multicast    : boolean = false;
 
   c_callsign  : String;
@@ -1287,8 +1287,8 @@ begin
   else begin
     cmbProfiles.Text := dmData.GetProfileText(old_prof)
   end;
-  if cmbProfiles.Text <> '' then
-    cmbProfilesChange(nil);
+  //if cmbProfiles.Text <> '' then
+     cmbProfilesChange(nil);
 
   if sbNewQSO.Panels[0].Text = '' then
     sbNewQSO.Panels[0].Text := cMyLoc + cqrini.ReadString('Station','LOC','');
@@ -1744,7 +1744,7 @@ begin
   old_cfreq := '';
 
   Running      := False;
-  EscFirstTime := False;
+  EscFirstPressDone := False;
   ChangeDXCC   := False;
 
   ClearAll;
@@ -5133,7 +5133,10 @@ procedure TfrmNewQSO.cmbProfilesChange(Sender: TObject);
 var
   myloc : String;
 begin
-  myloc := dmData.GetMyLocFromProfile(cmbProfiles.Text);
+  if cmbProfiles.Text = '' then
+   myloc :=  cqrini.ReadString('Station','LOC','')
+  else
+   myloc := dmData.GetMyLocFromProfile(cmbProfiles.Text);
   if myloc <> '' then
      sbNewQSO.Panels[0].Text := cMyLoc + myloc;
   if dmData.DebugLevel >=1 then Writeln(cmbProfiles.Text)
@@ -5401,7 +5404,7 @@ begin
   begin
     if not (fViewQSO or fEditQSO) then
     begin
-      if EscFirstTime then
+      if EscFirstPressDone then
       begin
         //SaveGrid;
         if edtCall.Text = '' then
@@ -5411,14 +5414,14 @@ begin
         end
         else
          edtCall.Text := ''; // OnChange calls ClearAll;
-        EscFirstTime := False;
+        EscFirstPressDone := False;
         old_ccall := '';
         old_cfreq := '';
         old_cmode := '';
       end
       else begin
         if Assigned(CWint) then CWint.StopSending;
-        EscFirstTime   := True;
+        EscFirstPressDone   := True;
         tmrESC.Enabled := True
       end
     end
@@ -5451,7 +5454,7 @@ begin
     end
   end
   else
-    EscFirstTime := False;
+    EscFirstPressDone := False;
 
   if (Key >= VK_F1) and (Key <= VK_F10) and (Shift = []) then
   Begin
@@ -5848,7 +5851,7 @@ end;
 
 procedure TfrmNewQSO.tmrESCTimer(Sender: TObject);
 begin
-  EscFirstTime   := False;
+  EscFirstPressDone   := False;
   tmrESC.Enabled := False
 end;
 
@@ -6247,7 +6250,7 @@ begin
   tmrStart.Enabled := False;
 
   Running      := False;
-  EscFirstTime := False;
+  EscFirstPressDone := False;
   ChangeDXCC   := False;
   dmData.InsertProfiles(cmbProfiles,true);
   


### PR DESCRIPTION
If you have master log without QTH profiles and you ADIF import portable logs that have one or several QTH profiles defined those profiles are added to master log during import.
Then if you view or edit imported qso that has profile set with different locator than master locator that is changed to NewQSO (bottom left) and when you close view or edit that locator remains, although QTH profile selector becomes empty.

There is no other way than feed the master locator again with Ctrl+L or restart cqrlog.

This fix sets locator from proferences/Station if NewQSO/QTH profile selector is selected as  empty, or cleared by return from View or edit.