### PR TITLE
Fix 1xESC keys

### DIFF
--- a/src/cqrlog.lpi
+++ b/src/cqrlog.lpi
@@ -105,7 +105,7 @@
         <MinVersion Major="1" Minor="2" Release="1" Valid="True"/>
       </Item10>
     </RequiredPackages>
-    <Units Count="117">
+    <Units Count="118">
       <Unit0>
         <Filename Value="cqrlog.lpr"/>
         <IsPartOfProject Value="True"/>
@@ -869,6 +869,13 @@
         <HasResources Value="True"/>
         <ResourceBaseClass Value="Form"/>
       </Unit116>
+      <Unit117>
+        <Filename Value="fRemind.pas"/>
+        <IsPartOfProject Value="True"/>
+        <ComponentName Value="frmReminder"/>
+        <HasResources Value="True"/>
+        <ResourceBaseClass Value="Form"/>
+      </Unit117>
     </Units>
   </ProjectOptions>
   <CompilerOptions>

--- a/src/fCWKeys.pas
+++ b/src/fCWKeys.pas
@@ -59,6 +59,12 @@ procedure TfrmCWKeys.FormKeyUp(Sender : TObject; var Key : Word;
 begin
   if (Key >= VK_F1) and (Key <= VK_F10) and (Shift = []) then
                       frmNewQSO.FormKeyUp(Sender,Key,Shift);
+
+  if (key= VK_ESCAPE) then
+  begin
+    frmNewQSO.ReturnToNewQSO;
+    key := 0
+  end
 end;
 
 procedure TfrmCWKeys.FormShow(Sender: TObject);

--- a/src/fMain.lfm
+++ b/src/fMain.lfm
@@ -158,6 +158,7 @@ object frmMain: TfrmMain
   OnCloseQuery = FormCloseQuery
   OnCreate = FormCreate
   OnKeyDown = FormKeyDown
+  OnKeyUp = FormKeyUp
   OnShow = FormShow
   LCLVersion = '1.8.2.0'
   object sbMain: TStatusBar

--- a/src/fMain.pas
+++ b/src/fMain.pas
@@ -389,6 +389,7 @@ type
     procedure acWASCfmExecute(Sender: TObject);
     procedure acDOKCfmExecute(Sender: TObject);
     procedure acWAZCfmExecute(Sender: TObject);
+    procedure FormKeyUp(Sender: TObject; var Key: Word; Shift: TShiftState);
     procedure mnueQSLViewClick(Sender: TObject);
     procedure mnuIK3AQRClick(Sender: TObject);
     procedure mnuHelpIndexClick(Sender: TObject);
@@ -1225,6 +1226,16 @@ begin
     ShowModal
   finally
     Free
+  end
+end;
+
+procedure TfrmMain.FormKeyUp(Sender: TObject; var Key: Word;
+  Shift: TShiftState);
+begin
+  if (key= VK_ESCAPE) then
+  begin
+    frmNewQSO.ReturnToNewQSO;
+    key := 0
   end
 end;
 

--- a/src/fNewQSO.pas
+++ b/src/fNewQSO.pas
@@ -7157,8 +7157,11 @@ end;
 
 procedure TfrmNewQSO.ReturnToNewQSO;
 begin
-  if edtCall.Enabled then
-    edtCall.SetFocus
+  if frmContest.Showing then
+      frmContest.edtCall.SetFocus
+    else
+      if edtCall.Enabled then
+         edtCall.SetFocus
 end;
 
 procedure TfrmNewQSO.RefreshInfoLabels;

--- a/src/fRemind.lfm
+++ b/src/fRemind.lfm
@@ -8,6 +8,7 @@ object frmReminder: TfrmReminder
   ClientHeight = 128
   ClientWidth = 599
   OnClose = FormClose
+  OnKeyUp = FormKeyUp
   OnShow = FormShow
   Position = poScreenCenter
   LCLVersion = '1.6.0.4'
@@ -24,6 +25,7 @@ object frmReminder: TfrmReminder
     BorderSpacing.Bottom = 4
     MaxLength = 255
     OnKeyPress = RemiMemoLimit
+    OnKeyUp = FormKeyUp
     TabOrder = 0
   end
   object chRemi: TCheckBox

--- a/src/fRemind.pas
+++ b/src/fRemind.pas
@@ -6,7 +6,7 @@ interface
 
 uses
   Classes, SysUtils, FileUtil, LResources, Forms, Controls, Graphics, Dialogs,
-  ExtCtrls, StdCtrls, maskedit;
+  ExtCtrls, StdCtrls, maskedit, LCLtype;
 
 type
 
@@ -23,6 +23,7 @@ type
     RemindTimeSet: TMaskEdit;
     RemiMemo: TMemo;
     tmrRemi: TTimer;
+    procedure FormKeyUp(Sender: TObject; var Key: Word; Shift: TShiftState);
     procedure FormShow(Sender: TObject);
     procedure RemiMemoLimit(Sender: TObject; var Key: Char);
     procedure btCloseClick(Sender: TObject);
@@ -51,7 +52,7 @@ implementation
 
 { TfrmReminder }
 
-uses dData,dUtils,uMyini;
+uses dData,dUtils,uMyini,fNewQSO;
 
 Procedure TfrmReminder.OpenReminder;
 
@@ -84,6 +85,17 @@ end;
 procedure TfrmReminder.FormShow(Sender: TObject);
 begin
   //dmUtils.LoadWindowPos(frmReminder);    // this breaks big fonts and positions used in this form !!!!
+end;
+
+procedure TfrmReminder.FormKeyUp(Sender : TObject; var Key : Word;
+  Shift : TShiftState);
+begin
+  if (key= VK_ESCAPE) then
+  begin
+    btCloseClick(nil);
+    frmNewQSO.ReturnToNewQSO;
+    key := 0
+  end
 end;
 
 

--- a/src/fWorkedGrids.lfm
+++ b/src/fWorkedGrids.lfm
@@ -8,8 +8,10 @@ object frmWorkedGrids: TfrmWorkedGrids
   Caption = 'Worked locator grids'
   ClientHeight = 432
   ClientWidth = 721
+  OnActivate = FormActivate
   OnClose = FormClose
   OnCreate = FormCreate
+  OnKeyUp = FormKeyUp
   OnShow = FormShow
   Position = poDefault
   LCLVersion = '2.0.0.4'
@@ -43,6 +45,7 @@ object frmWorkedGrids: TfrmWorkedGrids
       '2M'
     )
     OnChange = BandSelectorChange
