### PR TITLE
ADIF export submode extensions

### DIFF
--- a/help/h1.html
+++ b/help/h1.html
@@ -308,15 +308,18 @@ You can also switch between memory frequencies with TRXControl's <b>M up</b> and
 <img src="img/h121.png"><br><br>
 <a name=ah8><h2><strong>Modes</strong></h2></a>
 <img src=img/h11.png border=0><br><br>
-Here you can set up the default bandwidth for any of the supported modes (CW - SSB - RTTY - AM - FM).
+<p>Here you can set up the default bandwidth for any of the supported modes (CW - SSB - RTTY - AM - FM).
 If your radio is tuned to the corresponding band segment or if you switch the mode on the radio
 control panel, CQRLOG will change the bandwidth to the desired value. The bandwidth can be
 changed at any time, however a program restart will probably be needed to make the changes
-take effect.<br><br>
-<strong>User definable digital modes</strong> can be set up in a separate box. Use comma
-as a separator, ie. BPSK31,QPSK64,OLIVIA,CONTESTIA etc.<br>
+take effect.<br>
 Some <strong>TRX like ICOM don't have support for this in HamLib. To get mode settings work, set
 all values to 0 (zero).</strong>
+</p><p><strong>User definable digital modes</strong> can be set up in a separate box. Use comma
+as a separator, ie. MYMODE1,MYMODE2 etc.<br>
+If user adds digital modes (submode names) exactly as written in this table <a href="https://adif.org/312/ADIF_312.htm#Mode_Enumeration">ADIF.org: Mode_Enumeration</a> ADIF export will place correct mode and submode tags to exported file.
+ Submode list is copied at 2021-08-25 and may need updating of source code some day in future.
+</p>
 <p align=center><img src=img/line.png></p>
 <a name=ah9><h2><strong>QTH Profiles</strong></h2></a>
 <img src=img/h12.png border=0><br><br>

--- a/src/fExportProgress.pas
+++ b/src/fExportProgress.pas
@@ -221,22 +221,99 @@ var
     if ExMode then
     begin
       case Mode of
