### PR TITLE
Fix to modes bandwidth

### DIFF
--- a/src/fPreferences.lfm
+++ b/src/fPreferences.lfm
@@ -3557,6 +3557,7 @@ object frmPreferences: TfrmPreferences
           Width = 81
           Increment = 50
           MaxValue = 3000
+          MinValue = -1
           TabOrder = 0
           Value = 500
         end
@@ -3583,6 +3584,7 @@ object frmPreferences: TfrmPreferences
           Width = 81
           Increment = 50
           MaxValue = 3000
+          MinValue = -1
           TabOrder = 1
           Value = 1800
         end
@@ -3609,6 +3611,7 @@ object frmPreferences: TfrmPreferences
           Width = 81
           Increment = 50
           MaxValue = 3000
+          MinValue = -1
           TabOrder = 2
           Value = 500
         end
@@ -3635,6 +3638,7 @@ object frmPreferences: TfrmPreferences
           Width = 81
           Increment = 100
           MaxValue = 6000
+          MinValue = -1
           TabOrder = 3
           Value = 3000
         end
@@ -3661,6 +3665,7 @@ object frmPreferences: TfrmPreferences
           Width = 81
           Increment = 100
           MaxValue = 6000
+          MinValue = -1
           TabOrder = 4
           Value = 2500
         end
@@ -3713,6 +3718,7 @@ object frmPreferences: TfrmPreferences
           Width = 81
           Increment = 50
           MaxValue = 3000
+          MinValue = -1
           TabOrder = 0
           Value = 500
         end
@@ -3739,6 +3745,7 @@ object frmPreferences: TfrmPreferences
           Width = 81
           Increment = 50
           MaxValue = 3000
+          MinValue = -1
           TabOrder = 1
           Value = 1800
         end
@@ -3765,6 +3772,7 @@ object frmPreferences: TfrmPreferences
           Width = 81
           Increment = 50
           MaxValue = 3000
+          MinValue = -1
           TabOrder = 2
           Value = 500
         end
@@ -3791,6 +3799,7 @@ object frmPreferences: TfrmPreferences
           Width = 81
           Increment = 100
           MaxValue = 6000
+          MinValue = -1
           TabOrder = 3
           Value = 3000
         end
@@ -3817,6 +3826,7 @@ object frmPreferences: TfrmPreferences
           Width = 81
           Increment = 100
           MaxValue = 6000
+          MinValue = -1
           TabOrder = 4
           Value = 2500
         end


### PR DESCRIPTION
Rigctld has mode setting option "0" that means use default bandwidth.( M USB 0 )
That is mentioned in man pages.
What is not in man pages (until now) is that option "-1" is accepted too without errors. It means "No change". (WSJT-X program uses that, so it can be there for all rigs)

Not all rigs support this, but as some do it must be possible to enter also "-1" to preferences/modes/bandwidths
Fixed MinValue of bandwidth edits to -1