### PR TITLE
Bugfixes to Grayline and Grid map

### DIFF
--- a/src/fGrayline.pas
+++ b/src/fGrayline.pas
@@ -417,13 +417,9 @@ end;
 
 procedure TfrmGrayline.FormClose(Sender: TObject; var CloseAction: TCloseAction);
 begin
-  if RBNThread<>nil then
-   Begin
-    RBNThread.lTelnet.Disconnect(true);
-    RBNThread.Terminate;
-   end;
+  if RBNThread<>nil then RBNThread.Terminate;
   cqrini.WriteBool('Grayline','Statusbar',sbGrayLine.Visible);
-  dmUtils.SaveWindowPos(frmGrayline);
+  dmUtils.SaveWindowPos(frmGrayline)
 end;
 
 procedure TfrmGrayline.acShowStatusBarExecute(Sender : TObject);
@@ -453,7 +449,6 @@ begin
       pumLinkToRBNMonitor.Enabled:=true;
     end
     else begin
-      pumLinkToRBNMonitor.Enabled:=false;
       acLinkToRbnMonitor.Checked :=false;
       RBNThread := TRBNThread.Create(True);
       RBNThread.FreeOnTerminate := True;
@@ -465,6 +460,7 @@ end;
 procedure TfrmGrayline.acLinkToRbnMonitorExecute(Sender: TObject);
 begin
     acLinkToRbnMonitor.Checked := not acLinkToRbnMonitor.Checked;
+    cqrini.WriteBool('RBN','AutoLink',acLinkToRbnMonitor.Checked);
     pumConnect.Enabled:=not acLinkToRbnMonitor.Checked;
     if acLinkToRbnMonitor.Checked then
      rbn_status := 'Linked to RBNMonitor'
@@ -478,7 +474,7 @@ begin
   tmrGrayLine.Enabled := False;
   tmrAutoConnect.Enabled:=False;
   tmrRemoveDots.Enabled:=False;
-  SavePosition;
+  sleep(100)
 end;
 
 procedure TfrmGrayline.FormDestroy(Sender: TObject);
@@ -612,9 +608,15 @@ var
 begin
   sbGrayLine.SimpleText := rbn_status;
   if rbn_status='Connected' then
-    acConnect.Caption := 'Disconnect'
+   Begin
+    acConnect.Caption := 'Disconnect';
+    pumLinkToRBNMonitor.Enabled:=false;
+   end
   else
-    acConnect.Caption := 'Connect to RBN';
+   Begin
+     acConnect.Caption := 'Connect to RBN';
+     pumLinkToRBNMonitor.Enabled:=True;
+   end;
   ob^.body_smaz;
   for i:=1 to MAX_ITEMS do
   begin

--- a/src/fWorkedGrids.lfm
+++ b/src/fWorkedGrids.lfm
@@ -8,7 +8,6 @@ object frmWorkedGrids: TfrmWorkedGrids
   Caption = 'Worked locator grids'
   ClientHeight = 432
   ClientWidth = 721
-  OnActivate = FormActivate
   OnClose = FormClose
   OnCreate = FormCreate
   OnKeyUp = FormKeyUp

--- a/src/fWorkedGrids.pas
+++ b/src/fWorkedGrids.pas
@@ -29,7 +29,6 @@ type
     BandLabel: TLabel;
     ZooMap: TImage;
     procedure BandSelectorChange(Sender: TObject);
-    procedure FormActivate(Sender: TObject);
     procedure FormKeyUp(Sender: TObject; var Key: Word; Shift: TShiftState);
     procedure FormShow(Sender: TObject);
     procedure LocMapChangeBounds(Sender: TObject);
@@ -676,19 +675,11 @@ begin
   if (BandSelector.ItemIndex >= 0) then UpdateGridData;
 end;
 
-
-
 procedure TfrmWorkedGrids.BandSelectorChange(Sender: TObject);
 Begin
     UpdateGridData;
 end;
 
-procedure TfrmWorkedGrids.FormActivate(Sender: TObject);
-begin
-  BandSelector.SetFocus;
-end;
-//FormKeyUp does not work unless focus is set to some of selectors (BandSelector)
-//and there BandSelector.OnKeyUp can access FromKeyUp procedure
 procedure TfrmWorkedGrids.FormKeyUp(Sender: TObject; var Key: Word;
   Shift: TShiftState);
 begin


### PR DESCRIPTION
Grayline:
	popup menu "Link" were not enabled properly in all cases.
	Uncheck popup menu "Link" was not possible if proferences had this property checked
Grid map:
	Focusing bandselector at startup caused looping at certain cases. Return to newQSO with ESC seems to work now without it.