### PR TITLE
Callbook database update fix

### DIFF
--- a/src/fMain.pas
+++ b/src/fMain.pas
@@ -953,6 +953,9 @@ begin
     'Question ...', mb_YesNo + mb_IconQuestion) = idNo then
     exit;
   lastid := cqrini.ReadInteger('CallBook', 'LastId', -1);
+
+  //lastid:=9999999; //for testing
+
   if lastid > -1 then
   begin
     if Application.MessageBox(
@@ -962,7 +965,10 @@ begin
     cqrini.WriteInteger('CallBook', 'LastId', -1)
   end
   else
+   Begin
+    dmData.qCQRLOG.First; //without this only the last qso of filtered selection is updated
     lastid := dmData.qCQRLOG.FieldByName('id_cqrlog_main').AsInteger;
+   end;
 
   if Application.MessageBox('Update names from previous QSOs?','Question ...',mb_YesNo + mb_IconQuestion) = idYes then
     prenames := True;


### PR DESCRIPTION
Some users report that execution stops when running it. I have found same, but randomly. It may crash whole Xwindow system and it needs to be killed via terminal (Ctrl+Alt+F2) login.

Things that I have found out and can be repeated happens like this:

Take a test log.
Make filter that select few qsos
Use group edit to drop all names from them (to see better what database update does)
Go to Callbook/Database update and let it run.

  1) It always updates only the last qso from selected qsos, nothing else.
  2) If Database update has been cancelled at last time it stores the last id.
     How ever if qso selection of current filter does not contain that qso id
     update gets lost and window does not close from "Cancel" button.

These are now tried fix, but storing the cancelled updates last id is not good idea because of filter selection for next databaseupdate may not contain that qso, or it may even be deleted from log between database updates.

Squashed commit of the following:

commit b36e78c662eac58623329570a70536850ee8f10b
Author: OH1KH <oh1kh@sral.fi>
Date:   Thu Dec 10 11:29:14 2020 +0200

    breakpoint out of selection fix

commit 7bae646fcdec44af8c84368b95863e93afe93318
Author: OH1KH <oh1kh@sral.fi>
Date:   Thu Dec 10 07:20:42 2020 +0200

    callbook update to filtered selection fix