### PR TITLE
Fix for RBNmonitor filter

### DIFF
--- a/src/fRbnMonitor.pas
+++ b/src/fRbnMonitor.pas
@@ -281,17 +281,15 @@ begin
     2 : dxinfo := 'B';
     3 : dxinfo := 'M';
     else
-      dxinfo := ''
+     Begin
+      dxinfo := '';
+      if fil_NewDXCOnly then
+                        Begin
+                          if dmData.DebugLevel>=2 then Writeln('RBNMonitor: ','Not new one, band or mode - ',dxstn);
+                          exit;
+                        end;
+     end;
   end; //case
-
-  if fil_NewDXCOnly then
-  begin
-    if (index>0) and (index<4) then
-    begin
-      if dmData.DebugLevel>=2 then Writeln('RBNMonitor: ','Not new one, band or mode - ',dxstn);
-      exit
-    end
-  end;
 
   Result := True
 end;


### PR DESCRIPTION
Checkbox "show only new, new band, new mode" in filter settings worked just opposite way dropping all those spots that had NMB marking.  https://cqrlog.com/node/3127

Reversed that. Now shows only spots with NMB.