### PR TITLE
Fix wsjtx timer parameters

### DIFF
--- a/src/fMonWsjtx.pas
+++ b/src/fMonWsjtx.pas
@@ -848,10 +848,10 @@ var
     tmr: integer;
 begin
   tmrCqPeriod.Enabled := False;
-  tmr := 60000;
+  tmr := 40000;   // tmr about 2/3 of period time
   case CurMode of
-       'FT8': tmr := 15000;
-       'FT4': tmr := 8000;
+       'FT8': tmr := 10000;
+       'FT4': tmr := 5000;
   end;
   tmrCqPeriod.Interval := tmr;
   if LocalDbg then Writeln('Period timer set to: ',tmr);

--- a/src/uVersion.pas
+++ b/src/uVersion.pas
@@ -9,7 +9,7 @@ const
   cMINOR      = 4;
   cRELEAS     = 0;
   cBUILD      = 1;
-  cBUILD_DATE = '2020-11-24';
+  cBUILD_DATE = '2020-12-08';
 
 implementation
 


### PR DESCRIPTION
Change to wsjtx remote parameters. This seems to be better.