### PR TITLE
Fix for propagation

### DIFF
--- a/src/fPropagation.pas
+++ b/src/fPropagation.pas
@@ -189,54 +189,54 @@ begin
     Child := Doc.DocumentElement.FirstChild;
 
     data := Child.FindNode('updated');
-    if Assigned(data) then
+    if Assigned(data) and (data.ChildNodes.Count>0) then
       frmPropagation.LastUpdate := String(data.FirstChild.NodeValue);
 
     data := Child.FindNode('solarflux');
-    if Assigned(data) then
+    if Assigned(data) and (data.ChildNodes.Count>0) then
       frmPropagation.sfi := String(data.FirstChild.NodeValue);
 
     data := Child.FindNode('aindex');
-    if Assigned(data) then
+    if Assigned(data) and (data.ChildNodes.Count>0) then
       frmPropagation.a := String(data.FirstChild.NodeValue);
 
     data := Child.FindNode('kindex');
-    if Assigned(data) then
+    if Assigned(data) and (data.ChildNodes.Count>0) then
       frmPropagation.k := String(data.FirstChild.NodeValue);
 
     data := Child.FindNode('sunspots');
-    if Assigned(data) then
+    if Assigned(data) and (data.ChildNodes.Count>0) then
       frmPropagation.ssn := String(data.FirstChild.NodeValue);
 
     data := Child.FindNode('aurora');
-    if Assigned(data) then
+    if Assigned(data) and (data.ChildNodes.Count>0) then
     begin
       if Assigned(data.FirstChild) then
         frmPropagation.aur := String(data.FirstChild.NodeValue)
     end;
 
     data := Child.FindNode('latdegree');
-    if Assigned(data) then
+    if Assigned(data) and (data.ChildNodes.Count>0) then
       frmPropagation.lat := String(data.FirstChild.NodeValue);
 
     data := Child.FindNode('magneticfield');
-    if Assigned(data) then
+    if Assigned(data) and (data.ChildNodes.Count>0) then
       frmPropagation.mag := String(data.FirstChild.NodeValue);
 
     data := Child.FindNode('geomagfield');
-    if Assigned(data) then
+    if Assigned(data) and (data.ChildNodes.Count>0) then
       frmPropagation.geo := String(data.FirstChild.NodeValue);
 
     data := Child.FindNode('signalnoise');
-    if Assigned(data) then
+    if Assigned(data) and (data.ChildNodes.Count>0) then
       frmPropagation.sigs := String(data.FirstChild.NodeValue);
 
     data := Child.FindNode('fof2');
-    if Assigned(data) then
+    if Assigned(data) and (data.ChildNodes.Count>0) then
       frmPropagation.fof2 := String(data.FirstChild.NodeValue);
 
     data := Child.FindNode('calculatedconditions');
-    if Assigned(data) then
+    if Assigned(data) and (data.ChildNodes.Count>0) then
     begin
       for j:=0 to data.ChildNodes.Count-1 do
       begin                                              //80-40m                                       daynight                                                         poor

--- a/src/uVersion.pas
+++ b/src/uVersion.pas
@@ -10,7 +10,7 @@ const
   cRELEAS     = 2;
   cBUILD      = 1;
 
-  cBUILD_DATE = '2021-07-12';
+  cBUILD_DATE = '2021-08-11';
 
 implementation
 


### PR DESCRIPTION
 When propagation/solar data is defined to show out as text there are sometimes
 situations that no data is shown. On next day problem is away.

 Found out that if downloaded solardata.xml (as solar.xml in cqrlog directory)
 has node(s) without data try loop fails to loadxmlfile because data is
 assigned, but there are no (0) first.child to load.

 Added check that assigned data has also ChildNodes.Count > 0

 Helped to view values today when "fof2" node was empty. So I guess it is ok
 to test also with other nodes loaded.