### PR TITLE
Prevent execution of critical operations my pressing Esc

### DIFF
--- a/src/fDBConnect.pas
+++ b/src/fDBConnect.pas
@@ -261,12 +261,12 @@ begin
     exit;
   end;
 
-  if Application.MessageBox('Do you really want to delete this log?','Question ...', mb_YesNo + mb_IconQuestion) in [idNo, idCancel] then
+  if Application.MessageBox('Do you really want to delete this log?','Question ...', mb_YesNo + mb_IconQuestion + mb_DefButton2) in [idNo, idCancel] then
   begin
     exit;
   end;
 
-  if Application.MessageBox('LOG WILL BE _DELETED_. Are you sure?','Question ...', mb_YesNo + mb_IconQuestion) in [idNo, idCancel] then
+  if Application.MessageBox('LOG WILL BE _DELETED_. Are you sure?','Question ...', mb_YesNo + mb_IconQuestion + mb_DefButton2) in [idNo, idCancel] then
   begin
     exit;
   end;
@@ -446,7 +446,7 @@ var
 begin
   s := 'YOUR ENTIRE LOG WILL BE DELETED!'+LineEnding+LineEnding+
        'Do you want to CANCEL this operation?';
-  if Application.MessageBox(s,'Question ...', mb_YesNo + mb_IconQuestion) in [idNo, idCancel] then
+  if Application.MessageBox(s,'Question ...', mb_YesNo + mb_IconQuestion + mb_DefButton1) in [idNo, idCancel] then
   begin
     dmData.TruncateTables(dmData.qLogList.Fields[0].AsInteger);
     ShowMessage('Log is empty')

--- a/src/fDBConnect.pas
+++ b/src/fDBConnect.pas
@@ -261,12 +261,12 @@ begin
     exit;
   end;
 
-  if Application.MessageBox('Do you really want to delete this log?','Question ...', mb_YesNo + mb_IconQuestion) = idNo then
+  if Application.MessageBox('Do you really want to delete this log?','Question ...', mb_YesNo + mb_IconQuestion) in [idNo, idCancel] then
   begin
     exit;
   end;
 
-  if Application.MessageBox('LOG WILL BE _DELETED_. Are you sure?','Question ...', mb_YesNo + mb_IconQuestion) = idNo then
+  if Application.MessageBox('LOG WILL BE _DELETED_. Are you sure?','Question ...', mb_YesNo + mb_IconQuestion) in [idNo, idCancel] then
   begin
     exit;
   end;
@@ -446,7 +446,7 @@ var
 begin
   s := 'YOUR ENTIRE LOG WILL BE DELETED!'+LineEnding+LineEnding+
        'Do you want to CANCEL this operation?';
-  if Application.MessageBox(s,'Question ...', mb_YesNo + mb_IconQuestion) = idNo then
+  if Application.MessageBox(s,'Question ...', mb_YesNo + mb_IconQuestion) in [idNo, idCancel] then
   begin
     dmData.TruncateTables(dmData.qLogList.Fields[0].AsInteger);
     ShowMessage('Log is empty')

--- a/src/fDXClusterList.pas
+++ b/src/fDXClusterList.pas
@@ -88,7 +88,7 @@ var
   id : Integer;
 begin
   if Application.MessageBox('Do you really want to delete this dxcluster?',
-                            'Question ...', MB_ICONQUESTION + MB_YESNO) in [idNo, idCancel] then
+                            'Question ...', MB_ICONQUESTION + MB_YESNO + MB_DEFBUTTON2) in [idNo, idCancel] then
     exit;
 
   id := dmData.qDXClusters.FieldByName('id_dxclusters').AsInteger;

--- a/src/fDXClusterList.pas
+++ b/src/fDXClusterList.pas
@@ -88,7 +88,7 @@ var
   id : Integer;
 begin
   if Application.MessageBox('Do you really want to delete this dxcluster?',
-                            'Question ...', MB_ICONQUESTION + MB_YESNO) = idNo then
+                            'Question ...', MB_ICONQUESTION + MB_YESNO) in [idNo, idCancel] then
     exit;
 
   id := dmData.qDXClusters.FieldByName('id_dxclusters').AsInteger;

--- a/src/fGroupEdit.pas
+++ b/src/fGroupEdit.pas
@@ -273,14 +273,14 @@ begin
            sql := 'rst_r='+QuotedStr(cmbValue.Text)
          end;
      8 : begin
