### PR TITLE
Exchange my grid loc and DX station's grid loc

### DIFF
--- a/src/fNewQSO.pas
+++ b/src/fNewQSO.pas
@@ -7004,7 +7004,7 @@ begin
       HisName:= edtName.Text;
       tmp := 'DX ' + FloatToStrF(f,ffFixed,8,1) + ' ' + call;
       ModRst := cmbMode.Text+' '+ rst_s;
-      HMLoc := edtGrid.Text+'<'+dmSatellite.GetPropShortName(cmbPropagation.Text)+'>'+copy(sbNewQSO.Panels[0].Text,Length(cMyLoc)+1,6);
+      HMLoc := copy(sbNewQSO.Panels[0].Text,Length(cMyLoc)+1,6)+'<'+dmSatellite.GetPropShortName(cmbPropagation.Text)+'>'+edtGrid.Text;
 
     end;
   end


### PR DESCRIPTION
I was contacted because the DX spots that can be created from CQRlog obviously set my grid and the DX station's grid in wrong order. Subsequently some DX info collection tools fail to parse or parse with incorrect data. 
The concrete question arose on Twitter: https://twitter.com/SpaceStation22/status/1341377735361486848?s=20
The full thread is here: https://twitter.com/SpaceStation22/status/1340998770402717699?s=20
After reading on DXluster message it seems my grid and DX station grid just need to be exchanged. This patch implements that.

![Screenshot from 2020-12-23 23-02-24](https://user-images.githubusercontent.com/7112907/103040444-baa71600-4573-11eb-9aa8-16e87681417c.png)

In this case my grid (JO31ol) stands before propagation mode and UA3XCR's grid follows. This seems to be the correct pattern.
Evidence is welcome :)