### PR TITLE
Fixes for local settings

### DIFF
--- a/src/fConfigStorage.pas
+++ b/src/fConfigStorage.pas
@@ -170,7 +170,7 @@ begin
   if cmbStoreCWInterface.ItemIndex>0 then
     Sections := Sections + 'CW,';
   if cmbStoreFldigiInterface.ItemIndex>0 then
-    Sections := Sections + 'fldigi,wsjt';
+    Sections := Sections + 'fldigi,wsjt,n1mm';
   if cmbStoreAutoBackup.ItemIndex>0 then
     Sections := Sections + 'Backup,';
   if cmbStoreExtViewers.ItemIndex>0 then

--- a/src/fNewQSO.lfm
+++ b/src/fNewQSO.lfm
@@ -2152,7 +2152,6 @@ object frmNewQSO: TfrmNewQSO
     ClientHeight = 588
     ClientWidth = 1032
     TabOrder = 0
-    OnClick = pnlAllClick
     object pnlQsoInfo: TPanel
       AnchorSideTop.Side = asrBottom
       AnchorSideRight.Side = asrBottom
@@ -3154,7 +3153,6 @@ object frmNewQSO: TfrmNewQSO
           BorderSpacing.Top = 3
           TabIndex = 0
           TabOrder = 27
-          OnChange = pgDetailsChange
           object tabDXCCStat: TTabSheet
             AnchorSideRight.Side = asrBottom
             AnchorSideBottom.Side = asrBottom

--- a/src/fNewQSO.pas
+++ b/src/fNewQSO.pas
@@ -566,8 +566,6 @@ type
     procedure mnuIOTAClick(Sender: TObject);
     procedure mnuQSOBeforeClick(Sender: TObject);
     procedure mnuQSOListClick(Sender: TObject);
-    procedure pgDetailsChange(Sender: TObject);
-    procedure pnlAllClick(Sender: TObject);
     procedure popEditQSOPopup(Sender: TObject);
     procedure sbtnAttachClick(Sender: TObject);
     procedure sbtnLocatorMapClick(Sender: TObject);
@@ -5932,16 +5930,6 @@ begin
     frmMain.WindowState := wsNormal;
   frmMain.Show;
   frmMain.BringToFront;
-end;
-
-procedure TfrmNewQSO.pgDetailsChange(Sender: TObject);
-begin
-
-end;
-
-procedure TfrmNewQSO.pnlAllClick(Sender: TObject);
-begin
-
 end;
 
 procedure TfrmNewQSO.popEditQSOPopup(Sender: TObject);

--- a/src/uMyIni.pas
+++ b/src/uMyIni.pas
@@ -5,7 +5,7 @@ unit uMyIni;
 interface
 
 uses
-  Classes, SysUtils, iniFiles, dynlibs;
+  Classes, SysUtils, iniFiles, dynlibs,strutils;
 
 type
   TMyIni = class
@@ -225,7 +225,7 @@ end;
 
 function TMyIni.LocalOnly(Section : String) : Boolean;
 begin
-  Result := Pos(Section+',',LocalSections)>0
+  Result := IsWordPresent(Section,LocalSections,[',']);
 end;
 
 procedure TMyIni.LoadLocalSectionsList;

--- a/src/uVersion.pas
+++ b/src/uVersion.pas
@@ -10,7 +10,7 @@ const
   cRELEAS     = 1;
   cBUILD      = 1;
 
-  cBUILD_DATE = '2021-01-30';
+  cBUILD_DATE = '2021-02-01';
 
 implementation
 


### PR DESCRIPTION
 - MyIni function LocalOnly checked sections+comma from localsections list. This led to situation that always last section was ignored because it did not end to comma. Fixed to check the section names without comma.
 - fldigi/wsjtx section did not include "ADIF" IP and port (former "n1mm" as named in config file). Added that.
 - removed two empty actions from NewQSO form that were added there by accident when editing PullRequest #385