### PR TITLE
Fix for Statistics/Big squares

### DIFF
--- a/src/fBigSquareStat.pas
+++ b/src/fBigSquareStat.pas
@@ -159,13 +159,10 @@ begin
         db := TBufDataset.Create(nil); //I was not able to clear all records from TBufDataset without this workaround
         try
           db.FieldDefs.Clear;
-          with db.FieldDefs do
-          begin
-            Add('loc', ftString, 4);
-            Add('cfm',ftBoolean)
-          end;
-          db.CreateDataset;
+          db.FieldDefs.Add('loc', ftString, 4);
           db.IndexDefs.Add('loc','loc',[ixPrimary]);
+          db.FieldDefs.Add('cfm',ftBoolean);
+          db.CreateDataset;
 
           db.Open;
           wkd := 0;


### PR DESCRIPTION
Compile with Laz2.0.10/fpc3.2.0 or with laz2.0.12/fpc3.2.0-1 cause runtime Access violation in Big square statistics. https://www.cqrlog.com/node/3123

When older Laz/fpc is used this error does not exist at line 177: db.post of fBigSquareStat.pas

Got some help from Lazarus forum and modified it little bit further. Result seems to be again similar compared to result with old laz/fpc compiled version result without Access violation errors.