### PR TITLE
RIT and XIT modifications

### DIFF
--- a/src/fNewQSO.pas
+++ b/src/fNewQSO.pas
@@ -7442,6 +7442,7 @@ begin
                   wHiSpeed  := 10;    //mS will be shorter when FT8
                   wLoSpeed  := 1000;
 
+                  frmTRXControl.DisableRitXit; //wsjtx does not do this, so we have to ...
 
                   tmrWsjtx.Interval := wLoSpeed;      //  timer has now dynamic value. Most of time there is nothing to do
 

--- a/src/fTRXControl.pas
+++ b/src/fTRXControl.pas
@@ -185,6 +185,7 @@ type
     procedure Split(up : Integer);
     procedure DisableSplit;
     procedure ClearRIT;
+    procedure DisableRitXit;
     procedure LoadUsrButtonCaptions;
     procedure LoadButtonCaptions;
     procedure SetDebugMode(DebugMode : Boolean);
@@ -1508,7 +1509,15 @@ procedure TfrmTRXControl.ClearRIT;
 begin
   if (lblFreq.Caption = empty_freq) then
     exit;
-  radio.ClearRit
+  radio.ClearRit;
+  radio.ClearXit   //this clears Xit too
+end;
+procedure TfrmTRXControl.DisableRitXit;
+begin
+  if (lblFreq.Caption = empty_freq) then
+    exit;
+  radio.DisableRit;
+  radio.DisableSplit   //this disabeles Xit
 end;
 procedure TfrmTRXControl.LoadUsrButtonCaptions;
 var       r:char;

--- a/src/uRigControl.pas
+++ b/src/uRigControl.pas
@@ -104,8 +104,10 @@ type TRigControl = class
     procedure SetModePass(mode : TRigMode);
     procedure SetFreqKHz(freq : Double);
     procedure SetSplit(up:integer);
-    procedure DisableSplit;
+    procedure DisableSplit;  //this is disable XIT
+    procedure ClearXit;
     procedure ClearRit;
+    procedure DisableRit;
     procedure Restart;
     procedure PwrOn;
     procedure PwrOff;
@@ -261,10 +263,18 @@ procedure TRigControl.ClearRit;
 begin
   RigCommand.Add('J 0')
 end;
+procedure TRigControl.DisableRit;
+Begin
+  RigCommand.Add('U RIT 0');
+end;
 procedure TRigControl.SetSplit(up:integer);
 Begin
   RigCommand.Add('Z '+IntToStr(up));
   RigCommand.Add('U XIT 1');
+end;
+procedure TRigControl.ClearXit;
+begin
+  RigCommand.Add('Z 0')
 end;
 procedure TRigControl.DisableSplit;
 Begin


### PR DESCRIPTION
"New QSO/Clear rit after save qso" with Icom IC7300 this clears also XIT to zero. It is good thing specially if XIT has been used for split up/down for qso.
How ever all rig brands and models may not clear XIT when RIT is cleared. Therefore command "Z 0" is added to "clear RIT" command to be sure that also XIT is cleared then.

Wsjt-x controls rig but for reason that was not explained by develop team it does not disable RIT and XIT. RIT is not fatal, but XIT may cause transmits off the used frequency slot and it is hard to notice by user because waterfall TX mark shows still a point inside frequency slot.
That is why command disableRitXit is added when entering to wsjt-remote mode.