### PR TITLE
Fix for qsl label printing.

### DIFF
--- a/src/dUtils.pas
+++ b/src/dUtils.pas
@@ -3243,6 +3243,8 @@ end;
 
 function TdmUtils.IsQSLViaValid(Text: string): boolean;
 begin
+  Result :=false;
+  if Text='' then exit; //do not allow empty RegExp
   reg.InputString := Text;
   reg.Expression := '\A\w{1,2}\d[A-Z]{1,3}\Z';
   Result := reg.ExecPos(1);

--- a/src/uVersion.pas
+++ b/src/uVersion.pas
@@ -10,7 +10,7 @@ const
   cRELEAS     = 2;
   cBUILD      = 1;
 
-  cBUILD_DATE = '2021-02-20';
+  cBUILD_DATE = '2021-03-05';
 
 implementation
 


### PR DESCRIPTION
Fixed empty RegExp error that happens in qsl label printing when cqrlog is compiled with freepascal ver > 3.0.4