### PR TITLE
Fix for winkeyer

### DIFF
--- a/src/fNewQSO.pas
+++ b/src/fNewQSO.pas
@@ -1398,8 +1398,8 @@ begin
 
   dmData.LoadQSODateColorSettings;
 
-  InitializeCW;
-
+  if cqrini.ReadBool('CW', 'NoReset', false) then     //is set: user does not want reset CW keyer at rig switch/init
+                                        InitializeCW; //so we have to do it at least once: Here.
   Op := '';
 
   if dbgrdQSOBefore.Visible then

--- a/src/uCWKeying.pas
+++ b/src/uCWKeying.pas
@@ -165,8 +165,11 @@ procedure TCWWinKeyerUSB.Open;
 var
   rec : byte;
 begin
-  if fActive then Close();
-
+  if fActive then
+                 Begin
+                   Close();
+                   sleep (200);
+                 end;
   if fDebugMode then Writeln('Device: ',fDevice);
   ser.RaiseExcept := False;
   ser.Connect(fDevice);
@@ -185,12 +188,12 @@ begin
   ser.SendByte($13);
   ser.SendByte($13);  //sending null commands
   ser.SendByte($13);
-  sleep(50);
+  sleep(300);
   if fDebugMode then Writeln('After sending null command');
   ser.SendByte(0);
   ser.SendByte(4);  //send echo command
   ser.SendByte(20);
-  sleep(50);
+  sleep(300);
   while ser.CanReadex(10) do
   begin
     rec := (ser.recvByte(0))
@@ -201,6 +204,7 @@ begin
   else begin
     fLastErrNr := 1000;
     fLastErrSt := 'WinKeyer USB inicialization failed';
+    if fDebugMode then Writeln(fLastErrSt);
     exit
   end;
   ser.SendByte(0);
@@ -270,6 +274,11 @@ var
   i : Integer;
   spd : Integer;
 begin
+  if not fActive then
+    Begin
+     if fDebugMode then Writeln('Winkeyer is not active. Can not send: ',text);
+     exit
+    end;
   spd  := fSpeed;
   text := UpperCase(text);
   if fDebugMode then Writeln('Sending text: ',text);

--- a/src/uVersion.pas
+++ b/src/uVersion.pas
@@ -10,7 +10,7 @@ const
   cRELEAS     = 0;
   cBUILD      = 1;
 
-  cBUILD_DATE = '2021-01-16';
+  cBUILD_DATE = '2021-01-20';
 
 implementation
 


### PR DESCRIPTION
Winkeyer init fails leading to defunct speed change and stop (by esc). Issue #377

I could not find error from code. But increasing delays (50ms) at init procedure to 300 ms seems to fix init and when it passes OK everything works.

Changed CW init from newQSO start. It is not needed there because rig init inits also CWkeyer.
Exeption is that when user denies keyer init when switch radios, then init must be done at newQSO start (to be done at least once).

Added fActive check to winkeyer send text routine. It was not there allowing text send even when winkeyer init failed. Now does not send text if init failed.