### PR TITLE
Shorten grid to 6 chars for label export

### DIFF
--- a/src/fExLabelPrint.pas
+++ b/src/fExLabelPrint.pas
@@ -253,7 +253,7 @@ begin
       dmData.Q.ParamByName('qsl_r').AsString      := dmData.qCQRLOG.FieldByName('qsl_r').AsString;
       dmData.Q.ParamByName('iota').AsString       := dmData.qCQRLOG.FieldByName('iota').AsString;
       dmData.Q.ParamByName('pwr').AsString        := dmData.qCQRLOG.FieldByName('pwr').AsString;
-      dmData.Q.ParamByName('loc').AsString        := dmData.qCQRLOG.FieldByName('loc').AsString;
+      dmData.Q.ParamByName('loc').AsString        := Copy(dmData.qCQRLOG.FieldByName('loc').AsString, 1, 6);
       dmData.Q.ParamByName('my_loc').AsString     := dmData.qCQRLOG.FieldByName('my_loc').AsString;
       dmData.Q.ParamByName('award').AsString      := Rep(dmData.qCQRLOG.FieldByName('award').AsString);
       dmData.Q.ParamByName('band').AsString       := dmData.qCQRLOG.FieldByName('band').AsString;


### PR DESCRIPTION
Upon exporting QSOs for label printing that have grids with more then 6 chars, CQRlog throws an exception because the loc fiefd in temporary qslexport table is only VARCHAR(6):

![Screenshot from 2021-03-22 18-07-06](https://user-images.githubusercontent.com/7112907/112030666-c8504580-8b3a-11eb-8c8d-87c1182311c1.png)

This shortens longer locators to 6 chars to that the export works again.