### PR TITLE
Fix for eQSL upload

### DIFF
--- a/src/feQSLUpload.pas
+++ b/src/feQSLUpload.pas
@@ -114,7 +114,7 @@ begin
     Writeln(f, '<PROGRAMVERSION:',Length(cVERSION),'>',cVERSION);
     Writeln(f);
     Writeln(f,dmUtils.StringToADIF('<EQSL_USER',cqrini.ReadString('LoTW','eQSLName','')));
-    Writeln(f,dmUtils.StringToADIF('<EQSL_PSWD',dmUtils.EncodeURLData(cqrini.ReadString('LoTW','eQSLPass',''))));
+    Writeln(f,dmUtils.StringToADIF('<EQSL_PSWD',cqrini.ReadString('LoTW','eQSLPass','')));
     Writeln(f,'<EOH>');
     while not dmData.Q.Eof do
     begin


### PR DESCRIPTION
 - removed password encode url from eQSL upload. When username and password are placed in uploaded adif file header part as tags encoding special characters is not needed and leads to wrong password.

Tested with <EQSL_PSWD:9>Saku!_<>: that did work both down and upload that proves urlEncode is needed only in download where password is included in URL.
In upload it is placed in adif header where encode is not needed and plain text accepted.

How ever password can not contain special UTF-8 characters. Only one byte ascii up to 0x7E can be handled by cqrlog. And I suspect the same with eQSL server.