-           if (cmbValue.Text='') and (Application.MessageBox('Dou you really want to clear name field?',
-              'Question ...',mb_YesNo+mb_IconQuestion) in [idNo, idCancel]) then
+           if (cmbValue.Text='') and (Application.MessageBox('Do you really want to clear name field?',
+              'Question ...',mb_YesNo+mb_IconQuestion+mb_DefButton2) in [idNo, idCancel]) then
              exit;
            sql := 'name='+QuotedStr(cmbValue.Text)
          end;
      9 : begin
-           if (cmbValue.Text='') and (Application.MessageBox('Dou you really want to clear QTH field?',
-              'Question ...',mb_YesNo+mb_IconQuestion) in [idNo, idCancel]) then
+           if (cmbValue.Text='') and (Application.MessageBox('Do you really want to clear QTH field?',
+              'Question ...',mb_YesNo+mb_IconQuestion+mb_DefButton2) in [idNo, idCancel]) then
            begin
              cmbValue.SetFocus;
              exit
@@ -310,8 +310,8 @@ begin
            sql := 'waz='+cmbValue.Text
          end;
     13 : begin
-           if (cmbValue.Text='') and (Application.MessageBox('Dou you really want to clear County field?',
-              'Question ...',mb_YesNo+mb_IconQuestion) in [idNo, idCancel]) then
+           if (cmbValue.Text='') and (Application.MessageBox('Do you really want to clear County field?',
+              'Question ...',mb_YesNo+mb_IconQuestion+mb_DefButton2) in [idNo, idCancel]) then
            begin
              cmbValue.SetFocus;
              exit
@@ -319,8 +319,8 @@ begin
            sql := 'county='+QuotedStr(cmbValue.Text)
          end;
     14 : begin
-           if (cmbValue.Text='') and (Application.MessageBox('Dou you really want to clear State field?',
-              'Question ...',mb_YesNo+mb_IconQuestion) in [idNo, idCancel]) then
+           if (cmbValue.Text='') and (Application.MessageBox('Do you really want to clear State field?',
+              'Question ...',mb_YesNo+mb_IconQuestion+mb_DefButton2) in [idNo, idCancel]) then
            begin
              cmbValue.SetFocus;
              exit
@@ -329,8 +329,8 @@ begin
          end;
 
     15 : begin
-           if (cmbValue.Text='') and (Application.MessageBox('Dou you really want to clear Award field?',
-              'Question ...',mb_YesNo+mb_IconQuestion) in [idNo, idCancel]) then
+           if (cmbValue.Text='') and (Application.MessageBox('Do you really want to clear Award field?',
+              'Question ...',mb_YesNo+mb_IconQuestion+mb_DefButton2) in [idNo, idCancel]) then
            begin
              cmbValue.SetFocus;
              exit
@@ -347,8 +347,8 @@ begin
            sql := 'iota='+QuotedStr(UpperCase(cmbValue.Text))
          end;
     17 : begin
-           if (cmbValue.Text='') and (Application.MessageBox('Dou you really want to clear Comment to QSO field?',
-              'Question ...',mb_YesNo+mb_IconQuestion) in [idNo, idCancel]) then
+           if (cmbValue.Text='') and (Application.MessageBox('Do you really want to clear Comment to QSO field?',
+              'Question ...',mb_YesNo+mb_IconQuestion+mb_DefButton2) in [idNo, idCancel]) then
            begin
              cmbValue.SetFocus;
              exit
@@ -366,8 +366,8 @@ begin
               end
             end
            else begin
-             if (Application.MessageBox('Dou you really want to clear My locator field?',
-              'Question ...',mb_YesNo+mb_IconQuestion) in [idNo, idCancel]) then
+             if (Application.MessageBox('Do you really want to clear My locator field?',
+              'Question ...',mb_YesNo+mb_IconQuestion+mb_DefButton2) in [idNo, idCancel]) then
             begin
               cmbValue.SetFocus;
               exit
@@ -386,8 +386,8 @@ begin
             end
           end
           else begin
-            if (Application.MessageBox('Dou you really want to clear Locator field?',
-               'Question ...',mb_YesNo+mb_IconQuestion) in [idNo, idCancel]) then
+            if (Application.MessageBox('Do you really want to clear Locator field?',
+               'Question ...',mb_YesNo+mb_IconQuestion+mb_DefButton2) in [idNo, idCancel]) then
             begin
               cmbValue.SetFocus;
               exit
