### PR TITLE
QTHprofile numbering and temporary locator fixes

### DIFF
--- a/src/dQTHProfile.pas
+++ b/src/dQTHProfile.pas
@@ -39,7 +39,7 @@ implementation
 
 function TdmQTHProfile.GetNewProfileNumber() : Integer;
 const
-  SQL = 'select max(nr)+1 as nr from profiles';
+  SQL = 'select max(nr) as nr from profiles';
 var
   Connection : TInternalConnection;
 begin
@@ -48,7 +48,8 @@ begin
     Connection.Q.SQL.Text := SQL;
     Connection.Q.Open;
 
-    Result := Connection.Q.Fields[0].AsInteger;
+    Result := Connection.Q.Fields[0].AsInteger + 1;
+
   finally
     FreeAndNil(Connection);
   end;

--- a/src/fChangeLocator.pas
+++ b/src/fChangeLocator.pas
@@ -33,7 +33,7 @@ implementation
 {$R *.lfm}
 
 { TfrmChangeLocator }
-uses dUtils;
+uses dUtils, uMyIni;
 
 procedure TfrmChangeLocator.edtLocatorKeyPress(Sender: TObject; var Key: char);
 begin
@@ -46,6 +46,7 @@ end;
 
 procedure TfrmChangeLocator.btnOKClick(Sender: TObject);
 begin
+   if  edtLocator.Text='' then  edtLocator.Text:= cqrini.ReadString('Station', 'LOC', '');
    if dmUtils.isLocOK(edtLocator.Text) then
     ModalResult := mrOK
     else


### PR DESCRIPTION
I guess that QTH profile numbering is meant to start from 1.
How ever sql sentence "select max(nr)+1" does not work if there are no profiles. Max(nr) generates NULL and addition NULL+1 results to NULL.

If we just take max(nr) and then later produce "AsInteger" then we can add +1 and in case of NULL AsInteger results 0 and addition +1 to that results to 1 what is expected.

If temporary locator editor (Ctrl_L) is left empty station locator from preferences is copied at close with OK. This is easy way to restore locator back to base setting.