### PR TITLE
DX spot locator order fix

### DIFF
--- a/src/fNewQSO.pas
+++ b/src/fNewQSO.pas
@@ -7023,7 +7023,7 @@ begin
       Writeln(dmData.Q.SQL.Text);
     dmData.Q.Open();
     ModRst  := dmData.Q.Fields[0].AsString+' '+dmData.Q.Fields[1].AsString;
-    HMLoc   := dmData.Q.Fields[2].AsString+'<'+dmData.Q.Fields[3].AsString+'>'+dmData.Q.Fields[4].AsString;
+    HMLoc   := dmData.Q.Fields[4].AsString+'<'+dmData.Q.Fields[3].AsString+'>'+dmData.Q.Fields[2].AsString;
     rst_s := dmData.Q.Fields[1].AsString;
     stx :=  dmData.Q.Fields[5].AsString;
     stx_str:=dmData.Q.Fields[6].AsString;


### PR DESCRIPTION
Locator order was fixed in #368 .
That affects to spot created from call that is in NewQSO.

If new QSO is empty and spot is created from last logged qso the order is upside down.
This fixes also that part.