+    OnKeyUp = FormKeyUp
     Style = csDropDownList
     TabOrder = 0
   end

--- a/src/fWorkedGrids.pas
+++ b/src/fWorkedGrids.pas
@@ -6,7 +6,7 @@ interface
 
 uses
   Classes, SysUtils, FileUtil,
-  Forms, Controls, Graphics, Dialogs, ExtCtrls, StdCtrls, LResources, IniFiles;
+  Forms, Controls, Graphics, Dialogs, ExtCtrls, StdCtrls, LResources, IniFiles, LCLType;
 
 type
 
@@ -29,6 +29,8 @@ type
     BandLabel: TLabel;
     ZooMap: TImage;
     procedure BandSelectorChange(Sender: TObject);
+    procedure FormActivate(Sender: TObject);
+    procedure FormKeyUp(Sender: TObject; var Key: Word; Shift: TShiftState);
     procedure FormShow(Sender: TObject);
     procedure LocMapChangeBounds(Sender: TObject);
     procedure LocMapClick(Sender: TObject);
@@ -680,6 +682,23 @@ procedure TfrmWorkedGrids.BandSelectorChange(Sender: TObject);
 Begin
     UpdateGridData;
 end;
+
+procedure TfrmWorkedGrids.FormActivate(Sender: TObject);
+begin
+  BandSelector.SetFocus;
+end;
+//FormKeyUp does not work unless focus is set to some of selectors (BandSelector)
+//and there BandSelector.OnKeyUp can access FromKeyUp procedure
+procedure TfrmWorkedGrids.FormKeyUp(Sender: TObject; var Key: Word;
+  Shift: TShiftState);
+begin
+  if (key= VK_ESCAPE) then
+  begin
+    frmNewQSO.ReturnToNewQSO;
+    key := 0
+  end
+end;
+
 procedure TfrmWorkedGrids.UpdateGridData;
 begin
     if not ZooMap.Visible then DrawFullMap else DrawSubMap;


### PR DESCRIPTION
Several forms fixed so that if active 1xESC will return focus to NewQSO/edtCall.
This has been default action as most of forms already act this way.

In addition return to NewQSO/edtCall is fixed so that if Contest form is active return to Contest/edtCall is made instead.

Form fRemind was not part of project. Added to project.