### PR TITLE
Bug fix for UTF8

### DIFF
--- a/src/dData.pas
+++ b/src/dData.pas
@@ -530,30 +530,35 @@ begin
   if RbnMonCon.Connected then
     RbnMonCon.Connected := False;
 
+  MainCon.CharSet:='UTF8';
   MainCon.HostName     := host;
   MainCon.Params.Text  := 'Port='+port;
   MainCon.UserName     := user;
   MainCon.Password     := pass;
   MainCon.DatabaseName := 'information_schema';
 
+  BandMapCon.CharSet:='UTF8';
   BandMapCon.HostName     := host;
   BandMapCon.Params.Text  := 'Port='+port;
   BandMapCon.UserName     := user;
   BandMapCon.Password     := pass;
   BandMapCon.DatabaseName := 'information_schema';
 
+  RbnMonCon.CharSet:='UTF8';
   RbnMonCon.HostName     := host;
   RbnMonCon.Params.Text  := 'Port='+port;
   RbnMonCon.UserName     := user;
   RbnMonCon.Password     := pass;
   RbnMonCon.DatabaseName := 'information_schema';
 
+  dbDXC.CharSet:='UTF8';
   dbDXC.HostName     := host;
   dbDXC.Params.Text  := 'Port='+port;
   dbDXC.UserName     := user;
   dbDXC.Password     := pass;
   dbDXC.DatabaseName := 'information_schema';
 
+  LogUploadCon.CharSet:='UTF8';
   LogUploadCon.HostName     := host;
   LogUploadCon.Params.Text  := 'Port='+port;
   LogUploadCon.UserName     := user;

--- a/src/uVersion.pas
+++ b/src/uVersion.pas
@@ -10,7 +10,7 @@ const
   cRELEAS     = 2;
   cBUILD      = 1;
 
-  cBUILD_DATE = '2021-02-12';
+  cBUILD_DATE = '2021-02-13';
 
 implementation
 


### PR DESCRIPTION
This fixes bug (long lasting) with UTF-8 that appears with Laz2.0.10/fpc3.2.0 but has been lying there already before. (issue #323)

This makes old qsos special characters "garbage" when they were saved with program compiled with fpc3.0.4 or earlier.

That is why I do NOT expect this pull request is ACCEPTED !!

This is just to show how things must be, and for testing.
This problem needs further thinking how this is implemented with minor trouble for users.