### PR TITLE
Fix for NEwQSO/Offline

### DIFF
--- a/src/fNewQSO.pas
+++ b/src/fNewQSO.pas
@@ -6774,7 +6774,6 @@ begin
   lblCall.Caption    := 'Call (edit mode):';
   lblCall.Font.Color := clRed;
   Caption := dmUtils.GetNewQSOCaption('Edit QSO');
-  OffLnBeforeEdit:=cbOffline.Checked;
   cbOffline.Checked :=true;
 end;
 
@@ -6783,8 +6782,7 @@ begin
   lblCall.Caption    := 'Call:';
   lblCall.Font.Color := clDefault;
   Caption := dmUtils.GetNewQSOCaption('New QSO');
-  cbOffline.Checked :=OffLnBeforeEdit;
-  OffLnBeforeEdit:=cbOffline.Checked;
+  cbOffline.Checked := cqrini.ReadBool('TMPQSO','OFF',False);
 end;
 
 procedure TfrmNewQSO.CheckCallsignClub;

--- a/src/uVersion.pas
+++ b/src/uVersion.pas
@@ -10,7 +10,7 @@ const
   cRELEAS     = 2;
   cBUILD      = 1;
 
-  cBUILD_DATE = '2021-02-13';
+  cBUILD_DATE = '2021-02-19';
 
 implementation
 


### PR DESCRIPTION
While fixing just date/time change when old qso was edited made a new bug that resets Offline checked when New Qso is saved in situation where Offline is set manually I.E. no rig CAT control in use.

This should now fix both. Keep manually set Offline on and set Offline while old qso edit.