@@ -399,8 +399,8 @@ begin
           sql := 'profile=' + IntToStr(dmData.GetNRFromProfile(cmbValue.Text))
         end;
    21 : begin
-          if (cmbValue.Text='') and (Application.MessageBox('Dou you really want to clear QSL via field?',
-             'Question ...',mb_YesNo+mb_IconQuestion) in [idNo, idCancel]) then
+          if (cmbValue.Text='') and (Application.MessageBox('Do you really want to clear QSL via field?',
+             'Question ...',mb_YesNo+mb_IconQuestion+mb_DefButton2) in [idNo, idCancel]) then
           begin
             cmbValue.SetFocus;
             exit
@@ -408,8 +408,8 @@ begin
           sql := 'qsl_via='+QuotedStr(UpperCase(cmbValue.Text))
         end;
    22 : begin
-          if (cmbValue.ItemIndex=0) and (Application.MessageBox('Dou you really want to clear QSL_S field?',
-             'Question ...',mb_YesNo+mb_IconQuestion) in [idNo, idCancel]) then
+          if (cmbValue.ItemIndex=0) and (Application.MessageBox('Do you really want to clear QSL_S field?',
+             'Question ...',mb_YesNo+mb_IconQuestion+mb_DefButton2) in [idNo, idCancel]) then
           begin
             cmbValue.SetFocus;
             exit
@@ -429,8 +429,8 @@ begin
             sql := 'qsls_date='+QuotedStr(cmbValue.Text)
         end;
    24 : begin
-          if (cmbValue.ItemIndex=0) and (Application.MessageBox('Dou you really want to clear QSL_R field?',
-             'Question ...',mb_YesNo+mb_IconQuestion) in [idNo, idCancel]) then
+          if (cmbValue.ItemIndex=0) and (Application.MessageBox('Do you really want to clear QSL_R field?',
+             'Question ...',mb_YesNo+mb_IconQuestion+mb_DefButton2) in [idNo, idCancel]) then
           begin
             cmbValue.SetFocus;
             exit
@@ -523,20 +523,20 @@ begin
                    QuotedStr(cmbValue.Text)
         end;
    34 : begin
-           if (cmbValue.Text='') and (Application.MessageBox('Dou you really want to clear Contest name field?',
-              'Question ...',mb_YesNo+mb_IconQuestion) in [idNo, idCancel]) then
+           if (cmbValue.Text='') and (Application.MessageBox('Do you really want to clear Contest name field?',
+              'Question ...',mb_YesNo+mb_IconQuestion+mb_DefButton2) in [idNo, idCancel]) then
              exit;
            sql := 'contestname='+QuotedStr(ExtractWord(1,cmbValue.Text,['|']));
          end;
    35 : begin
-           if (cmbValue.Text='') and (Application.MessageBox('Dou you really want to clear Propagation mode field?',
-              'Question ...',mb_YesNo+mb_IconQuestion) in [idNo, idCancel]) then
+           if (cmbValue.Text='') and (Application.MessageBox('Do you really want to clear Propagation mode field?',
+              'Question ...',mb_YesNo+mb_IconQuestion+mb_DefButton2) in [idNo, idCancel]) then
              exit;
            sql := 'prop_mode='+QuotedStr(ExtractWord(1,cmbValue.Text,['|']));
          end;
    36 : begin
-           if (cmbValue.Text='') and (Application.MessageBox('Dou you really want to clear Satellite field?',
-              'Question ...',mb_YesNo+mb_IconQuestion) in [idNo, idCancel]) then
+           if (cmbValue.Text='') and (Application.MessageBox('Do you really want to clear Satellite field?',
+              'Question ...',mb_YesNo+mb_IconQuestion+mb_DefButton2) in [idNo, idCancel]) then
              exit;
            sql := 'satellite='+QuotedStr(ExtractWord(1,cmbValue.Text,['|']));
          end;

