### PR TITLE
Fixes to adif import

### DIFF
--- a/src/fAdifImport.lfm
+++ b/src/fAdifImport.lfm
@@ -383,6 +383,7 @@ object frmAdifImport: TfrmAdifImport
       BorderSpacing.Bottom = 6
       Caption = 'Close'
       ModalResult = 2
+      OnClick = btnCloseClick
       TabOrder = 2
     end
     object chkFilterDateRange: TCheckBox
@@ -529,5 +530,21 @@ object frmAdifImport: TfrmAdifImport
     Params = <>
     Left = 280
     Top = 144
+  end
+  object popErrFile: TPopupMenu
+    Left = 320
+    Top = 144
+    object mnuedit: TMenuItem
+      Caption = 'Open with text editor'
+      OnClick = mnueditClick
+    end
+    object mnuImport: TMenuItem
+      Caption = 'Adif import file'
+      OnClick = mnuImportClick
+    end
+    object mnuDelete: TMenuItem
+      Caption = 'Delete file'
+      OnClick = mnuDeleteClick
+    end
   end
 end

--- a/src/fAdifImport.pas
+++ b/src/fAdifImport.pas
@@ -127,6 +127,7 @@ type
     Q4: TSQLQuery;
     sb: TStatusBar;
     tr: TSQLTransaction;
+    procedure btnCloseClick(Sender: TObject);
     procedure chkFilterDateRangeChange(Sender: TObject);
     procedure FormCreate(Sender: TObject);
     procedure FormShow(Sender: TObject);
@@ -881,8 +882,17 @@ begin
 end;
 
 procedure TfrmAdifImport.mnuImportClick(Sender: TObject);
+var
+  tmp:Char;
 begin
   popErrFile.Close;
+  try
+    tmp := FormatSettings.TimeSeparator;
+    FormatSettings.TimeSeparator := '_';
+    ERR_FILE := 'errors_'+TimeToStr(now)+'.adi'
+  finally
+    FormatSettings.TimeSeparator := tmp
+  end;
   lblFileName.Caption:= lblErrorLog.Caption;
   lblErrorLog.Caption:='';
   lblCount.Caption :='';
@@ -956,6 +966,11 @@ begin
   pnlFilterDateRange.Enabled := chkFilterDateRange.Checked;
   lblFilteredOut.Visible := chkFilterDateRange.Checked;
   lblFilteredOutCount.Visible := chkFilterDateRange.Checked;
+end;
+
+procedure TfrmAdifImport.btnCloseClick(Sender: TObject);
+begin
+  AbortImport:=true;
 end;
 
 procedure TfrmAdifImport.FormShow(Sender: TObject);


### PR DESCRIPTION
Commit #419 had errors in fAdifImport.lfm. I had cleaned it too much removing the popupmenu that should appear by error file name click. Fixed.

I do not know if I also cleaned btnClose onClick, but as also the pas file did not had btnCloseClick procedure it might have been missing for long.
Now added btnCloseClick that sets boolean AbortEdit true. That stops long, or looping import.

Using popup at error file name with selection adif import file caused a loop if error file was not completely fixed. If there was still error(s) they were added to error file that was the same as imported file. Endless loop.
Now importing error file will create a new error file with different name.