### PR TITLE
Fix for NewQSO: Edit and View error

### DIFF
--- a/src/fNewQSO.lfm
+++ b/src/fNewQSO.lfm
@@ -1,15 +1,15 @@
 object frmNewQSO: TfrmNewQSO
-  Left = 266
+  Left = 244
   Height = 709
-  Top = 112
+  Top = 66
   Width = 1032
   HelpType = htKeyword
   HelpKeyword = 'help/index.html'
-  HorzScrollBar.Page = 983
+  HorzScrollBar.Page = 974
   VertScrollBar.Page = 638
   AutoScroll = True
   Caption = 'New QSO ... (CQRLOG for Linux)'
-  ClientHeight = 687
+  ClientHeight = 684
   ClientWidth = 1032
   Icon.Data = {
     3E08010000000100010080800000010020002808010016000000280000008000
@@ -2138,7 +2138,7 @@ object frmNewQSO: TfrmNewQSO
   OnKeyUp = FormKeyUp
   OnShow = FormShow
   OnWindowStateChange = FormWindowStateChange
-  LCLVersion = '2.0.6.0'
+  LCLVersion = '2.0.8.0'
   object pnlAll: TPanel
     AnchorSideTop.Control = dbgrdQSOBefore
     AnchorSideTop.Side = asrBottom
@@ -2146,7 +2146,7 @@ object frmNewQSO: TfrmNewQSO
     AnchorSideBottom.Side = asrBottom
     Left = 0
     Height = 588
-    Top = 99
+    Top = 96
     Width = 1032
     Align = alBottom
     ClientHeight = 588
@@ -2157,39 +2157,37 @@ object frmNewQSO: TfrmNewQSO
       AnchorSideRight.Side = asrBottom
       AnchorSideBottom.Side = asrBottom
       Left = 1
-      Height = 536
-      Top = 27
+      Height = 532
+      Top = 35
       Width = 759
       Align = alClient
       BorderSpacing.Bottom = 2
       BevelOuter = bvNone
-      ClientHeight = 536
+      ClientHeight = 532
       ClientWidth = 759
       TabOrder = 0
       object pnlQSOinput: TPanel
         AnchorSideRight.Side = asrBottom
         AnchorSideBottom.Side = asrBottom
         Left = 0
-        Height = 536
+        Height = 532
         Top = 0
         Width = 759
         Align = alClient
         BorderSpacing.InnerBorder = 2
         BevelOuter = bvNone
-        ClientHeight = 536
+        ClientHeight = 532
         ClientWidth = 759
         ParentShowHint = False
         TabOrder = 0
         object lblCommentToCallsign: TLabel
           AnchorSideLeft.Control = lblCounty
-          AnchorSideTop.Control = edtDXCCRef
-          AnchorSideTop.Side = asrBottom
+          AnchorSideTop.Control = lblDate
           AnchorSideBottom.Side = asrBottom
           Left = 259
-          Height = 17
-          Top = 191
-          Width = 139
-          BorderSpacing.Top = 3
+          Height = 15
+          Top = 215
+          Width = 135
           Caption = 'Comment to callsign'
           Layout = tlBottom
           ParentColor = False
@@ -2200,9 +2198,9 @@ object frmNewQSO: TfrmNewQSO
           AnchorSideTop.Control = lblName
           AnchorSideTop.Side = asrCenter
           Left = 109
-          Height = 17
-          Top = 50
-          Width = 31
+          Height = 15
+          Top = 56
+          Width = 28
           Caption = 'QTH'
           ParentColor = False
           ParentFont = False
@@ -2212,9 +2210,9 @@ object frmNewQSO: TfrmNewQSO
           AnchorSideTop.Control = edtCall
           AnchorSideTop.Side = asrBottom
           Left = 12
-          Height = 17
-          Top = 50
-          Width = 41
+          Height = 15
+          Top = 56
+          Width = 39
           BorderSpacing.Top = 3
           Caption = 'Name'
           ParentColor = False
@@ -2225,9 +2223,9 @@ object frmNewQSO: TfrmNewQSO
           AnchorSideTop.Control = lblCall
           AnchorSideTop.Side = asrCenter
           Left = 445
-          Height = 17
+          Height = 15
           Top = 3
-          Width = 59
+          Width = 57
           Caption = 'RST rcvd'
           ParentColor = False
           ParentFont = False
@@ -2237,9 +2235,9 @@ object frmNewQSO: TfrmNewQSO
           AnchorSideTop.Control = lblCall
           AnchorSideTop.Side = asrCenter
           Left = 353
-          Height = 17
+          Height = 15
           Top = 3
-          Width = 59
+          Width = 57
           Caption = 'RST sent'
           ParentColor = False
           ParentFont = False
@@ -2248,9 +2246,9 @@ object frmNewQSO: TfrmNewQSO
           AnchorSideLeft.Control = pnlQSOinput
           AnchorSideTop.Control = pnlQSOinput
           Left = 12
-          Height = 17
+          Height = 15
           Top = 3
-          Width = 26
+          Width = 25
           BorderSpacing.Left = 12
           BorderSpacing.Top = 3
           Caption = 'Call'
@@ -2262,9 +2260,9 @@ object frmNewQSO: TfrmNewQSO
           AnchorSideTop.Control = lblCall
           AnchorSideTop.Side = asrCenter
           Left = 132
-          Height = 17
+          Height = 15
           Top = 3
-          Width = 72
+          Width = 67
           Caption = 'Frequency'
           ParentColor = False
           ParentFont = False
@@ -2274,23 +2272,20 @@ object frmNewQSO: TfrmNewQSO
           AnchorSideTop.Control = lblCall
           AnchorSideTop.Side = asrCenter
           Left = 237
-          Height = 17
+          Height = 15
           Top = 3
-          Width = 40
+          Width = 36
           Caption = 'Mode'
           ParentColor = False
           ParentFont = False
         end
         object lblEndTime: TLabel
           AnchorSideLeft.Control = edtEndTime
-          AnchorSideTop.Side = asrCenter
-          AnchorSideBottom.Control = edtEndTime
-          Left = 177
-          Height = 17
-          Top = 260
-          Width = 26
-          Anchors = [akLeft, akBottom]
-          BorderSpacing.Top = 6
+          AnchorSideTop.Control = lblDate
+          Left = 179
+          Height = 15
+          Top = 215
+          Width = 24
           Caption = '&End'
           FocusControl = edtEndTime
           ParentColor = False
@@ -2298,28 +2293,25 @@ object frmNewQSO: TfrmNewQSO
         end
         object lblStartTime: TLabel
           AnchorSideLeft.Control = edtStartTime
-          AnchorSideTop.Side = asrCenter
-          AnchorSideBottom.Control = edtStartTime
-          Left = 117
-          Height = 17
-          Top = 260
-          Width = 34
-          Anchors = [akLeft, akBottom]
-          BorderSpacing.Top = 6
+          AnchorSideTop.Control = lblDate
+          Left = 118
+          Height = 15
+          Top = 215
+          Width = 31
           Caption = '&Start'
           FocusControl = edtStartTime
           ParentColor = False
           ParentFont = False
         end
         object lblDate: TLabel
-          AnchorSideLeft.Control = edtDate
-          AnchorSideTop.Side = asrCenter
-          AnchorSideBottom.Control = edtDate
+          AnchorSideLeft.Control = edtDXCCRef
+          AnchorSideTop.Control = edtDXCCRef
+          AnchorSideTop.Side = asrBottom
           Left = 12
-          Height = 17
-          Top = 260
-          Width = 33
-          Anchors = [akLeft, akBottom]
+          Height = 15
+          Top = 215
+          Width = 31
+          BorderSpacing.Top = 3
           Caption = 'Date'
           ParentColor = False
           ParentFont = False
@@ -2329,9 +2321,9 @@ object frmNewQSO: TfrmNewQSO
           AnchorSideTop.Control = lblName
           AnchorSideTop.Side = asrCenter
           Left = 250
-          Height = 17
-          Top = 50
-          Width = 35
+          Height = 15
+          Top = 56
+          Width = 33
           Caption = 'GRID'
           ParentColor = False
           ParentFont = False
@@ -2341,9 +2333,9 @@ object frmNewQSO: TfrmNewQSO
           AnchorSideTop.Control = lblName
           AnchorSideTop.Side = asrCenter
           Left = 327
-          Height = 17
-          Top = 50
-          Width = 34
+          Height = 15
+          Top = 56
+          Width = 30
           Caption = 'PWR'
           ParentColor = False
           ParentFont = False
@@ -2353,9 +2345,9 @@ object frmNewQSO: TfrmNewQSO
           AnchorSideTop.Control = lblName
           AnchorSideTop.Side = asrCenter
           Left = 387
-          Height = 17
-          Top = 50
-          Width = 43
+          Height = 15
+          Top = 56
+          Width = 40
           Caption = 'QSL_S'
           ParentColor = False
           ParentFont = False
@@ -2365,9 +2357,9 @@ object frmNewQSO: TfrmNewQSO
           AnchorSideTop.Control = lblName
           AnchorSideTop.Side = asrCenter
           Left = 461
-          Height = 17
-          Top = 50
-          Width = 46
+          Height = 15
+          Top = 56
+          Width = 41
           Caption = 'QSL_R'
           ParentColor = False
           ParentFont = False
@@ -2377,9 +2369,9 @@ object frmNewQSO: TfrmNewQSO
           AnchorSideTop.Control = edtName
           AnchorSideTop.Side = asrBottom
           Left = 12
-          Height = 17
-          Top = 97
-          Width = 23
+          Height = 15
+          Top = 109
+          Width = 22
           BorderSpacing.Top = 3
           Caption = 'ITU'
           ParentColor = False
@@ -2390,9 +2382,9 @@ object frmNewQSO: TfrmNewQSO
           AnchorSideTop.Control = lblItuEdit
           AnchorSideTop.Side = asrCenter
           Left = 392
-          Height = 17
-          Top = 97
-          Width = 44
+          Height = 15
+          Top = 109
+          Width = 41
           Caption = 'Award'
           ParentColor = False
           ParentFont = False
@@ -2402,9 +2394,9 @@ object frmNewQSO: TfrmNewQSO
           AnchorSideTop.Control = edtITU
           AnchorSideTop.Side = asrBottom
           Left = 12
-          Height = 17
-          Top = 144
-          Width = 64
+          Height = 15
+          Top = 162
+          Width = 62
           BorderSpacing.Top = 3
           Caption = 'DXCC ref.'
           ParentColor = False
@@ -2415,9 +2407,9 @@ object frmNewQSO: TfrmNewQSO
           AnchorSideTop.Control = lblItuEdit
           AnchorSideTop.Side = asrCenter
           Left = 59
-          Height = 17
-          Top = 97
-          Width = 33
+          Height = 15
+          Top = 109
+          Width = 31
           Caption = 'WAZ'
           ParentColor = False
           ParentFont = False
@@ -2427,9 +2419,9 @@ object frmNewQSO: TfrmNewQSO
           AnchorSideTop.Control = lblItuEdit
           AnchorSideTop.Side = asrCenter
           Left = 106
-          Height = 17
-          Top = 97
-          Width = 33
+          Height = 15
+          Top = 109
+          Width = 31
           Caption = 'IOTA'
           ParentColor = False
           ParentFont = False
@@ -2439,9 +2431,9 @@ object frmNewQSO: TfrmNewQSO
           AnchorSideTop.Control = lblItuEdit
           AnchorSideTop.Side = asrCenter
           Left = 259
-          Height = 17
-          Top = 97
-          Width = 50
+          Height = 15
+          Top = 109
+          Width = 46
           Caption = 'County'
           ParentColor = False
           ParentFont = False
@@ -2451,9 +2443,9 @@ object frmNewQSO: TfrmNewQSO
           AnchorSideTop.Control = lblDXCCRef
           AnchorSideTop.Side = asrCenter
           Left = 107
-          Height = 17
-          Top = 144
-          Width = 120
+          Height = 15
+          Top = 162
+          Width = 113
           Caption = 'Comment to QSO'
           ParentColor = False
           ParentFont = False
@@ -2463,22 +2455,23 @@ object frmNewQSO: TfrmNewQSO
           AnchorSideTop.Control = lblDXCCRef
           AnchorSideTop.Side = asrCenter
           Left = 402
-          Height = 17
-          Top = 144
-          Width = 55
+          Height = 15
+          Top = 162
+          Width = 51
           Caption = 'QSL VIA'
           ParentColor = False
           ParentFont = False
         end
         object lblQSOTakes: TLabel
-          AnchorSideLeft.Control = edtStartTime
-          AnchorSideTop.Control = pnlOffline
-          AnchorSideTop.Side = asrCenter
+          AnchorSideLeft.Control = pnlOffline
+          AnchorSideTop.Side = asrBottom
+          AnchorSideBottom.Control = mComment
           AnchorSideBottom.Side = asrBottom
-          Left = 117
-          Height = 17
-          Top = 308
-          Width = 75
+          Left = 12
+          Height = 15
+          Top = 309
+          Width = 71
+          Anchors = [akLeft, akBottom]
           Caption = 'QSO takes '
           Layout = tlBottom
           ParentColor = False
@@ -2487,13 +2480,11 @@ object frmNewQSO: TfrmNewQSO
         end
         object lblQSLMgr: TLabel
           AnchorSideLeft.Control = edtQSL_VIA
-          AnchorSideTop.Control = lblCommentToCallsign
-          AnchorSideTop.Side = asrCenter
+          AnchorSideTop.Control = lblDate
           Left = 402
-          Height = 17
-          Top = 191
-          Width = 139
-          BorderSpacing.Top = 10
+          Height = 15
+          Top = 215
+          Width = 133
           Caption = 'QSL manager found!'
           Font.Color = clGreen
           Layout = tlBottom
@@ -2507,54 +2498,22 @@ object frmNewQSO: TfrmNewQSO
           AnchorSideTop.Control = lblItuEdit
           AnchorSideTop.Side = asrCenter
           Left = 211
-          Height = 17
-          Top = 97
-          Width = 37
+          Height = 15
+          Top = 109
+          Width = 34
           BorderSpacing.Left = 5
           Caption = 'State'
           ParentColor = False
           ParentFont = False
           OnClick = lblStateClick
         end
-        object lblCfmLoTW: TLabel
-          AnchorSideLeft.Control = edtDXCCRef
-          AnchorSideTop.Control = lbleQslRcvdDate
-          AnchorSideTop.Side = asrBottom
-          Left = 12
-          Height = 17
-          Top = 231
-          Width = 91
-          BorderSpacing.Top = 3
-          Caption = 'Cfm by LoTW'
-          Font.Color = clGreen
-          Layout = tlBottom
-          ParentColor = False
-          ParentFont = False
-          Visible = False
-        end
-        object lblQSLRcvdDate: TLabel
-          AnchorSideLeft.Control = edtDXCCRef
-          AnchorSideTop.Control = lblCommentToCallsign
-          AnchorSideTop.Side = asrCenter
-          AnchorSideBottom.Side = asrCenter
-          Left = 12
-          Height = 17
-          Top = 191
-          Width = 85
-          Caption = 'QSL rcvd on '
-          Font.Color = clGreen
-          Layout = tlBottom
-          ParentColor = False
-          ParentFont = False
-          Visible = False
-        end
         object edtDXCCRef: TEdit
           AnchorSideLeft.Control = lblDXCCRef
           AnchorSideTop.Control = lblDXCCRef
           AnchorSideTop.Side = asrBottom
           Left = 12
-          Height = 25
-          Top = 163
+          Height = 33
+          Top = 179
           Width = 64
           BorderSpacing.Top = 2
           CharCase = ecUppercase
@@ -2572,7 +2531,7 @@ object frmNewQSO: TfrmNewQSO
           Left = 259
           Height = 92
           Hint = 'Comment/Remark to the callsign, max length 256'
-          Top = 210
+          Top = 232
           Width = 276
           BorderSpacing.Top = 2
           BorderSpacing.Right = 6
@@ -2593,9 +2552,9 @@ object frmNewQSO: TfrmNewQSO
           AnchorSideTop.Control = edtName
           AnchorSideTop.Side = asrCenter
           Left = 109
-          Height = 25
+          Height = 33
           Hint = 'QTH, max length 60'
-          Top = 69
+          Top = 73
           Width = 136
           BorderSpacing.Left = 5
           BorderSpacing.Top = 2
@@ -2612,9 +2571,9 @@ object frmNewQSO: TfrmNewQSO
           AnchorSideTop.Control = lblName
           AnchorSideTop.Side = asrBottom
           Left = 12
-          Height = 25
+          Height = 33
           Hint = 'Name, max length 40'
-          Top = 69
+          Top = 73
           Width = 92
           BorderSpacing.Top = 2
           MaxLength = 40
@@ -2631,9 +2590,9 @@ object frmNewQSO: TfrmNewQSO
           AnchorSideTop.Control = edtCall
           AnchorSideTop.Side = asrCenter
           Left = 445
-          Height = 25
+          Height = 33
           Hint = 'RST received, max length 20'
-          Top = 22
+          Top = 20
           Width = 86
           BorderSpacing.Left = 6
           BorderSpacing.Top = 2
@@ -2651,9 +2610,9 @@ object frmNewQSO: TfrmNewQSO
           AnchorSideTop.Control = edtCall
           AnchorSideTop.Side = asrCenter
           Left = 353
-          Height = 25
+          Height = 33
           Hint = 'RST sent, max length 20'
-          Top = 22
+          Top = 20
           Width = 86
           BorderSpacing.Left = 5
           BorderSpacing.Top = 2
@@ -2671,9 +2630,9 @@ object frmNewQSO: TfrmNewQSO
           AnchorSideTop.Control = lblCall
           AnchorSideTop.Side = asrBottom
           Left = 12
-          Height = 25
+          Height = 33
           Hint = 'callsign, max length 20'
-          Top = 22
+          Top = 20
           Width = 115
           BorderSpacing.Top = 2
           CharCase = ecUppercase
@@ -2693,15 +2652,15 @@ object frmNewQSO: TfrmNewQSO
           AnchorSideTop.Control = edtCall
           AnchorSideTop.Side = asrCenter
           Left = 237
-          Height = 25
+          Height = 33
           Hint = 'mode, max length 12'
-          Top = 22
+          Top = 20
           Width = 111
           AutoComplete = True
           AutoCompleteText = [cbactEnabled, cbactEndOfLineComplete, cbactSearchAscending]
           BorderSpacing.Left = 5
           BorderSpacing.Top = 2
-          ItemHeight = 17
+          ItemHeight = 0
           Items.Strings = (
             'SSB'
             'CW'
@@ -2745,9 +2704,9 @@ object frmNewQSO: TfrmNewQSO
           AnchorSideTop.Control = edtName
           AnchorSideTop.Side = asrCenter
           Left = 250
-          Height = 25
+          Height = 33
           Hint = 'Grid/Locator, max length 10'
-          Top = 69
+          Top = 73
           Width = 72
           BorderSpacing.Left = 5
           BorderSpacing.Top = 2
@@ -2767,9 +2726,9 @@ object frmNewQSO: TfrmNewQSO
           AnchorSideTop.Control = edtName
           AnchorSideTop.Side = asrCenter
           Left = 327
-          Height = 25
+          Height = 33
           Hint = 'Output power, max length 10'
-          Top = 69
+          Top = 73
           Width = 55
           BorderSpacing.Left = 5
           BorderSpacing.Top = 2
@@ -2787,14 +2746,14 @@ object frmNewQSO: TfrmNewQSO
           AnchorSideTop.Control = edtName
           AnchorSideTop.Side = asrCenter
           Left = 387
-          Height = 25
-          Top = 69
+          Height = 33
+          Top = 73
           Width = 69
           AutoComplete = True
           AutoCompleteText = [cbactEnabled, cbactEndOfLineComplete, cbactSearchAscending]
           BorderSpacing.Left = 5
           BorderSpacing.Top = 2
-          ItemHeight = 17
+          ItemHeight = 0
           ItemIndex = 1
           Items.Strings = (
             ''
@@ -2821,14 +2780,14 @@ object frmNewQSO: TfrmNewQSO
           AnchorSideTop.Control = edtName
           AnchorSideTop.Side = asrCenter
           Left = 461
-          Height = 25
-          Top = 69
+          Height = 33
+          Top = 73
           Width = 69
           AutoComplete = True
           AutoCompleteText = [cbactEnabled, cbactEndOfLineComplete, cbactSearchAscending]
           BorderSpacing.Left = 5
           BorderSpacing.Top = 2
-          ItemHeight = 17
+          ItemHeight = 0
           Items.Strings = (
             ''
             ''
@@ -2846,9 +2805,9 @@ object frmNewQSO: TfrmNewQSO
           AnchorSideTop.Control = lblItuEdit
           AnchorSideTop.Side = asrBottom
           Left = 12
-          Height = 25
+          Height = 33
           Hint = 'ITU, must be a number (integer)'
-          Top = 116
+          Top = 126
           Width = 42
           BorderSpacing.Top = 2
           CharCase = ecUppercase
@@ -2865,9 +2824,9 @@ object frmNewQSO: TfrmNewQSO
           AnchorSideTop.Control = lblAward
           AnchorSideTop.Side = asrBottom
           Left = 392
-          Height = 25
+          Height = 33
           Hint = 'Award, max length 50'
-          Top = 116
+          Top = 126
           Width = 140
           BorderSpacing.Left = 5
           BorderSpacing.Top = 2
@@ -2885,9 +2844,9 @@ object frmNewQSO: TfrmNewQSO
           AnchorSideTop.Control = lblWazEdit
           AnchorSideTop.Side = asrBottom
           Left = 59
-          Height = 25
+          Height = 33
           Hint = 'ITU, must be a number (integer)'
-          Top = 116
+          Top = 126
           Width = 42
           HelpType = htKeyword
           BorderSpacing.Left = 5
@@ -2906,9 +2865,9 @@ object frmNewQSO: TfrmNewQSO
           AnchorSideTop.Control = lblCounty
           AnchorSideTop.Side = asrBottom
           Left = 259
-          Height = 25
+          Height = 33
           Hint = 'County, max length 30'
-          Top = 116
+          Top = 126
           Width = 128
           BorderSpacing.Left = 53
           BorderSpacing.Top = 2
@@ -2926,14 +2885,14 @@ object frmNewQSO: TfrmNewQSO
           AnchorSideTop.Control = edtCall
           AnchorSideTop.Side = asrCenter
           Left = 132
-          Height = 25
-          Top = 22
+          Height = 33
+          Top = 20
           Width = 100
           AutoComplete = True
           AutoCompleteText = [cbactEnabled, cbactEndOfLineComplete, cbactSearchAscending]
           BorderSpacing.Left = 5
           BorderSpacing.Top = 2
-          ItemHeight = 17
+          ItemHeight = 0
           OnChange = cmbFreqChange
           OnEnter = cmbFreqEnter
           OnExit = cmbFreqExit
@@ -2946,9 +2905,9 @@ object frmNewQSO: TfrmNewQSO
           AnchorSideTop.Control = lblQSLVia
           AnchorSideTop.Side = asrBottom
           Left = 402
-          Height = 25
+          Height = 33
           Hint = 'QSl via/QSL Manager, max length 30'
-          Top = 163
+          Top = 179
           Width = 96
           BorderSpacing.Left = 5
           BorderSpacing.Top = 2
@@ -2967,7 +2926,7 @@ object frmNewQSO: TfrmNewQSO
           AnchorSideTop.Side = asrBottom
           Left = 78
           Height = 27
-          Top = 163
+          Top = 179
           Width = 24
           BorderSpacing.Left = 2
           BorderSpacing.Top = 2
@@ -2983,7 +2942,7 @@ object frmNewQSO: TfrmNewQSO
           AnchorSideTop.Side = asrBottom
           Left = 500
           Height = 27
-          Top = 163
+          Top = 179
           Width = 24
           BorderSpacing.Left = 2
           BorderSpacing.Top = 2
@@ -2993,15 +2952,15 @@ object frmNewQSO: TfrmNewQSO
           TabOrder = 21
         end
         object edtDate: TEdit
-          AnchorSideLeft.Control = edtDXCCRef
+          AnchorSideLeft.Control = lblDate
+          AnchorSideTop.Control = lblDate
           AnchorSideTop.Side = asrBottom
-          AnchorSideBottom.Control = edtStartTime
           AnchorSideBottom.Side = asrBottom
           Left = 12
-          Height = 25
-          Top = 277
+          Height = 33
+          Top = 232
           Width = 100
-          Anchors = [akLeft, akBottom]
+          BorderSpacing.Top = 2
           OnEnter = edtDateEnter
           OnExit = edtDateExit
           OnKeyDown = edtDateKeyDown
@@ -3011,15 +2970,15 @@ object frmNewQSO: TfrmNewQSO
         object edtStartTime: TEdit
           AnchorSideLeft.Control = edtDate
           AnchorSideLeft.Side = asrBottom
-          AnchorSideTop.Side = asrCenter
-          AnchorSideBottom.Control = edtEndTime
+          AnchorSideTop.Control = lblStartTime
+          AnchorSideTop.Side = asrBottom
           AnchorSideBottom.Side = asrBottom
-          Left = 117
-          Height = 25
-          Top = 277
+          Left = 118
+          Height = 33
+          Top = 232
           Width = 55
-          Anchors = [akLeft, akBottom]
-          BorderSpacing.Left = 5
+          BorderSpacing.Left = 6
+          BorderSpacing.Top = 2
           OnEnter = edtStartTimeEnter
           OnExit = edtStartTimeExit
           OnKeyDown = edtStartTimeKeyDown
@@ -3029,15 +2988,15 @@ object frmNewQSO: TfrmNewQSO
         object edtEndTime: TEdit
           AnchorSideLeft.Control = edtStartTime
           AnchorSideLeft.Side = asrBottom
-          AnchorSideTop.Side = asrCenter
-          AnchorSideBottom.Control = mComment
+          AnchorSideTop.Control = lblEndTime
+          AnchorSideTop.Side = asrBottom
           AnchorSideBottom.Side = asrBottom
-          Left = 177
-          Height = 25
-          Top = 277
+          Left = 179
+          Height = 33
+          Top = 232
           Width = 55
-          Anchors = [akLeft, akBottom]
-          BorderSpacing.Left = 5
+          BorderSpacing.Left = 6
+          BorderSpacing.Top = 2
           OnEnter = edtEndTimeEnter
           OnExit = edtEndTimeExit
           OnKeyDown = edtEndTimeKeyDown
@@ -3050,14 +3009,14 @@ object frmNewQSO: TfrmNewQSO
           AnchorSideTop.Control = lblIOTA
           AnchorSideTop.Side = asrBottom
           Left = 106
-          Height = 25
+          Height = 33
           Hint = 'IOTA, max length 6'
-          Top = 116
+          Top = 126
           Width = 100
           BorderSpacing.Left = 5
           BorderSpacing.Top = 2
           CharCase = ecUppercase
-          ItemHeight = 17
+          ItemHeight = 0
           MaxLength = 6
           OnChange = cmbIOTAChange
           OnEnter = cmbIOTAEnter
@@ -3073,9 +3032,9 @@ object frmNewQSO: TfrmNewQSO
           AnchorSideTop.Control = lblCommentToQSO
           AnchorSideTop.Side = asrBottom
           Left = 107
-          Height = 25
+          Height = 33
           Hint = 'Comment/Remarks, max length 200'
-          Top = 163
+          Top = 179
           Width = 290
           BorderSpacing.Left = 5
           BorderSpacing.Top = 2
@@ -3091,9 +3050,9 @@ object frmNewQSO: TfrmNewQSO
           AnchorSideLeft.Side = asrBottom
           AnchorSideTop.Control = cmbIOTA
           Left = 211
-          Height = 25
+          Height = 33
           Hint = 'State, max length 4'
-          Top = 116
+          Top = 126
           Width = 42
           BorderSpacing.Left = 5
           CharCase = ecUppercase
@@ -3111,10 +3070,10 @@ object frmNewQSO: TfrmNewQSO
           AnchorSideTop.Side = asrCenter
           AnchorSideRight.Control = cmbMode
           AnchorSideRight.Side = asrBottom
-          Left = 283
+          Left = 285
           Height = 23
-          Top = 0
-          Width = 65
+          Top = -1
+          Width = 63
           Anchors = [akTop, akRight]
           BorderSpacing.Left = 4
           Caption = 'AUTO'
@@ -3128,9 +3087,9 @@ object frmNewQSO: TfrmNewQSO
           AnchorSideLeft.Side = asrBottom
           AnchorSideTop.Control = edtEndTime
           AnchorSideTop.Side = asrCenter
-          Left = 235
+          Left = 237
           Height = 20
-          Top = 279
+          Top = 238
           Width = 20
           Action = acRefreshTime
           AutoSize = True
@@ -3139,13 +3098,13 @@ object frmNewQSO: TfrmNewQSO
           ParentShowHint = False
         end
         object pgDetails: TPageControl
-          AnchorSideTop.Control = pnlOffline
+          AnchorSideTop.Control = pnlSbtn0
           AnchorSideTop.Side = asrBottom
           AnchorSideRight.Side = asrBottom
           AnchorSideBottom.Side = asrBottom
           Left = 0
-          Height = 204
-          Top = 332
+          Height = 178
+          Top = 354
           Width = 759
           ActivePage = tabDXCCStat
           Align = alBottom
@@ -3157,15 +3116,15 @@ object frmNewQSO: TfrmNewQSO
             AnchorSideRight.Side = asrBottom
             AnchorSideBottom.Side = asrBottom
             Caption = 'DXCC statistic'
-            ClientHeight = 173
-            ClientWidth = 755
+            ClientHeight = 147
+            ClientWidth = 749
             object sgrdStatistic: TStringGrid
               AnchorSideRight.Side = asrBottom
               AnchorSideBottom.Side = asrBottom
               Left = 0
-              Height = 173
+              Height = 147
               Top = 0
-              Width = 755
+              Width = 749
               Align = alClient
               AutoFillColumns = True
               ColCount = 2
@@ -3179,8 +3138,8 @@ object frmNewQSO: TfrmNewQSO
               TitleFont.Height = 8
               TitleStyle = tsNative
               ColWidths = (
-                376
-                377
+                373
+                374
               )
             end
           end
@@ -3188,7 +3147,7 @@ object frmNewQSO: TfrmNewQSO
             AnchorSideBottom.Side = asrBottom
             Caption = 'Satellite'
             ClientHeight = 147
-            ClientWidth = 758
+            ClientWidth = 749
             object cmbPropagation: TComboBox
               AnchorSideLeft.Control = lblStatellite
               AnchorSideTop.Control = lblPropagation
@@ -3198,7 +3157,7 @@ object frmNewQSO: TfrmNewQSO
               Top = 80
               Width = 272
               BorderSpacing.Top = 3
-              ItemHeight = 25
+              ItemHeight = 0
               OnChange = cmbPropagationChange
               ParentFont = False
               Style = csDropDownList
@@ -3239,7 +3198,7 @@ object frmNewQSO: TfrmNewQSO
               Top = 24
               Width = 272
               BorderSpacing.Top = 3
-              ItemHeight = 25
+              ItemHeight = 0
               OnChange = cmbSatelliteChange
               ParentFont = False
               Style = csDropDownList
@@ -3320,7 +3279,7 @@ object frmNewQSO: TfrmNewQSO
             AnchorSideBottom.Side = asrBottom
             Caption = 'LO Config'
             ClientHeight = 147
-            ClientWidth = 758
+            ClientWidth = 749
             object cbTxLo: TCheckBox
               Left = 8
               Height = 23
@@ -3402,23 +3361,23 @@ object frmNewQSO: TfrmNewQSO
           AnchorSideRight.Control = pnlQSOinput
           AnchorSideRight.Side = asrBottom
           Left = 555
-          Height = 192
+          Height = 188
           Top = 0
           Width = 204
           Anchors = [akTop, akLeft, akRight, akBottom]
           BorderSpacing.Left = 20
           Caption = 'Contest'
-          ClientHeight = 166
-          ClientWidth = 198
+          ClientHeight = 170
+          ClientWidth = 202
           TabOrder = 28
           Visible = False
           object lblContestName: TLabel
             AnchorSideLeft.Control = gbContest
             AnchorSideTop.Control = gbContest
             Left = 3
-            Height = 17
+            Height = 15
             Top = 3
-            Width = 92
+            Width = 87
             BorderSpacing.Left = 3
             BorderSpacing.Top = 3
             Caption = 'Contestname'
@@ -3429,9 +3388,9 @@ object frmNewQSO: TfrmNewQSO
             AnchorSideTop.Control = edtContestName
             AnchorSideTop.Side = asrBottom
             Left = 3
-            Height = 17
-            Top = 54
-            Width = 71
+            Height = 15
+            Top = 60
+            Width = 69
             BorderSpacing.Top = 6
             Caption = 'Serial sent'
             ParentColor = False
@@ -3441,9 +3400,9 @@ object frmNewQSO: TfrmNewQSO
             AnchorSideTop.Control = edtContestSerialSent
             AnchorSideTop.Side = asrBottom
             Left = 3
-            Height = 17
-            Top = 105
-            Width = 71
+            Height = 15
+            Top = 117
+            Width = 69
             BorderSpacing.Top = 6
             Caption = 'Serial rcvd'
             ParentColor = False
@@ -3452,10 +3411,10 @@ object frmNewQSO: TfrmNewQSO
             AnchorSideLeft.Control = lblContestSerialSent
             AnchorSideLeft.Side = asrBottom
             AnchorSideTop.Control = lblContestSerialSent
-            Left = 83
-            Height = 17
-            Top = 54
-            Width = 62
+            Left = 81
+            Height = 15
+            Top = 60
+            Width = 59
             BorderSpacing.Left = 9
             Caption = 'Msg sent'
             ParentColor = False
@@ -3463,10 +3422,10 @@ object frmNewQSO: TfrmNewQSO
           object lblContestExchangeMessageReceived: TLabel
             AnchorSideLeft.Control = lblContestExchangeMessageSent
             AnchorSideTop.Control = lblContestSerialReceived
-            Left = 83
-            Height = 17
-            Top = 105
-            Width = 61
+            Left = 81
+            Height = 15
+            Top = 117
+            Width = 59
             Caption = 'Msg rcvd'
             ParentColor = False
           end
@@ -3477,10 +3436,10 @@ object frmNewQSO: TfrmNewQSO
             AnchorSideRight.Control = gbContest
             AnchorSideRight.Side = asrBottom
             Left = 3
-            Height = 25
+            Height = 33
             Hint = 'name of contest, max 40 characters allowed'
-            Top = 23
-            Width = 192
+            Top = 21
+            Width = 196
             Anchors = [akTop, akLeft, akRight]
             BorderSpacing.Top = 3
             BorderSpacing.Right = 3
@@ -3495,9 +3454,9 @@ object frmNewQSO: TfrmNewQSO
             AnchorSideTop.Control = lblContestSerialSent
             AnchorSideTop.Side = asrBottom
             Left = 3
-            Height = 25
+            Height = 33
             Hint = 'serial number sent of contest, max 6 characters'
-            Top = 74
+            Top = 78
             Width = 64
             BorderSpacing.Top = 3
             MaxLength = 6
@@ -3510,9 +3469,9 @@ object frmNewQSO: TfrmNewQSO
             AnchorSideTop.Control = lblContestSerialReceived
             AnchorSideTop.Side = asrBottom
             Left = 3
-            Height = 25
+            Height = 33
             Hint = 'rserial number received of contest, max 6 characters'
-            Top = 128
+            Top = 138
             Width = 64
             BorderSpacing.Top = 6
             MaxLength = 6
@@ -3526,11 +3485,11 @@ object frmNewQSO: TfrmNewQSO
             AnchorSideTop.Side = asrCenter
             AnchorSideRight.Control = gbContest
             AnchorSideRight.Side = asrBottom
-            Left = 83
-            Height = 25
+            Left = 81
+            Height = 33
             Hint = 'contest exchange message sent, max 50 characters'
-            Top = 74
-            Width = 112
+            Top = 78
+            Width = 118
             Anchors = [akTop, akLeft, akRight]
             BorderSpacing.Top = 6
             BorderSpacing.Right = 3
@@ -3546,11 +3505,11 @@ object frmNewQSO: TfrmNewQSO
             AnchorSideTop.Side = asrCenter
             AnchorSideRight.Control = gbContest
             AnchorSideRight.Side = asrBottom
-            Left = 83
-            Height = 25
+            Left = 81
+            Height = 33
             Hint = 'contest exchange message received, max 50 characters'
-            Top = 128
-            Width = 112
+            Top = 138
+            Width = 118
             Anchors = [akTop, akLeft, akRight]
             BorderSpacing.Right = 3
             MaxLength = 50
@@ -3566,9 +3525,9 @@ object frmNewQSO: TfrmNewQSO
           AnchorSideTop.Control = lblItuEdit
           AnchorSideTop.Side = asrCenter
           Left = 211
-          Height = 17
-          Top = 97
-          Width = 33
+          Height = 15
+          Top = 109
+          Width = 29
           BorderSpacing.Left = 5
           Caption = 'DOK'
           ParentColor = False
@@ -3581,9 +3540,9 @@ object frmNewQSO: TfrmNewQSO
           AnchorSideLeft.Side = asrBottom
           AnchorSideTop.Control = cmbIOTA
           Left = 211
-          Height = 25
+          Height = 33
           Hint = 'DOK, max length 12'
-          Top = 116
+          Top = 126
           Width = 42
           BorderSpacing.Left = 5
           CharCase = ecUppercase
@@ -3598,13 +3557,13 @@ object frmNewQSO: TfrmNewQSO
         end
         object pnlOffline: TPanel
           AnchorSideLeft.Control = edtDate
-          AnchorSideTop.Control = mComment
+          AnchorSideTop.Control = edtDate
           AnchorSideTop.Side = asrBottom
           Left = 12
           Height = 25
-          Top = 304
+          Top = 271
           Width = 91
-          BorderSpacing.Top = 2
+          BorderSpacing.Top = 6
           BevelOuter = bvNone
           ClientHeight = 25
           ClientWidth = 91
@@ -3618,7 +3577,7 @@ object frmNewQSO: TfrmNewQSO
             Left = 0
             Height = 23
             Top = 1
-            Width = 74
+            Width = 70
             BorderSpacing.CellAlignHorizontal = ccaRightBottom
             BorderSpacing.CellAlignVertical = ccaRightBottom
             Caption = 'Offline'
@@ -3626,28 +3585,13 @@ object frmNewQSO: TfrmNewQSO
             TabOrder = 0
           end
         end
-        object lbleQslRcvdDate: TLabel
-          AnchorSideLeft.Control = edtDXCCRef
-          AnchorSideTop.Control = lblQSLRcvdDate
-          AnchorSideTop.Side = asrBottom
-          Left = 12
-          Height = 17
-          Top = 211
-          Width = 90
-          BorderSpacing.Top = 3
-          Caption = 'eQSL rcvd on'
-          Font.Color = clGreen
-          ParentColor = False
-          ParentFont = False
-          Visible = False
-        end
         object pnlSbtn0: TPanel
           AnchorSideLeft.Side = asrBottom
           AnchorSideTop.Control = pnlSbtn1
           AnchorSideRight.Control = pnlSbtn1
           Left = 360
           Height = 25
-          Top = 304
+          Top = 326
           Width = 25
           Anchors = [akTop, akRight]
           BevelOuter = bvNone
@@ -3712,7 +3656,7 @@ object frmNewQSO: TfrmNewQSO
           AnchorSideRight.Control = pnlSbtn2
           Left = 385
           Height = 25
-          Top = 304
+          Top = 326
           Width = 25
           Anchors = [akTop, akRight]
           BevelOuter = bvNone
@@ -3777,7 +3721,7 @@ object frmNewQSO: TfrmNewQSO
           AnchorSideRight.Control = pnlSbtn3
           Left = 410
           Height = 25
-          Top = 304
+          Top = 326
           Width = 25
           Anchors = [akTop, akRight]
           BevelOuter = bvNone
@@ -3882,7 +3826,7 @@ object frmNewQSO: TfrmNewQSO
           AnchorSideRight.Control = pnlSbtn4
           Left = 435
           Height = 25
-          Top = 304
+          Top = 326
           Width = 25
           Anchors = [akTop, akRight]
           BevelOuter = bvNone
@@ -3946,7 +3890,7 @@ object frmNewQSO: TfrmNewQSO
           AnchorSideRight.Control = pnlSbtn5
           Left = 460
           Height = 25
-          Top = 304
+          Top = 326
           Width = 25
           Anchors = [akTop, akRight]
           BevelOuter = bvNone
@@ -4010,7 +3954,7 @@ object frmNewQSO: TfrmNewQSO
           AnchorSideRight.Control = pnlSbtn6
           Left = 485
           Height = 25
-          Top = 304
+          Top = 326
           Width = 25
           Anchors = [akTop, akRight]
           BevelOuter = bvNone
@@ -4077,7 +4021,7 @@ object frmNewQSO: TfrmNewQSO
           AnchorSideRight.Side = asrBottom
           Left = 510
           Height = 25
-          Top = 304
+          Top = 326
           Width = 25
           Anchors = [akTop, akRight]
           BorderSpacing.Top = 2
@@ -4144,13 +4088,13 @@ object frmNewQSO: TfrmNewQSO
       AnchorSideRight.Side = asrBottom
       AnchorSideBottom.Side = asrBottom
       Left = 760
-      Height = 538
-      Top = 27
+      Height = 534
+      Top = 35
       Width = 271
       Align = alRight
       BevelOuter = bvNone
       ChildSizing.LeftRightSpacing = 484
-      ClientHeight = 538
+      ClientHeight = 534
       ClientWidth = 271
       TabOrder = 1
       object gbDXCCdata: TGroupBox
@@ -4164,18 +4108,18 @@ object frmNewQSO: TfrmNewQSO
         BorderSpacing.Top = 4
         BorderSpacing.Bottom = 4
         Caption = 'DXCC info'
-        ClientHeight = 458
-        ClientWidth = 252
+        ClientHeight = 466
+        ClientWidth = 256
         ParentFont = False
         TabOrder = 0
         object lblDXCCCaption: TLabel
           AnchorSideLeft.Control = lblContCaption
           AnchorSideTop.Control = lblContCaption
           AnchorSideTop.Side = asrBottom
-          Left = 135
-          Height = 17
-          Top = 115
-          Width = 42
+          Left = 131
+          Height = 15
+          Top = 113
+          Width = 41
           BorderSpacing.Top = 5
           Caption = 'DXCC:'
           ParentColor = False
@@ -4186,9 +4130,9 @@ object frmNewQSO: TfrmNewQSO
           AnchorSideTop.Control = pnlDXCCCountry
           AnchorSideTop.Side = asrBottom
           Left = 7
-          Height = 17
+          Height = 15
           Top = 93
-          Width = 37
+          Width = 35
           BorderSpacing.Left = 7
           BorderSpacing.Top = 5
           Caption = 'WAZ:'
@@ -4201,9 +4145,9 @@ object frmNewQSO: TfrmNewQSO
           AnchorSideTop.Control = lblWAZCaption
           AnchorSideTop.Side = asrBottom
           Left = 7
-          Height = 17
-          Top = 115
-          Width = 27
+          Height = 15
+          Top = 113
+          Width = 26
           BorderSpacing.Top = 5
           Caption = 'ITU:'
           Layout = tlBottom
@@ -4215,10 +4159,10 @@ object frmNewQSO: TfrmNewQSO
           AnchorSideLeft.Side = asrBottom
           AnchorSideTop.Control = pnlDXCCCountry
           AnchorSideTop.Side = asrBottom
-          Left = 135
-          Height = 17
+          Left = 131
+          Height = 15
           Top = 93
-          Width = 37
+          Width = 34
           BorderSpacing.Left = 57
           BorderSpacing.Top = 5
           Caption = 'Cont:'
@@ -4232,9 +4176,9 @@ object frmNewQSO: TfrmNewQSO
           AnchorSideBottom.Control = lblWAZCaption
           AnchorSideBottom.Side = asrBottom
           Left = 47
-          Height = 17
+          Height = 15
           Top = 93
-          Width = 31
+          Width = 27
           Anchors = [akLeft, akBottom]
           BorderSpacing.Left = 40
           BorderSpacing.Top = 5
@@ -4249,9 +4193,9 @@ object frmNewQSO: TfrmNewQSO
           AnchorSideBottom.Control = lblITUCaption
           AnchorSideBottom.Side = asrBottom
           Left = 47
-          Height = 17
-          Top = 115
-          Width = 31
+          Height = 15
+          Top = 113
+          Width = 27
           Anchors = [akLeft, akBottom]
           BorderSpacing.Top = 5
           Caption = 'AAA'
@@ -4264,10 +4208,10 @@ object frmNewQSO: TfrmNewQSO
           AnchorSideTop.Side = asrBottom
           AnchorSideBottom.Control = lblDXCCCaption
           AnchorSideBottom.Side = asrBottom
-          Left = 181
-          Height = 17
-          Top = 115
-          Width = 31
+          Left = 174
+          Height = 15
+          Top = 113
+          Width = 27
           Anchors = [akLeft, akBottom]
           BorderSpacing.Top = 5
           Caption = 'AAA'
@@ -4281,10 +4225,10 @@ object frmNewQSO: TfrmNewQSO
           AnchorSideTop.Side = asrCenter
           AnchorSideBottom.Control = lblContCaption
           AnchorSideBottom.Side = asrBottom
-          Left = 181
-          Height = 17
+          Left = 174
+          Height = 15
           Top = 93
-          Width = 31
+          Width = 27
           Anchors = [akLeft, akBottom]
           BorderSpacing.Left = 9
           Caption = 'AAA'
@@ -4297,9 +4241,9 @@ object frmNewQSO: TfrmNewQSO
           AnchorSideTop.Control = lblITUCaption
           AnchorSideTop.Side = asrBottom
           Left = 7
-          Height = 17
-          Top = 137
-          Width = 29
+          Height = 15
+          Top = 133
+          Width = 28
           BorderSpacing.Top = 5
           Caption = 'LAT:'
           Layout = tlBottom
@@ -4310,10 +4254,10 @@ object frmNewQSO: TfrmNewQSO
           AnchorSideLeft.Control = lblContCaption
           AnchorSideTop.Control = lblDXCCCaption
           AnchorSideTop.Side = asrBottom
-          Left = 135
-          Height = 17
-          Top = 137
-          Width = 44
+          Left = 131
+          Height = 15
+          Top = 133
+          Width = 41
           BorderSpacing.Top = 5
           Caption = 'LONG:'
           Layout = tlBottom
@@ -4325,9 +4269,9 @@ object frmNewQSO: TfrmNewQSO
           AnchorSideBottom.Control = lblLatCaption
           AnchorSideBottom.Side = asrBottom
           Left = 47
-          Height = 17
-          Top = 137
-          Width = 31
+          Height = 15
+          Top = 133
+          Width = 27
           Anchors = [akLeft, akBottom]
           Caption = 'AAA'
           Layout = tlBottom
@@ -4339,10 +4283,10 @@ object frmNewQSO: TfrmNewQSO
           AnchorSideTop.Side = asrCenter
           AnchorSideBottom.Control = lblLongCaption
           AnchorSideBottom.Side = asrBottom
-          Left = 181
-          Height = 17
-          Top = 137
-          Width = 31
+          Left = 174
+          Height = 15
+          Top = 133
+          Width = 27
           Anchors = [akLeft, akBottom]
           Caption = 'AAA'
           Layout = tlBottom
@@ -4354,9 +4298,9 @@ object frmNewQSO: TfrmNewQSO
           AnchorSideTop.Control = lblLatCaption
           AnchorSideTop.Side = asrBottom
           Left = 7
-          Height = 17
-          Top = 159
-          Width = 34
+          Height = 15
+          Top = 153
+          Width = 33
           BorderSpacing.Top = 5
           Caption = 'DIST:'
           Layout = tlBottom
@@ -4369,9 +4313,9 @@ object frmNewQSO: TfrmNewQSO
           AnchorSideBottom.Control = lblDistCaption
           AnchorSideBottom.Side = asrBottom
           Left = 47
-          Height = 17
-          Top = 159
-          Width = 31
+          Height = 15
+          Top = 153
+          Width = 27
           Anchors = [akLeft, akBottom]
           Caption = 'AAA'
           Layout = tlBottom
@@ -4383,10 +4327,10 @@ object frmNewQSO: TfrmNewQSO
           AnchorSideLeft.Control = lblContCaption
           AnchorSideTop.Control = lblLongCaption
           AnchorSideTop.Side = asrBottom
-          Left = 135
-          Height = 17
-          Top = 159
-          Width = 40
+          Left = 131
+          Height = 15
+          Top = 153
+          Width = 38
           BorderSpacing.Top = 5
           Caption = 'AZIM:'
           Layout = tlBottom
@@ -4397,10 +4341,10 @@ object frmNewQSO: TfrmNewQSO
           AnchorSideTop.Side = asrCenter
           AnchorSideBottom.Control = lblAzim
           AnchorSideBottom.Side = asrBottom
-          Left = 181
-          Height = 17
-          Top = 159
-          Width = 31
+          Left = 174
+          Height = 15
+          Top = 153
+          Width = 27
           Anchors = [akLeft, akBottom]
           Caption = 'AAA'
           Layout = tlBottom
@@ -4414,7 +4358,7 @@ object frmNewQSO: TfrmNewQSO
           AnchorSideTop.Side = asrBottom
           Left = 7
           Height = 20
-          Top = 220
+          Top = 212
           Width = 162
           AutoSize = False
           BorderSpacing.Top = 6
@@ -4430,9 +4374,9 @@ object frmNewQSO: TfrmNewQSO
           AnchorSideBottom.Control = lblHisTime
           AnchorSideBottom.Side = asrBottom
           Left = 181
-          Height = 17
-          Top = 223
-          Width = 48
+          Height = 15
+          Top = 217
+          Width = 44
           Anchors = [akLeft, akBottom]
           BorderSpacing.Left = 12
           Caption = 'GE/GM'
@@ -4447,7 +4391,7 @@ object frmNewQSO: TfrmNewQSO
           AnchorSideTop.Side = asrBottom
           Left = 7
           Height = 22
-          Top = 192
+          Top = 184
           Width = 23
           BorderSpacing.Top = 16
           Flat = True
@@ -4492,9 +4436,9 @@ object frmNewQSO: TfrmNewQSO
           AnchorSideTop.Side = asrCenter
           AnchorSideBottom.Control = SpeedButton3
           AnchorSideBottom.Side = asrBottom
-          Left = 136
+          Left = 132
           Height = 22
-          Top = 268
+          Top = 258
           Width = 23
           Anchors = [akLeft, akBottom]
           BorderSpacing.Left = 1
@@ -4534,7 +4478,7 @@ object frmNewQSO: TfrmNewQSO
           AnchorSideTop.Side = asrBottom
           Left = 7
           Height = 22
-          Top = 268
+          Top = 258
           Width = 23
           BorderSpacing.Top = 5
           Flat = True
@@ -4579,9 +4523,9 @@ object frmNewQSO: TfrmNewQSO
           AnchorSideTop.Side = asrCenter
           AnchorSideBottom.Control = btnSunRise
           AnchorSideBottom.Side = asrBottom
-          Left = 135
+          Left = 131
           Height = 22
-          Top = 192
+          Top = 184
           Width = 23
           Anchors = [akLeft, akBottom]
           Flat = True
@@ -4621,9 +4565,9 @@ object frmNewQSO: TfrmNewQSO
           AnchorSideBottom.Control = SpeedButton3
           AnchorSideBottom.Side = asrBottom
           Left = 30
-          Height = 17
-          Top = 273
-          Width = 94
+          Height = 15
+          Top = 265
+          Width = 90
           Anchors = [akLeft, akBottom]
           Caption = 'lblLocSunRise'
           Layout = tlBottom
@@ -4636,10 +4580,10 @@ object frmNewQSO: TfrmNewQSO
           AnchorSideTop.Side = asrCenter
           AnchorSideBottom.Control = SpeedButton3
           AnchorSideBottom.Side = asrBottom
-          Left = 164
-          Height = 17
-          Top = 273
-          Width = 88
+          Left = 160
+          Height = 15
+          Top = 265
+          Width = 83
           Anchors = [akLeft, akBottom]
           BorderSpacing.Left = 5
           Caption = 'lblLocSunSet'
@@ -4654,9 +4598,9 @@ object frmNewQSO: TfrmNewQSO
           AnchorSideBottom.Control = btnSunRise
           AnchorSideBottom.Side = asrBottom
           Left = 30
-          Height = 17
-          Top = 197
-          Width = 92
+          Height = 15
+          Top = 191
+          Width = 87
           Anchors = [akLeft, akBottom]
           BorderSpacing.Top = 5
           Caption = 'lblTarSunRise'
@@ -4670,10 +4614,10 @@ object frmNewQSO: TfrmNewQSO
           AnchorSideTop.Side = asrCenter
           AnchorSideBottom.Control = btnSunRise
           AnchorSideBottom.Side = asrBottom
-          Left = 163
-          Height = 17
-          Top = 197
-          Width = 86
+          Left = 159
+          Height = 15
+          Top = 191
+          Width = 80
           Anchors = [akLeft, akBottom]
           BorderSpacing.Left = 5
           Caption = 'lblTarSunSet'
@@ -4686,9 +4630,9 @@ object frmNewQSO: TfrmNewQSO
           AnchorSideTop.Control = lblHisTime
           AnchorSideTop.Side = asrBottom
           Left = 7
-          Height = 17
-          Top = 246
-          Width = 40
+          Height = 15
+          Top = 238
+          Width = 38
           BorderSpacing.Top = 6
           Caption = 'Local:'
           Layout = tlBottom
@@ -4701,12 +4645,12 @@ object frmNewQSO: TfrmNewQSO
           Left = 0
           Height = 88
           Top = 0
-          Width = 252
+          Width = 256
           Align = alTop
           BevelOuter = bvNone
           Caption = 'pnlmCountry'
           ClientHeight = 88
-          ClientWidth = 252
+          ClientWidth = 256
           TabOrder = 0
           object mCountry: TMemo
             AnchorSideLeft.Control = pnlDXCCCountry
@@ -4714,7 +4658,7 @@ object frmNewQSO: TfrmNewQSO
             Left = 0
             Height = 88
             Top = 0
-            Width = 252
+            Width = 256
             Align = alClient
             ParentFont = False
             TabOrder = 0
@@ -4727,9 +4671,9 @@ object frmNewQSO: TfrmNewQSO
           AnchorSideTop.Side = asrBottom
           AnchorSideBottom.Side = asrBottom
           Left = 0
-          Height = 137
-          Top = 321
-          Width = 252
+          Height = 157
+          Top = 309
+          Width = 256
           Align = alBottom
           Anchors = [akTop, akLeft, akRight]
           ParentFont = False
@@ -4741,9 +4685,9 @@ object frmNewQSO: TfrmNewQSO
           AnchorSideTop.Control = SpeedButton3
           AnchorSideTop.Side = asrBottom
           Left = 3
-          Height = 17
-          Top = 302
-          Width = 64
+          Height = 15
+          Top = 292
+          Width = 61
           BorderSpacing.Left = 3
           BorderSpacing.Top = 12
           BorderSpacing.Bottom = 2
@@ -4756,9 +4700,9 @@ object frmNewQSO: TfrmNewQSO
         AnchorSideBottom.Control = pnlDXCCinfo
         AnchorSideBottom.Side = asrBottom
         Left = 6
-        Height = 29
-        Top = 503
-        Width = 132
+        Height = 35
+        Top = 493
+        Width = 130
         Anchors = [akLeft, akBottom]
         AutoSize = True
         BorderSpacing.Bottom = 6
@@ -4772,10 +4716,10 @@ object frmNewQSO: TfrmNewQSO
         AnchorSideRight.Side = asrBottom
         AnchorSideBottom.Control = pnlDXCCinfo
         AnchorSideBottom.Side = asrBottom
-        Left = 150
-        Height = 29
-        Top = 503
-        Width = 114
+        Left = 151
+        Height = 35
+        Top = 493
+        Width = 113
         Anchors = [akRight, akBottom]
         AutoSize = True
         BorderSpacing.Bottom = 6
@@ -4789,13 +4733,13 @@ object frmNewQSO: TfrmNewQSO
     object pnlProfiles: TPanel
       AnchorSideRight.Side = asrBottom
       Left = 1
-      Height = 26
+      Height = 34
       Top = 1
       Width = 1030
       Align = alTop
       AutoSize = True
       BevelOuter = bvNone
-      ClientHeight = 26
+      ClientHeight = 34
       ClientWidth = 1030
       TabOrder = 2
       object lblQSONr: TLabel
@@ -4804,10 +4748,10 @@ object frmNewQSO: TfrmNewQSO
         AnchorSideTop.Side = asrCenter
         AnchorSideBottom.Control = lblQSONrDesc
         AnchorSideBottom.Side = asrBottom
-        Left = 70
-        Height = 17
-        Top = 5
-        Width = 9
+        Left = 67
+        Height = 15
+        Top = 10
+        Width = 8
         Anchors = [akLeft, akBottom]
         BorderSpacing.Left = 6
         Caption = '0'
@@ -4820,9 +4764,9 @@ object frmNewQSO: TfrmNewQSO
         AnchorSideTop.Control = pnlProfiles
         AnchorSideTop.Side = asrCenter
         Left = 12
-        Height = 17
-        Top = 5
-        Width = 52
+        Height = 15
+        Top = 10
+        Width = 49
         BorderSpacing.Left = 12
         Caption = 'QSO nr.'
         Layout = tlBottom
@@ -4835,10 +4779,10 @@ object frmNewQSO: TfrmNewQSO
         AnchorSideTop.Control = pnlProfiles
         AnchorSideTop.Side = asrCenter
         AnchorSideBottom.Side = asrBottom
-        Left = 485
-        Height = 17
-        Top = 5
-        Width = 129
+        Left = 477
+        Height = 15
+        Top = 10
+        Width = 123
         Alignment = taRightJustify
         BorderSpacing.Left = 10
         Caption = 'New band country!'
@@ -4853,10 +4797,10 @@ object frmNewQSO: TfrmNewQSO
         AnchorSideTop.Control = pnlProfiles
         AnchorSideTop.Side = asrCenter
         AnchorSideBottom.Side = asrBottom
-        Left = 624
-        Height = 17
-        Top = 5
-        Width = 121
+        Left = 610
+        Height = 15
+        Top = 10
+        Width = 115
         BorderSpacing.Left = 10
         Caption = 'Ambiguous prefix'
         Font.Color = clRed
@@ -4871,10 +4815,10 @@ object frmNewQSO: TfrmNewQSO
         AnchorSideTop.Control = pnlProfiles
         AnchorSideTop.Side = asrCenter
         AnchorSideBottom.Side = asrBottom
-        Left = 99
-        Height = 17
-        Top = 5
-        Width = 90
+        Left = 95
+        Height = 15
+        Top = 10
+        Width = 86
         BorderSpacing.Left = 20
         Caption = 'QTH profile:  '
         Layout = tlBottom
@@ -4886,12 +4830,12 @@ object frmNewQSO: TfrmNewQSO
         AnchorSideLeft.Side = asrBottom
         AnchorSideTop.Control = pnlProfiles
         AnchorSideTop.Side = asrCenter
-        Left = 194
-        Height = 25
+        Left = 186
+        Height = 33
         Top = 1
         Width = 281
         BorderSpacing.Left = 5
-        ItemHeight = 17
+        ItemHeight = 0
         OnChange = cmbProfilesChange
         ParentFont = False
         TabOrder = 0
@@ -4902,8 +4846,8 @@ object frmNewQSO: TfrmNewQSO
       AnchorSideRight.Side = asrBottom
       AnchorSideBottom.Side = asrBottom
       Left = 1
-      Height = 22
-      Top = 565
+      Height = 18
+      Top = 569
       Width = 1030
       Panels = <      
         item
@@ -4924,7 +4868,7 @@ object frmNewQSO: TfrmNewQSO
   object dbgrdQSOBefore: TDBGrid
     AnchorSideRight.Side = asrBottom
     Left = 0
-    Height = 99
+    Height = 96
     Top = 0
     Width = 1032
     Align = alClient

--- a/src/fNewQSO.pas
+++ b/src/fNewQSO.pas
@@ -21,7 +21,7 @@ uses
   LCLType, RTTICtrls, httpsend, Menus, ActnList, process, db,
   uCWKeying, ipc, baseunix, dLogUpload, blcksock, dateutils,
   fMonWsjtx, fWorkedGrids,fPropDK0WCY, fAdifImport, RegExpr,
-  FileUtil, LazFileUtils, sqldb;
+  FileUtil, LazFileUtils, sqldb, strutils;
 
 const
   cRefCall = 'Ref.call (CTRL+R): ';
@@ -106,7 +106,6 @@ type
     edtContestName: TEdit;
     edtRXFreq : TEdit;
     gbContest: TGroupBox;
-    lbleQslRcvdDate: TLabel;
     Label38: TLabel;
     Label37: TLabel;
     lblContestExchangeMessageReceived: TLabel;
@@ -120,7 +119,6 @@ type
     lblStatellite : TLabel;
     lblRXFreq : TLabel;
     lblRXMhz : TLabel;
-    lblQSLRcvdDate: TLabel;
     mCallBook : TMemo;
     mCountry : TMemo;
     MenuItem32 : TMenuItem;
@@ -238,7 +236,6 @@ type
     lblAmbiguous: TLabel;
     lblAzi: TLabel;
     lblCall: TLabel;
-    lblCfmLoTW: TLabel;
     lblCont: TLabel;
     lblCountryInfo: TLabel;
     lblDXCC: TLabel;
@@ -625,6 +622,10 @@ type
     IsJS8Callrmt     : Boolean; //way to isolate adif from JS8's JSON
 
     Op         : String;
+    QSLcfm,
+    eQSLcfm,
+    LoTWcfm    : String;
+    OffLnBeforeEdit : Boolean;
     procedure showDOK(stat:boolean);
     procedure ShowDXCCInfo(ref_adif : Word = 0);
     procedure ShowFields;
@@ -1096,20 +1097,21 @@ begin
         if (dok = '') and (dmData.qQSOBefore.FieldByName('callsign').AsString=edtCall.Text) then
           dok := dmData.qQSOBefore.FieldByName('dok').AsString;
         if (qslrdate = '') and (not dmData.qQSOBefore.FieldByName('qslr_date').IsNull) then
-          lblQSLRcvdDate.Caption := dmData.qQSOBefore.FieldByName('qslr_date').AsString+' rcvd QSL';
+          QSLcfm := dmData.qQSOBefore.FieldByName('qslr_date').AsString+'  '+
+                    dmData.qQSOBefore.FieldByName('band').AsString+'  QSL rcvd';
         if (lotw_qslrdate = '') and (not dmData.qQSOBefore.FieldByName('lotw_qslrdate').IsNull) then
-          lblCfmLoTW.Caption := dmData.qQSOBefore.FieldByName('lotw_qslrdate').AsString+' LoTW cfmd';
+          LoTWcfm := dmData.qQSOBefore.FieldByName('lotw_qslrdate').AsString+'  '+
+                     dmData.qQSOBefore.FieldByName('band').AsString+'  LoTW cfmd';
         if (eqslrdate = '') and (not dmData.qQSOBefore.FieldByName('eqsl_qslrdate').IsNull) then
-          lbleQslRcvdDate.Caption := dmData.qQSOBefore.FieldByName('eqsl_qslrdate').AsString+' rcvd eQSL';
+          eQSlcfm := dmData.qQSOBefore.FieldByName('eqsl_qslrdate').AsString+'  '+
+                     dmData.qQSOBefore.FieldByName('band').AsString+'  eQSL rcvd';
         if (waz = '') and (dmData.qQSOBefore.FieldByName('callsign').AsString=edtCall.Text) then
           waz := dmData.qQSOBefore.FieldByName('waz').AsString;
         if (itu = '') and (dmData.qQSOBefore.FieldByName('callsign').AsString=edtCall.Text) then
           itu := dmData.qQSOBefore.FieldByName('itu').AsString;
+
         dmData.qQSOBefore.Prior
       end;
-      lblQSLRcvdDate.Visible := True;
-      lbleQslRcvdDate.Visible := True;
-      lblCfmLoTW.Visible := True;
 
     finally
       dmData.qQSOBefore.Last;  //after this, dbgrid is not set to last record
@@ -1209,6 +1211,9 @@ begin
   lblGreeting.Caption := dmUtils.GetGreetings(lblHisTime.Caption);
   mCountry.Clear;
   mCountry.Lines.Add(country);
+  if QSLcfm<>'' then mCountry.Lines.Add(QSLcfm);
+  if eQSLcfm<>'' then mCountry.Lines.Add(eQSLcfm);
+  if LoTWcfm<>'' then mCountry.Lines.Add(LoTWcfm);
   mCountry.Repaint;
   if not (fEditQSO or fViewQSO) then
   begin
@@ -1296,10 +1301,9 @@ begin
   old_time := '';
   old_rstr := '';
   old_rsts := '';
-  lblCfmLoTW.Visible := False;
-  lblQSLRcvdDate.Visible := False;
-  lbleQslRcvdDate.Visible := False;
-  lblQSLRcvdDate.Caption := '';
+  QSLcfm:= '';
+  eQSLcfm := '';
+  LoTWcfm := '';
   lblCountryInfo.Caption := '';
   Mask  := '';
   lblQSONr.Caption := '0';
@@ -1813,6 +1817,11 @@ begin
   old_cmode := '';
   old_cfreq := '';
 
+  QSLcfm    := '';
+  eQSLcfm   := '';
+  LoTWcfm   := '';
+  OffLnBeforeEdit := False;
+
   Running      := False;
   EscFirstPressDone := False;
   ChangeDXCC   := False;
@@ -1866,8 +1875,9 @@ begin
     edtEndTime.Text   := FormatDateTime('hh:mm',date);
     Takes := StartTime - Date;
     DecodeTime(Takes,h,m,s,ms);
-    lblQSOTakes.Caption := 'QSO takes ' + IntToStr(h) + ' hr, ' + IntToStr(m) +
-                           ' min, ' + IntToStr(s) + ' sec'
+    lblQSOTakes.Caption := 'QSO takes: ' + AddChar('0',IntToStr(h),2) + 'hr '
+                                         + AddChar('0',IntToStr(m),2) + 'min '
+                                         + AddChar('0',IntToStr(s),2) + 'sec'
   end
 end;
 
@@ -6425,21 +6435,17 @@ begin
     edtState.Text     := Trim(dmData.qQSOBefore.FieldByName('state').AsString);
     edtDOK.Text       := Trim(dmData.qQSOBefore.FieldByName('dok').AsString);
     lotw_qslr         := dmData.qQSOBefore.FieldByName('lotw_qslr').AsString;
+
     if lotw_qslr = 'L' then
-    begin
-      lblCfmLoTW.Caption := dmData.qQSOBefore.FieldByName('lotw_qslrdate').AsString+ ' Cfmd by LoTW';
-      lblCfmLoTW.Visible := True
-    end;
+          LoTWcfm:= dmData.qQSOBefore.FieldByName('lotw_qslrdate').AsString + '  '+
+                    dmData.qQSOBefore.FieldByName('band').AsString +'  LoTW cfmd';
     if not dmData.qQSOBefore.FieldByName('qslr_date').IsNull then
-    begin
-      lblQSLRcvdDate.Caption := dmData.qQSOBefore.FieldByName('qslr_date').AsString+' rcvd QSL';
-      lblQSLRcvdDate.Visible := True
-    end;
-     if not dmData.qCQRLOG.FieldByName('eqsl_qslrdate').IsNull then
-    begin
-      lblQSLRcvdDate.Caption := dmData.qCQRLOG.FieldByName('eqsl_qslrdate').AsString+' rcvd eQSL';
-      lbleQslRcvdDate.Visible := True
-    end;
+          QSLcfm := dmData.qQSOBefore.FieldByName('qslr_date').AsString + '  '+
+                    dmData.qQSOBefore.FieldByName('band').AsString +'  QSL rcvd';
+    if not dmData.qQSOBefore.FieldByName('eqsl_qslrdate').IsNull then
+          eQSLcfm := dmData.qQSOBefore.FieldByName('eqsl_qslrdate').AsString + '  '+
+                     dmData.qQSOBefore.FieldByName('band').AsString +'  eQSL rcvd';
+
     dmSatellite.GetListOfSatellites(cmbSatellite, dmData.qQSOBefore.FieldByName('satellite').AsString);
     dmSatellite.GetListOfPropModes(cmbPropagation, dmData.qQSOBefore.FieldByName('prop_mode').AsString);
     edtRXFreq.Text := FloatToStr(dmData.qQSOBefore.FieldByName('rxfreq').AsFloat);
@@ -6486,21 +6492,17 @@ begin
     edtContestSerialReceived.Text := dmData.qCQRLOG.FieldByName('srx').AsString;
     edtContestExchangeMessageSent.Text := dmData.qCQRLOG.FieldByName('stx_string').AsString;
     edtContestExchangeMessageReceived.Text := dmData.qCQRLOG.FieldByName('srx_string').AsString;
+
     if lotw_qslr = 'L' then
-    begin
-      lblCfmLoTW.Caption := dmData.qQSOBefore.FieldByName('lotw_qslrdate').AsString+ ' Cfmd by LoTW';
-      lblCfmLoTW.Visible := True
-    end;
-    if not dmData.qQSOBefore.FieldByName('qslr_date').IsNull then
-    begin
-      lblQSLRcvdDate.Caption := dmData.qQSOBefore.FieldByName('qslr_date').AsString+' rcvd QSL';
-      lblQSLRcvdDate.Visible := True
-    end;
-     if not dmData.qCQRLOG.FieldByName('eqsl_qslrdate').IsNull then
-    begin
-      lblQSLRcvdDate.Caption := dmData.qCQRLOG.FieldByName('eqsl_qslrdate').AsString+' rcvd eQSL';
-      lbleQslRcvdDate.Visible := True
-    end;
+           LoTWcfm := dmData.qCQRLOG.FieldByName('lotw_qslrdate').AsString + '  '+
+                      dmData.qCQRLOG.FieldByName('band').AsString +'  LoTW cfmd' ;
+    if not dmData.qCQRLOG.FieldByName('qslr_date').IsNull then
+           QSLcfm := dmData.qCQRLOG.FieldByName('qslr_date').AsString + '  '+
+                     dmData.qCQRLOG.FieldByName('band').AsString +'  QSL rcvd ';
+    if not dmData.qCQRLOG.FieldByName('eqsl_qslrdate').IsNull then
+      eQSLcfm := dmData.qCQRLOG.FieldByName('eqsl_qslrdate').AsString + '  '+
+                 dmData.qCQRLOG.FieldByName('band').AsString +'  eQSL rcvd';
+
     dmSatellite.GetListOfSatellites(cmbSatellite, dmData.qCQRLOG.FieldByName('satellite').AsString);
     dmSatellite.GetListOfPropModes(cmbPropagation, dmData.qCQRLOG.FieldByName('prop_mode').AsString);
     edtRXFreq.Text := FloatToStr(dmData.qCQRLOG.FieldByName('rxfreq').AsFloat);
@@ -6760,14 +6762,18 @@ procedure TfrmNewQSO.SetEditLabel;
 begin
   lblCall.Caption    := 'Call (edit mode):';
   lblCall.Font.Color := clRed;
-  Caption := dmUtils.GetNewQSOCaption('Edit QSO')
+  Caption := dmUtils.GetNewQSOCaption('Edit QSO');
+  OffLnBeforeEdit:=cbOffline.Checked;
+  cbOffline.Checked :=true;
 end;
 
 procedure TfrmNewQSO.UnsetEditLabel;
 begin
   lblCall.Caption    := 'Call:';
   lblCall.Font.Color := clDefault;
-  Caption := dmUtils.GetNewQSOCaption('New QSO')
+  Caption := dmUtils.GetNewQSOCaption('New QSO');
+  cbOffline.Checked :=OffLnBeforeEdit;
+  OffLnBeforeEdit:=cbOffline.Checked;
 end;
 
 procedure TfrmNewQSO.CheckCallsignClub;

--- a/src/uVersion.pas
+++ b/src/uVersion.pas
@@ -10,7 +10,7 @@ const
   cRELEAS     = 1;
   cBUILD      = 1;
 
-  cBUILD_DATE = '2021-02-02';
+  cBUILD_DATE = '2021-02-03';
 
 implementation
 


### PR DESCRIPTION
    - fixed all my mistakes in PR #385. I do not understand how that code passed testing. Now Edit and View should work ok.
    - removed qsl, eqsl, lotw confirmed labels.
    - added them all appear to DXCC info Tedit box. It is actually kind of DXCC information. Activated auto scrollbars in case there will be more lines than fit.
    - added band info to confirmed lines. It always shows first found qso information with callsign. Good or bad? If many qsos with callsign should confirmation refer to current band, or should it be combination of all qsos confirmed (if confimation differs by bands)?
    - reordered/placed date,start,end, offline and qso takes as now there was more space.
    - fixed edit qso to set offline. Otherwise qso date/time was changed at save. How I have feeling that Edit did set offline ON somewhere in past. Bad memory?
    - fixed qso takes layout with preceeding zeros to keep it always same length

    Tried to test all different cases carefully. Usually bugs are fixed and new ones added ;-|

Squashed commit of the following:

commit 6a6681e93d2d5a44bc4d0b85c229b262ef51e1c9
Author: OH1KH <oh1kh@sral.fi>
Date:   Wed Feb 3 11:10:03 2021 +0200

    - removed qsl, eqsl, lotw confiremed labels.
    - added them to DXCC info Tedit box. It is actually kind of DXCC information. Made it auto scrollbars in case there will be more lines than fit.
    - added band info to confirmed labels. It always shows first found qso information with callsign. Good or bad? If many qsos with callsign should confirmation refer to current band, or should it be combination of all qsos confirmed (if confimation differs by bands)?
    - reordered date,start,end, offline and qso takes as now there was more space.
    - fixed edit qso to set offline. Otherwise qso date/time was changed at save
    - fixed qso takes layout with preceeding zeros to keep it always same length

    Tried to test all different cases carefully. (Usually bugs are fixed and new ones added ;-| )