--- a/src/fGroupEdit.pas
+++ b/src/fGroupEdit.pas
@@ -274,13 +274,13 @@ begin
          end;
      8 : begin
            if (cmbValue.Text='') and (Application.MessageBox('Dou you really want to clear name field?',
-              'Question ...',mb_YesNo+mb_IconQuestion)=idNo) then
+              'Question ...',mb_YesNo+mb_IconQuestion) in [idNo, idCancel]) then
              exit;
            sql := 'name='+QuotedStr(cmbValue.Text)
          end;
      9 : begin
            if (cmbValue.Text='') and (Application.MessageBox('Dou you really want to clear QTH field?',
-              'Question ...',mb_YesNo+mb_IconQuestion)=idNo) then
+              'Question ...',mb_YesNo+mb_IconQuestion) in [idNo, idCancel]) then
            begin
              cmbValue.SetFocus;
              exit
@@ -311,7 +311,7 @@ begin
          end;
     13 : begin
            if (cmbValue.Text='') and (Application.MessageBox('Dou you really want to clear County field?',
-              'Question ...',mb_YesNo+mb_IconQuestion)=idNo) then
+              'Question ...',mb_YesNo+mb_IconQuestion) in [idNo, idCancel]) then
            begin
              cmbValue.SetFocus;
              exit
@@ -320,7 +320,7 @@ begin
          end;
     14 : begin
            if (cmbValue.Text='') and (Application.MessageBox('Dou you really want to clear State field?',
-              'Question ...',mb_YesNo+mb_IconQuestion)=idNo) then
+              'Question ...',mb_YesNo+mb_IconQuestion) in [idNo, idCancel]) then
            begin
              cmbValue.SetFocus;
              exit
@@ -330,7 +330,7 @@ begin
 
     15 : begin
            if (cmbValue.Text='') and (Application.MessageBox('Dou you really want to clear Award field?',
-              'Question ...',mb_YesNo+mb_IconQuestion)=idNo) then
+              'Question ...',mb_YesNo+mb_IconQuestion) in [idNo, idCancel]) then
            begin
              cmbValue.SetFocus;
              exit
@@ -348,7 +348,7 @@ begin
          end;
     17 : begin
            if (cmbValue.Text='') and (Application.MessageBox('Dou you really want to clear Comment to QSO field?',
-              'Question ...',mb_YesNo+mb_IconQuestion)=idNo) then
+              'Question ...',mb_YesNo+mb_IconQuestion) in [idNo, idCancel]) then
            begin
              cmbValue.SetFocus;
              exit
@@ -367,7 +367,7 @@ begin
             end
            else begin
              if (Application.MessageBox('Dou you really want to clear My locator field?',
-              'Question ...',mb_YesNo+mb_IconQuestion)=idNo) then
+              'Question ...',mb_YesNo+mb_IconQuestion) in [idNo, idCancel]) then
             begin
               cmbValue.SetFocus;
               exit
@@ -387,7 +387,7 @@ begin
           end
           else begin
             if (Application.MessageBox('Dou you really want to clear Locator field?',
-               'Question ...',mb_YesNo+mb_IconQuestion)=idNo) then
+               'Question ...',mb_YesNo+mb_IconQuestion) in [idNo, idCancel]) then
             begin
               cmbValue.SetFocus;
               exit
@@ -400,7 +400,7 @@ begin
         end;
    21 : begin
           if (cmbValue.Text='') and (Application.MessageBox('Dou you really want to clear QSL via field?',
-             'Question ...',mb_YesNo+mb_IconQuestion)=idNo) then
+             'Question ...',mb_YesNo+mb_IconQuestion) in [idNo, idCancel]) then
           begin
             cmbValue.SetFocus;
             exit
@@ -409,7 +409,7 @@ begin
         end;
    22 : begin
           if (cmbValue.ItemIndex=0) and (Application.MessageBox('Dou you really want to clear QSL_S field?',
-             'Question ...',mb_YesNo+mb_IconQuestion)=idNo) then
+             'Question ...',mb_YesNo+mb_IconQuestion) in [idNo, idCancel]) then
           begin
             cmbValue.SetFocus;
             exit
@@ -430,7 +430,7 @@ begin
         end;
    24 : begin
           if (cmbValue.ItemIndex=0) and (Application.MessageBox('Dou you really want to clear QSL_R field?',
-             'Question ...',mb_YesNo+mb_IconQuestion)=idNo) then
+             'Question ...',mb_YesNo+mb_IconQuestion) in [idNo, idCancel]) then
           begin
             cmbValue.SetFocus;
             exit
