### PR TITLE
QTH profiles editor fix

### DIFF
--- a/src/fQTHProfiles.lfm
+++ b/src/fQTHProfiles.lfm
@@ -144,7 +144,7 @@ object frmQTHProfiles: TfrmQTHProfiles
     Align = alClient
     Color = clWindow
     Columns = <>
-    Options = [dgTitles, dgIndicator, dgColumnResize, dgColumnMove, dgColLines, dgRowLines, dgTabs, dgRowSelect, dgAlwaysShowSelection, dgConfirmDelete, dgCancelOnExit]
+    Options = [dgTitles, dgIndicator, dgColumnResize, dgColumnMove, dgColLines, dgRowLines, dgTabs, dgRowSelect, dgAlwaysShowSelection, dgConfirmDelete, dgCancelOnExit, dgAutoSizeColumns]
     TabOrder = 1
     TitleStyle = tsNative
     OnCellClick = dbgrdProfilesCellClick

--- a/src/fQTHProfiles.pas
+++ b/src/fQTHProfiles.pas
@@ -75,6 +75,7 @@ begin
 
   dbgrdProfiles.Columns[0].Visible := False;
   //dbgrdProfiles.Columns[6].Visible := False
+  btnEdit.Enabled:=(dmData.qProfiles.RecordCount <> 0);
 end;
 
 procedure TfrmQTHProfiles.LocateProfile(profile : String);


### PR DESCRIPTION
Button 'Edit' not enabled if profile count is zero. If it is used when count is zero edited profile save causes either SQL error or is just not saved anywhere.

QTH profile gird has now autosize columns for easier read.