-        'JS8'     : begin
-                      tmp := '<MODE:4>MFSK<SUBMODE:3>JS8';
-                      SaveTag(tmp,leng);
-                    end;
-        'FT4'     : begin
-                      tmp := '<MODE:4>MFSK<SUBMODE:3>FT4';
-                      SaveTag(tmp,leng);
-                    end;
-        'FST4'    : begin
-                      tmp := '<MODE:4>MFSK<SUBMODE:4>FST4';
-                      SaveTag(tmp,leng);
-                    end;
-        'PACKET'  :  begin
-                        tmp := '<MODE:3>PKT';
-                        SaveTag(tmp,leng);
-                     end;
+        'PACKET'                   : begin tmp := '<MODE:3>PKT'; SaveTag(tmp,leng); end;
+        //these modes come from ICOM rig (IC7300) when DATA is selected with USB,LSB,FM or AM
+        //and checkbox "auto" for mode is selected in NewQSO
+        //There is not clear what mode is then actually used (depends on additional program in use)
+        //but we put them all to PKT category here
+        'PKTUSB'                   : begin tmp := '<MODE:3>PKT'; SaveTag(tmp,leng); end;
+        'PKTLSB'                   : begin tmp := '<MODE:3>PKT'; SaveTag(tmp,leng); end;
+        'PKTFM'                    : begin tmp := '<MODE:3>PKT'; SaveTag(tmp,leng); end;
+        'PKTAM'                    : begin tmp := '<MODE:3>PKT'; SaveTag(tmp,leng); end;
+
+        //definitions by https://adif.org/312/ADIF_312.htm#Mode_Enumeration
+
+        'CHIP64','CHIP128'         : begin tmp := '<MODE:4>CHIP<SUBMODE:'+IntToStr(length(Mode))+'>'+Mode;SaveTag(tmp,leng);end;
+        'PCW'                      : begin tmp := '<MODE:2>CW<SUBMODE:'+IntToStr(length(Mode))+'>'+Mode;SaveTag(tmp,leng);end;
+        'DOM-M','DOM4','DOM5',
+        'DOM8','DOM11','DOM16',
+        'DOM22','DOM44','DOM88',
+        'DOMINOEX','DOMINOF'       : begin tmp := '<MODE:6>DOMINO<SUBMODE:'+IntToStr(length(Mode))+'>'+Mode;SaveTag(tmp,leng);end;
+        'FMHELL','FSKHELL',
+        'HELL80','HELLX5',
+        'HELLX9','HFSK',
+        'PSKHELL','SLOWHELL'       : begin tmp := '<MODE:4>HELL<SUBMODE:'+IntToStr(length(Mode))+'>'+Mode;SaveTag(tmp,leng);end;
+        'ISCAT-A','ISCAT-B'        : begin tmp := '<MODE:5>ISCAT<SUBMODE:'+IntToStr(length(Mode))+'>'+Mode;SaveTag(tmp,leng);end;
+        'JT4A','JT4B','JT4C',
+        'JT4D','JT4E','JT4F',
+        'JT4G'                     : begin tmp := '<MODE:3>JT4<SUBMODE:'+IntToStr(length(Mode))+'>'+Mode;SaveTag(tmp,leng);end;
+        'JT9-1','JT9-2','JT9-5',
+        'JT9-10','JT9-30',
+        'JT9A','JT9B','JT9C',
+        'JT9D','JT9E','JT9E FAST',
+        'JT9F','JT9F FAST','JT9G',
+        'JT9G FAST','JT9H',
+        'JT9H FAST'                 : begin tmp := '<MODE:3>JT9<SUBMODE:'+IntToStr(length(Mode))+'>'+Mode;SaveTag(tmp,leng);end;
+        'FSQCALL','FST4','FST4W',
+        'FT4','JS8','JTMS','MFSK4',
+        'MFSK8','MFSK11','MFSK16',
+        'MFSK22','MFSK31','MFSK32',
+        'MFSK64','MFSK64L',
+        'MFSK128'                   : begin tmp := '<MODE:4>MFSK<SUBMODE:'+IntToStr(length(Mode))+'>'+Mode;SaveTag(tmp,leng);end;
+        'OLIVIA 4/125','OLIVIA 4/250',
+        'OLIVIA 8/250','OLIVIA 8/500',
+        'OLIVIA 16/500','OLIVIA 16/1000',
+        'OLIVIA 32/1000'            : begin tmp := '<MODE:6>OLIVIA<SUBMODE:'+IntToStr(length(Mode))+'>'+Mode;SaveTag(tmp,leng);end;
+        'OPERA-BEACON',
+        'OPERA-QSO'                 : begin tmp := '<MODE:5>OPERA<SUBMODE:'+IntToStr(length(Mode))+'>'+Mode;SaveTag(tmp,leng);end;
+        'PAC2','PAC3','PAC4'        : begin tmp := '<MODE:3>PAC<SUBMODE:'+IntToStr(length(Mode))+'>'+Mode;SaveTag(tmp,leng);end;
+        'PAX2'                      : begin tmp := '<MODE:3>PAX<SUBMODE:'+IntToStr(length(Mode))+'>'+Mode;SaveTag(tmp,leng);end;
+        '8PSK125','8PSK125F',
+        '8PSK125FL','8PSK250',
+        '8PSK250F','8PSK250FL',
+        '8PSK500','8PSK500F',
+        '8PSK1000','8PSK1000F',
+        '8PSK1200F','FSK31','PSK10',
+        'PSK31','PSK63','PSK63F',
+        'PSK63RC4','PSK63RC5',
+        'PSK63RC10','PSK63RC20',
+        'PSK63RC32','PSK125',
+        'PSK125C12','PSK125R',
+        'PSK125RC10','PSK125RC12',
+        'PSK125RC16','PSK125RC4',
+        'PSK125RC5','PSK250',
+        'PSK250C6','PSK250R',
+        'PSK250RC2','PSK250RC3',
+        'PSK250RC5','PSK250RC6',
+        'PSK250RC7','PSK500',
+        'PSK500C2','PSK500C4',
+        'PSK500R','PSK500RC2',
+        'PSK500RC3','PSK500RC4',
+        'PSK800C2','PSK800RC2',
+        'PSK1000','PSK1000C2',
+        'PSK1000R','PSK1000RC2',
+        'PSKAM10','PSKAM31',
+        'PSKAM50','PSKFEC31',
+        'QPSK31','QPSK63',
+        'QPSK125','QPSK250',
+        'QPSK500','SIM31'           : begin tmp := '<MODE:3>PSK<SUBMODE:'+IntToStr(length(Mode))+'>'+Mode;SaveTag(tmp,leng);end;
+        'QRA64A','QRA64B','QRA64C',
+        'QRA64D','QRA64E'           : begin tmp := '<MODE:5>QRA64<SUBMODE:'+IntToStr(length(Mode))+'>'+Mode;SaveTag(tmp,leng);end;
+        'ROS-EME','ROS-HF',
+        'ROS-MF'                    : begin tmp := '<MODE:3>ROS<SUBMODE:'+IntToStr(length(Mode))+'>'+Mode;SaveTag(tmp,leng);end;
+        'ASCI','ASCII'              : begin tmp := '<MODE:4>RTTY<SUBMODE:'+IntToStr(length(Mode))+'>'+Mode;SaveTag(tmp,leng);end;
+        'LSB','USB'                 : begin tmp := '<MODE:3>SSB<SUBMODE:'+IntToStr(length(Mode))+'>'+Mode;SaveTag(tmp,leng);end;
+        'THOR-M','THOR4','THOR5',
+        'THOR8','THOR11','THOR16',
+        'THOR22','THOR25X4',
+        'THOR50X1','THOR50X2',
+        'THOR100'                   : begin tmp := '<MODE:4>THOR<SUBMODE:'+IntToStr(length(Mode))+'>'+Mode;SaveTag(tmp,leng);end;
+        'THRBX','THRBX1','THRBX2',
+        'THRBX4','THROB1','THROB2',
+        'THROB4'                    : begin tmp := '<MODE:4>THRB<SUBMODE:'+IntToStr(length(Mode))+'>'+Mode;SaveTag(tmp,leng);end;
+        'AMTORFEC','GTOR','NAVTEX',
+        'SITORB'                    : begin tmp := '<MODE:3>TOR<SUBMODE:'+IntToStr(length(Mode))+'>'+Mode;SaveTag(tmp,leng);end;
+
       else           begin
                         tmp := '<MODE';
                         SaveTag(dmUtils.StringToADIF(tmp,Mode),leng);

--- a/src/uVersion.pas
+++ b/src/uVersion.pas
@@ -10,7 +10,7 @@ const
   cRELEAS     = 2;
   cBUILD      = 1;
 
-  cBUILD_DATE = '2021-08-11';
+  cBUILD_DATE = '2021-08-28';
 
 implementation
 


### PR DESCRIPTION
Added all mode/submode enumerations from https://adif.org/312/ADIF_312.htm#Mode_Enumeration to ADIF export tag creation.
This way user can add to "modes/user defined digital modes" any submode written in same form as enumeration table and get it exported properly with mode+submode tags.  This addition is random tested as there are so many submodes. How ever I tried to use copy/paste from adif.org for creating source to avoid typing errors in submode names.

Added also modes that come from rig (ic7300) if "auto" mode checkbox is checked and "DATA" is used with any of USB,LSB,FM,AM. They all are now exported with tag PKT.
It may not be the right one if user uses additional program to work with and that program does not have remote link to cqrlog to tell the mode name. In anyway PKT is included in ADIF mode enumerations where modes from rig PKTUSB,PKTLSB,PKTFM and PKTAM are not.

Fixed help (Quick start/modes)