### PR TITLE
Ultra small fix to NewQSO

### DIFF
--- a/src/fNewQSO.pas
+++ b/src/fNewQSO.pas
@@ -1812,8 +1812,8 @@ begin
     edtEndTime.Text   := FormatDateTime('hh:mm',date);
     Takes := StartTime - Date;
     DecodeTime(Takes,h,m,s,ms);
-    lblQSOTakes.Caption := 'QSO takes ' + IntToStr(h) + ' hours, ' + IntToStr(m) +
-                           ' minutes, ' + IntToStr(s) + ' seconds'
+    lblQSOTakes.Caption := 'QSO takes ' + IntToStr(h) + ' hr, ' + IntToStr(m) +
+                           ' min, ' + IntToStr(s) + ' sec'
   end
 end;
 


### PR DESCRIPTION
Just had longer CW qso and noticed that "QSO takes" line rolls under Comment to callsign edit field when minutes and seconds have two digits.

Using just hr, min and sec will make the string short enough without loosing information.