@@ -524,19 +524,19 @@ begin
         end;
    34 : begin
            if (cmbValue.Text='') and (Application.MessageBox('Dou you really want to clear Contest name field?',
-              'Question ...',mb_YesNo+mb_IconQuestion)=idNo) then
+              'Question ...',mb_YesNo+mb_IconQuestion) in [idNo, idCancel]) then
              exit;
            sql := 'contestname='+QuotedStr(ExtractWord(1,cmbValue.Text,['|']));
          end;
    35 : begin
            if (cmbValue.Text='') and (Application.MessageBox('Dou you really want to clear Propagation mode field?',
-              'Question ...',mb_YesNo+mb_IconQuestion)=idNo) then
+              'Question ...',mb_YesNo+mb_IconQuestion) in [idNo, idCancel]) then
              exit;
            sql := 'prop_mode='+QuotedStr(ExtractWord(1,cmbValue.Text,['|']));
          end;
    36 : begin
            if (cmbValue.Text='') and (Application.MessageBox('Dou you really want to clear Satellite field?',
-              'Question ...',mb_YesNo+mb_IconQuestion)=idNo) then
+              'Question ...',mb_YesNo+mb_IconQuestion) in [idNo, idCancel]) then
              exit;
            sql := 'satellite='+QuotedStr(ExtractWord(1,cmbValue.Text,['|']));
          end;

--- a/src/fMain.pas
+++ b/src/fMain.pas
@@ -735,7 +735,7 @@ begin
     if dbgrdMain.SelectedRows.Count < 1 then
     begin
       if Application.MessageBox('Do you really want to delete this QSO?',
-        'Question ...', MB_ICONQUESTION + MB_YESNO) = idNo then
+        'Question ...', MB_ICONQUESTION + MB_YESNO) in [idNo, idCancel] then
         exit;
       dmData.qCQRLOG.DisableControls;
       try
@@ -761,7 +761,7 @@ begin
     else
     begin
       if Application.MessageBox('Do you really want to delete selected QSOs?',
-        'Question ...', MB_ICONQUESTION + MB_YESNO) = idNo then
+        'Question ...', MB_ICONQUESTION + MB_YESNO) in [idNo, idCancel] then
         exit;
       dmData.qCQRLOG.DisableControls;
       try
@@ -954,7 +954,7 @@ var
 
 begin
   if Application.MessageBox('Do you really want to run database update?',
-    'Question ...', mb_YesNo + mb_IconQuestion) = idNo then
+    'Question ...', mb_YesNo + mb_IconQuestion) in [idNo, idCancel] then
     exit;
   lastid := cqrini.ReadInteger('CallBook', 'LastId', -1);
   Selected:=dbgrdMain.SelectedRows.Count > 0;
@@ -985,7 +985,7 @@ begin
   begin
     if Application.MessageBox(
       'It looks like last update were canceled. Do you want to continue from last position?',
-      'Question ...', mb_YesNo + mb_IconQuestion) = idNo then
+      'Question ...', mb_YesNo + mb_IconQuestion) in [idNo, idCancel] then
       Begin
       if Selected then lastid := dmData.qCallBook.FieldByName('id_cqrlog_main').AsInteger
        else lastid := dmData.qCQRLOG.FieldByName('id_cqrlog_main').AsInteger
@@ -1132,7 +1132,7 @@ begin
            'This could cause that you won''t have more callsigns on one label and ' +
            'only last 500 QSO will be printed.'+LineEnding+LineEnding+
            'Do you want to continue?';
-    if Application.MessageBox(PChar(msg),'Warning ...',mb_YesNo + mb_IconWarning) = idNo then
+    if Application.MessageBox(PChar(msg),'Warning ...',mb_YesNo + mb_IconWarning) in [idNo, idCancel] then
       exit
   end;
   with TfrmExLabelPrint.Create(self) do
@@ -1167,7 +1167,7 @@ end;
 procedure TfrmMain.acSelAllExecute(Sender: TObject);
 begin
   if application.MessageBox('Do you really want to select all records?',
-    'Question ...', mb_ok + mb_YesNo) = idNo then
+    'Question ...', mb_ok + mb_YesNo) in [idNo, idCancel] then
     exit;
   try
     dbgrdMain.SelectedRows.Clear;
