### PR TITLE
Retain prop mode after saving (SAT) QSOs

### DIFF
--- a/src/fNewQSO.pas
+++ b/src/fNewQSO.pas
@@ -3426,7 +3426,7 @@ begin
   dmData.qQSOBefore.Close;
   fEditQSO := False;
   was_call := edtCall.Text;
-  edtCall.Text := ''; //calls Clear.All
+  edtCall.Text := ''; //calls ClearAll
   old_ccall := '';
   old_cfreq := '';
   old_cmode := '';
@@ -4764,8 +4764,6 @@ begin
     tabSatellite.Font.Color := clRed
   else
     tabSatellite.Font.Color := clDefault;
-
-  old_prop   := dmSatellite.GetPropShortName(cmbPropagation.Text); //old_prop is now selected value
 end;
 
 procedure TfrmNewQSO.cmbQSL_REnter(Sender: TObject);


### PR DESCRIPTION
Prop mode gets cleared after logging a (SAT) QSO. For some unknown reason the last prop mode is unset while saving. 
This patch circumvents this problem. I think it is useful to retain the prop mode until it is manually set to something else.