@@ -1439,7 +1439,7 @@ begin
     if cqrini.ReadBool('OnlineLog','HaUP',False)  or cqrini.ReadBool('OnlineLog','ClUP',False) or cqrini.ReadBool('OnlineLog','HrUP',False) then
     begin
       if Application.MessageBox('It seems you are using online log upload. First, please go to Online log menu and click to  "Mark all QSO as uploaded to all logs".'+
-                              LineEnding + LineEnding + 'Do you want to continue?','Question...', mb_YesNo+mb_IconQuestion) = idNo then
+                              LineEnding + LineEnding + 'Do you want to continue?','Question...', mb_YesNo+mb_IconQuestion) in [idNo, idCancel] then
         exit
     end;
     with TfrmImportProgress.Create(self) do
@@ -1840,7 +1840,7 @@ end;
 procedure TfrmMain.acAddQSLMgrsExecute(Sender: TObject);
 begin
   if Application.MessageBox('Do you really want to find qsl managers for these QSOs?',
-    'Question ...', mb_YesNo + mb_IconQuestion) = idNo then
+    'Question ...', mb_YesNo + mb_IconQuestion) in [idNo, idCancel] then
     exit;
 
   with TfrmImportProgress.Create(self) do

--- a/src/fMain.pas
+++ b/src/fMain.pas
@@ -735,7 +735,7 @@ begin
     if dbgrdMain.SelectedRows.Count < 1 then
     begin
       if Application.MessageBox('Do you really want to delete this QSO?',
-        'Question ...', MB_ICONQUESTION + MB_YESNO) in [idNo, idCancel] then
+        'Question ...', MB_ICONQUESTION + MB_YESNO + MB_DEFBUTTON2) in [idNo, idCancel] then
         exit;
       dmData.qCQRLOG.DisableControls;
       try
@@ -761,7 +761,7 @@ begin
     else
     begin
       if Application.MessageBox('Do you really want to delete selected QSOs?',
-        'Question ...', MB_ICONQUESTION + MB_YESNO) in [idNo, idCancel] then
+        'Question ...', MB_ICONQUESTION + MB_YESNO + MB_DEFBUTTON2) in [idNo, idCancel] then
         exit;
       dmData.qCQRLOG.DisableControls;
       try
@@ -1434,7 +1434,7 @@ end;
 procedure TfrmMain.acRemoveDupesExecute(Sender: TObject);
 begin
   if Application.MessageBox('PLEASE MAKE A BACKUP FIRST! THIS FUNCTION MAY DELETE QSO FROM YOUR LOG!'+LineEnding+LineEnding+
-       'Do you really want to remove dupes from database?','Question ...',mb_YesNo+mb_IconQuestion) = idYes then
+       'Do you really want to remove dupes from database?','Question ...',mb_YesNo+mb_IconQuestion+mb_DefButton2) = idYes then
   begin
     if cqrini.ReadBool('OnlineLog','HaUP',False)  or cqrini.ReadBool('OnlineLog','ClUP',False) or cqrini.ReadBool('OnlineLog','HrUP',False) then
     begin

--- a/src/fQTHProfiles.pas
+++ b/src/fQTHProfiles.pas
@@ -136,7 +136,7 @@ begin
     exit;
   end;
 
-  if Application.MessageBox('Do you really want to delete this profile?','Question ...', mb_YesNo + mb_IconQuestion) = idNo then
+  if Application.MessageBox('Do you really want to delete this profile?','Question ...', mb_YesNo + mb_IconQuestion) in [idNo, idCancel] then
   begin
     exit;
   end;

--- a/src/fQTHProfiles.pas
+++ b/src/fQTHProfiles.pas
@@ -136,7 +136,7 @@ begin
     exit;
   end;
 
-  if Application.MessageBox('Do you really want to delete this profile?','Question ...', mb_YesNo + mb_IconQuestion) in [idNo, idCancel] then
+  if Application.MessageBox('Do you really want to delete this profile?','Question ...', mb_YesNo + mb_IconQuestion + mb_DefButton2) in [idNo, idCancel] then
   begin
     exit;
   end;


### PR DESCRIPTION
As described in https://github.com/ok2cqr/cqrlog/issues/364 CQRlog executes critical operations even though the user presses ESC in the dialog box asking for YES or NO.  So if the program is asking if you really want to delete the database or a QSO and one presses ESC to cancel the process the critical operation is still executed. This is the opposite of what a user expects.
Also YES is the pre-selected button in those dialog boxes. I guess it should be 'NO' per default and force the user to explicitely select 'YES' to confirm.
This addresses issue https://github.com/ok2cqr/cqrlog/issues/364.