### PR TITLE
Fix for DXCC status form

### DIFF
--- a/src/fDXCCStat.lfm
+++ b/src/fDXCCStat.lfm
@@ -1,12 +1,11 @@
 object frmDXCCStat: TfrmDXCCStat
-  Left = 258
-  Height = 529
-  Top = 209
-  Width = 711
-  ActiveControl = grdDXCCStat
+  Left = 293
+  Height = 612
+  Top = 37
+  Width = 768
   Caption = 'DXCC Statistic'
-  ClientHeight = 529
-  ClientWidth = 711
+  ClientHeight = 612
+  ClientWidth = 768
   Icon.Data = {
     BE0C00000000010001002020000001001800A80C000016000000280000002000
     0000400000000100180000000000000C00006400000064000000000000000000
@@ -115,22 +114,34 @@ object frmDXCCStat: TfrmDXCCStat
   OnClose = FormClose
   OnCreate = FormCreate
   OnShow = FormShow
-  LCLVersion = '1.2.2.0'
-  object Panel1: TPanel
+  LCLVersion = '2.0.12.0'
+  object pnlStatSum: TPanel
+    AnchorSideLeft.Control = Owner
+    AnchorSideTop.Side = asrBottom
+    AnchorSideRight.Control = Owner
+    AnchorSideRight.Side = asrBottom
+    AnchorSideBottom.Control = Owner
+    AnchorSideBottom.Side = asrBottom
     Left = 0
-    Height = 81
-    Top = 448
-    Width = 711
-    Align = alBottom
-    ClientHeight = 81
-    ClientWidth = 711
+    Height = 80
+    Top = 532
+    Width = 768
+    Anchors = [akLeft, akRight, akBottom]
+    ClientHeight = 80
+    ClientWidth = 768
     TabOrder = 0
-    object Button1: TButton
-      Left = 624
+    object btClose: TButton
+      AnchorSideRight.Control = pnlStatSum
+      AnchorSideRight.Side = asrBottom
+      AnchorSideBottom.Control = pnlStatSum
+      AnchorSideBottom.Side = asrBottom
+      Left = 686
       Height = 25
       Top = 48
       Width = 75
-      Anchors = [akTop, akRight]
+      Anchors = [akRight, akBottom]
+      BorderSpacing.Right = 6
+      BorderSpacing.Bottom = 6
       BorderSpacing.InnerBorder = 4
       Cancel = True
       Caption = '&Close'
@@ -138,179 +149,215 @@ object frmDXCCStat: TfrmDXCCStat
       TabOrder = 0
     end
     object btnHTMLExport: TButton
-      Left = 488
+      AnchorSideRight.Control = btClose
+      AnchorSideBottom.Control = btClose
+      AnchorSideBottom.Side = asrBottom
+      Left = 565
       Height = 25
       Top = 48
       Width = 115
-      Anchors = [akTop, akRight]
+      Anchors = [akRight, akBottom]
+      BorderSpacing.Right = 6
       BorderSpacing.InnerBorder = 4
       Caption = 'Export to HTML'
       OnClick = btnHTMLExportClick
       TabOrder = 1
     end
-    object GroupBox1: TGroupBox
-      Left = 120
+    object gbCW: TGroupBox
+      AnchorSideLeft.Control = gbPhone
+      AnchorSideLeft.Side = asrBottom
+      AnchorSideBottom.Control = gbPhone
+      AnchorSideBottom.Side = asrBottom
+      Left = 117
       Height = 61
-      Top = 8
+      Top = 12
       Width = 104
+      Anchors = [akLeft, akBottom]
+      BorderSpacing.Left = 6
       Caption = ' CW '
-      ClientHeight = 45
+      ClientHeight = 43
       ClientWidth = 102
       TabOrder = 2
       object lblCWWKD: TLabel
+        AnchorSideLeft.Control = gbCW
+        AnchorSideTop.Control = gbCW
         Left = 6
         Height = 15
         Top = 0
-        Width = 25
+        Width = 31
+        BorderSpacing.Left = 6
         Caption = 'wkd:'
         ParentColor = False
       end
       object lblCWCmf: TLabel
+        AnchorSideLeft.Control = lblCWWKD
+        AnchorSideTop.Control = lblCWWKD
+        AnchorSideTop.Side = asrBottom
         Left = 6
         Height = 15
-        Top = 22
-        Width = 26
+        Top = 18
+        Width = 29
+        BorderSpacing.Top = 3
         Caption = 'cfm:'
         ParentColor = False
       end
     end
-    object GroupBox2: TGroupBox
-      Left = 8
+    object gbPhone: TGroupBox
+      AnchorSideLeft.Control = pnlStatSum
+      AnchorSideBottom.Control = pnlStatSum
+      AnchorSideBottom.Side = asrBottom
+      Left = 7
       Height = 61
-      Top = 8
+      Top = 12
       Width = 104
+      Anchors = [akLeft, akBottom]
+      BorderSpacing.Left = 6
+      BorderSpacing.Bottom = 6
       Caption = ' PHONE'
-      ClientHeight = 45
+      ClientHeight = 43
       ClientWidth = 102
       TabOrder = 3
       object lblFoneWKD: TLabel
+        AnchorSideLeft.Control = gbPhone
+        AnchorSideTop.Control = gbPhone
         Left = 6
         Height = 15
-        Top = -1
-        Width = 25
+        Top = 0
+        Width = 31
+        BorderSpacing.Left = 6
         Caption = 'wkd:'
         ParentColor = False
       end
       object lblFoneCmf: TLabel
+        AnchorSideLeft.Control = lblFoneWKD
+        AnchorSideTop.Control = lblFoneWKD
+        AnchorSideTop.Side = asrBottom
         Left = 6
         Height = 15
-        Top = 23
-        Width = 26
+        Top = 18
+        Width = 29
+        BorderSpacing.Top = 3
         Caption = 'cfm:'
         ParentColor = False
       end
     end
-    object GroupBox3: TGroupBox
-      Left = 232
+    object gbDigi: TGroupBox
+      AnchorSideLeft.Control = gbCW
+      AnchorSideLeft.Side = asrBottom
+      AnchorSideBottom.Control = gbCW
+      AnchorSideBottom.Side = asrBottom
+      Left = 227
       Height = 61
-      Top = 8
+      Top = 12
       Width = 104
+      Anchors = [akLeft, akBottom]
+      BorderSpacing.Left = 6
       Caption = ' DIGI '
-      ClientHeight = 45
+      ClientHeight = 43
       ClientWidth = 102
       TabOrder = 4
       object lblDIGIWKD: TLabel
+        AnchorSideLeft.Control = gbDigi
+        AnchorSideTop.Control = gbDigi
         Left = 6
         Height = 15
         Top = 0
-        Width = 25
+        Width = 31
+        BorderSpacing.Left = 6
         Caption = 'wkd:'
         ParentColor = False
       end
       object lblDIGICmf: TLabel
+        AnchorSideLeft.Control = lblDIGIWKD
+        AnchorSideTop.Control = lblDIGIWKD
+        AnchorSideTop.Side = asrBottom
         Left = 6
         Height = 15
-        Top = 22
-        Width = 26
+        Top = 18
+        Width = 29
+        BorderSpacing.Top = 3
         Caption = 'cfm:'
         ParentColor = False
       end
     end
-    object GroupBox4: TGroupBox
-      Left = 344
+    object gbMix: TGroupBox
+      AnchorSideLeft.Control = gbDigi
+      AnchorSideLeft.Side = asrBottom
+      AnchorSideBottom.Control = gbDigi
+      AnchorSideBottom.Side = asrBottom
+      Left = 337
       Height = 61
-      Top = 8
+      Top = 12
       Width = 104
+      Anchors = [akLeft, akBottom]
+      BorderSpacing.Left = 6
       Caption = ' MIX '
-      ClientHeight = 45
+      ClientHeight = 43
       ClientWidth = 102
       TabOrder = 5
       object lblWkdMix: TLabel
+        AnchorSideLeft.Control = gbMix
+        AnchorSideTop.Control = gbMix
         Left = 6
         Height = 15
         Top = 0
-        Width = 25
+        Width = 31
+        BorderSpacing.Left = 6
         Caption = 'wkd:'
         ParentColor = False
       end
       object lblCfmMix: TLabel
+        AnchorSideLeft.Control = lblWkdMix
+        AnchorSideTop.Control = lblWkdMix
+        AnchorSideTop.Side = asrBottom
         Left = 6
         Height = 15
-        Top = 22
-        Width = 26
+        Top = 18
+        Width = 29
+        BorderSpacing.Top = 3
         Caption = 'cfm:'
         ParentColor = False
       end
     end
   end
-  object grdStat: TStringGrid
+  object PnlDXCCStat: TPanel
+    AnchorSideLeft.Control = Owner
+    AnchorSideTop.Control = Owner
+    AnchorSideRight.Control = Owner
+    AnchorSideRight.Side = asrBottom
     Left = 0
-    Height = 144
-    Top = 304
-    Width = 711
-    Align = alBottom
-    ColCount = 27
-    DefaultColWidth = 50
-    DefaultRowHeight = 25
-    FixedCols = 0
-    Font.Name = 'courier [biznet]'
-    ParentFont = False
-    RowCount = 10
-    TabOrder = 1
-    TitleFont.Name = 'courier [biznet]'
-    TitleStyle = tsNative
-  end
-  object grdDXCCStat: TStringGrid
-    Left = 0
-    Height = 254
-    Top = 50
-    Width = 711
-    Align = alClient
-    ColCount = 27
-    DefaultColWidth = 55
-    DefaultRowHeight = 25
-    FixedCols = 0
-    Font.Name = 'dejavu sans mono [dejavu]'
-    Font.Pitch = fpFixed
-    ParentFont = False
-    TabOrder = 2
-    TitleFont.Name = 'dejavu sans mono [dejavu]'
-    TitleFont.Pitch = fpFixed
-    TitleStyle = tsNative
-  end
-  object Panel2: TPanel
-    Left = 0
-    Height = 50
+    Height = 60
     Top = 0
-    Width = 711
-    Align = alTop
+    Width = 768
+    Anchors = [akTop, akLeft, akRight]
     BevelOuter = bvNone
-    ClientHeight = 50
-    ClientWidth = 711
-    TabOrder = 3
-    object Label1: TLabel
-      Left = 19
-      Height = 15
-      Top = 18
-      Width = 91
-      Caption = 'Confirmed type:'
-      ParentColor = False
+    ClientHeight = 60
+    ClientWidth = 768
+    TabOrder = 1
+    object btnRefresh: TButton
+      AnchorSideLeft.Control = cmbCfmType
+      AnchorSideLeft.Side = asrBottom
+      AnchorSideTop.Control = cmbCfmType
+      AnchorSideTop.Side = asrCenter
+      Left = 447
+      Height = 25
+      Top = 13
+      Width = 147
+      BorderSpacing.Left = 32
+      Caption = 'Refresh statistic'
+      OnClick = btnRefreshClick
+      TabOrder = 1
     end
     object cmbCfmType: TComboBox
-      Left = 133
-      Height = 19
-      Top = 10
+      AnchorSideLeft.Control = lblDXCCType
+      AnchorSideLeft.Side = asrBottom
+      AnchorSideTop.Control = lblDXCCType
+      AnchorSideTop.Side = asrCenter
+      Left = 155
+      Height = 29
+      Top = 11
       Width = 260
+      BorderSpacing.Left = 32
       ItemHeight = 0
       ItemIndex = 6
       Items.Strings = (
@@ -326,19 +373,65 @@ object frmDXCCStat: TfrmDXCCStat
       TabOrder = 0
       Text = 'paper QSL, LoTW and eQSL'
     end
-    object btnRefresh: TButton
-      Left = 432
-      Height = 25
-      Top = 14
-      Width = 147
-      Caption = 'Refresh statistic'
-      OnClick = btnRefreshClick
-      TabOrder = 1
+    object lblDXCCType: TLabel
+      AnchorSideLeft.Control = PnlDXCCStat
+      AnchorSideTop.Control = PnlDXCCStat
+      Left = 18
+      Height = 15
+      Top = 18
+      Width = 105
+      BorderSpacing.Left = 18
+      BorderSpacing.Top = 18
+      Caption = 'Confirmed type:'
+      ParentColor = False
     end
+  end
+  object grdDXCCStat: TStringGrid
+    AnchorSideLeft.Control = Owner
+    AnchorSideTop.Control = PnlDXCCStat
+    AnchorSideTop.Side = asrBottom
+    AnchorSideRight.Control = Owner
+    AnchorSideRight.Side = asrBottom
+    AnchorSideBottom.Control = grdStatSum
+    Left = 0
+    Height = 212
+    Top = 60
+    Width = 768
+    Anchors = [akTop, akLeft, akRight, akBottom]
+    ColCount = 27
+    DefaultColWidth = 55
+    DefaultRowHeight = 25
+    FixedCols = 0
+    Font.Name = 'dejavu sans mono [dejavu]'
+    Font.Pitch = fpFixed
+    ParentFont = False
+    TabOrder = 2
+    TitleStyle = tsNative
+  end
+  object grdStatSum: TStringGrid
+    AnchorSideLeft.Control = Owner
+    AnchorSideTop.Side = asrBottom
+    AnchorSideRight.Control = Owner
+    AnchorSideRight.Side = asrBottom
+    AnchorSideBottom.Control = pnlStatSum
+    Left = 0
+    Height = 260
+    Top = 272
+    Width = 768
+    Anchors = [akLeft, akRight, akBottom]
+    ColCount = 27
+    DefaultColWidth = 50
+    DefaultRowHeight = 25
+    FixedCols = 0
+    Font.Name = 'courier [biznet]'
+    ParentFont = False
+    RowCount = 10
+    TabOrder = 3
+    TitleStyle = tsNative
   end
   object dlgSave: TSaveDialog
     FilterIndex = 0
-    left = 568
-    top = 232
+    Left = 568
+    Top = 232
   end
 end

--- a/src/fDXCCStat.pas
+++ b/src/fDXCCStat.pas
@@ -24,15 +24,17 @@ type
   { TfrmDXCCStat }
 
   TfrmDXCCStat = class(TForm)
-    Button1: TButton;
+    btnRefresh: TButton;
+    btClose: TButton;
     btnHTMLExport: TButton;
-    btnRefresh : TButton;
-    cmbCfmType : TComboBox;
-    GroupBox1: TGroupBox;
-    GroupBox2: TGroupBox;
-    GroupBox3: TGroupBox;
-    GroupBox4: TGroupBox;
-    Label1 : TLabel;
+    cmbCfmType: TComboBox;
+    grdDXCCStat: TStringGrid;
+    gbCW: TGroupBox;
+    gbPhone: TGroupBox;
+    gbDigi: TGroupBox;
+    gbMix: TGroupBox;
+    grdStatSum: TStringGrid;
+    lblDXCCType: TLabel;
     lblCfmMix: TLabel;
     lblWkdMix: TLabel;
     lblFoneCmf: TLabel;
@@ -41,11 +43,9 @@ type
     lblFoneWKD: TLabel;
     lblCWWKD: TLabel;
     lblDIGIWKD: TLabel;
-    Panel1: TPanel;
-    grdStat: TStringGrid;
-    grdDXCCStat: TStringGrid;
+    PnlDXCCStat: TPanel;
+    pnlStatSum: TPanel;
     dlgSave: TSaveDialog;
-    Panel2 : TPanel;
     procedure btnHTMLExportClick(Sender: TObject);
     procedure btnRefreshClick(Sender : TObject);
     procedure FormClose(Sender: TObject; var CloseAction: TCloseAction);
@@ -101,20 +101,21 @@ end;
 procedure TfrmDXCCStat.FormShow(Sender: TObject);
 begin
   dmUtils.LoadFontSettings(self);
+  grdStatSum.Constraints.MinHeight:=(grdStatSum.Font.Size+6)*10;
   LoadBandsSettings;
 
   if cqrini.ReadBool('Fonts','GridGreenBar',False) = True then
   begin
     grdDXCCStat.AlternateColor:=$00E7FFEB;
-    grdStat.AlternateColor:=$00E7FFEB;
+    grdStatSum.AlternateColor:=$00E7FFEB;
     grdDXCCStat.Options:=[goRowSelect,goRangeSelect,goSmoothScroll,goVertLine,goFixedVertLine];
-    grdStat.Options:=[goRowSelect,goRangeSelect,goSmoothScroll,goVertLine,goFixedVertLine];
+    grdStatSum.Options:=[goRowSelect,goRangeSelect,goSmoothScroll,goVertLine,goFixedVertLine];
   end
   else begin
     grdDXCCStat.AlternateColor:=clWindow;
-    grdStat.AlternateColor:=clWindow;
+    grdStatSum.AlternateColor:=clWindow;
     grdDXCCStat.Options:=[goRangeSelect,goSmoothScroll,goVertLine,goFixedVertLine,goFixedHorzLine,goHorzline];
-    grdStat.Options:=[goRangeSelect,goSmoothScroll,goVertLine,goFixedVertLine,goFixedHorzLine,goHorzline];
+    grdStatSum.Options:=[goRangeSelect,goSmoothScroll,goVertLine,goFixedVertLine,goFixedHorzLine,goHorzline];
   end;
 
   grdDXCCStat.Cells[0,0] := 'DXCC';
@@ -296,7 +297,7 @@ begin
   for i:=1 to grdDXCCStat.ColCount -1 do
   begin
     Writeln(f,'<TD WIDTH=40 bgcolor="#333366" class="hlava">');
-    tmp := grdStat.Cells[i,0];
+    tmp := grdStatSum.Cells[i,0];
     Writeln(f,'<div align="center" class="popis">' + tmp +  '</div>');
     Writeln(f,'</TD>');
   end;  //^^ table header
@@ -309,7 +310,7 @@ begin
   for i:=1 to grdDXCCStat.ColCount -1 do
   begin
     Writeln(f,'<TD WIDTH=60>');
-    tmp := grdStat.Cells[i,1];
+    tmp := grdStatSum.Cells[i,1];
     Writeln(f,'<P ALIGN=CENTER><FONT SIZE=2>' + tmp +  '</FONT></P>');
     Writeln(f,'</TD>');
   end;
@@ -322,7 +323,7 @@ begin
   for i:=1 to grdDXCCStat.ColCount -1 do
   begin
     Writeln(f,'<TD WIDTH=40>');
-    tmp := grdStat.Cells[i,2];
+    tmp := grdStatSum.Cells[i,2];
     Writeln(f,'<P ALIGN=CENTER><FONT SIZE=2><B>' + tmp +  '</B></FONT></P>');
     Writeln(f,'</TD>');
   end;
@@ -335,7 +336,7 @@ begin
   for i:=1 to grdDXCCStat.ColCount -1 do
   begin
     Writeln(f,'<TD WIDTH=40>');
-    tmp := grdStat.Cells[i,4];
+    tmp := grdStatSum.Cells[i,4];
     Writeln(f,'<P ALIGN=CENTER><FONT SIZE=2>' + tmp +  '</FONT></P>');
     Writeln(f,'</TD>');
   end;
@@ -348,7 +349,7 @@ begin
   for i:=1 to grdDXCCStat.ColCount -1 do
   begin
     Writeln(f,'<TD WIDTH=40>');
-    tmp := grdStat.Cells[i,5];
+    tmp := grdStatSum.Cells[i,5];
     Writeln(f,'<P ALIGN=CENTER><FONT SIZE=2><B>' + tmp +  '</B></FONT></P>');
     Writeln(f,'</TD>');
   end;
@@ -361,7 +362,7 @@ begin
   for i:=1 to grdDXCCStat.ColCount -1 do
   begin
     Writeln(f,'<TD WIDTH=40>');
-    tmp := grdStat.Cells[i,6];
+    tmp := grdStatSum.Cells[i,6];
     Writeln(f,'<P ALIGN=CENTER><FONT SIZE=2>' + tmp +  '</FONT></P>');
     Writeln(f,'</TD>');
   end;
@@ -374,7 +375,7 @@ begin
   for i:=1 to grdDXCCStat.ColCount -1 do
   begin
     Writeln(f,'<TD WIDTH=40>');
-    tmp := grdStat.Cells[i,7];
+    tmp := grdStatSum.Cells[i,7];
     Writeln(f,'<P ALIGN=CENTER><FONT SIZE=2><B>' + tmp +  '</B></FONT></P>');
     Writeln(f,'</TD>');
   end;
@@ -387,7 +388,7 @@ begin
   for i:=1 to grdDXCCStat.ColCount -1 do
   begin
     Writeln(f,'<TD WIDTH=40>');
-    tmp := grdStat.Cells[i,8];
+    tmp := grdStatSum.Cells[i,8];
     Writeln(f,'<P ALIGN=CENTER><FONT SIZE=2>' + tmp +  '</FONT></P>');
     Writeln(f,'</TD>');
   end;
@@ -400,7 +401,7 @@ begin
   for i:=1 to grdDXCCStat.ColCount -1 do
   begin
     Writeln(f,'<TD WIDTH=40>');
-    tmp := grdStat.Cells[i,9];
+    tmp := grdStatSum.Cells[i,9];
     Writeln(f,'<P ALIGN=CENTER><FONT SIZE=2><B>' + tmp +  '</B></FONT></P>');
     Writeln(f,'</TD>');
   end;
@@ -488,20 +489,20 @@ var
   i : Integer = 0;
 begin
   grdDXCCStat.ColCount := cMaxBandsCount;
-  grdStat.ColCount     := cMaxBandsCount;
+  grdStatSum.ColCount     := cMaxBandsCount;
   for i:=0 to cMaxBandsCount-1 do
   begin
     if dmUtils.MyBands[i][0]='' then
     begin
       grdDXCCStat.ColCount := i+2;
-      grdStat.ColCount     := i+1;
+      grdStatSum.ColCount     := i+1;
       break
     end;
     grdDXCCStat.Cells[i+2,0] := dmUtils.MyBands[i][1];
-    grdStat.Cells[i+1,0]     := dmUtils.MyBands[i][1];
+    grdStatSum.Cells[i+1,0]     := dmUtils.MyBands[i][1];
   end;
-  grdDXCCStat.ColWidths[grdStat.ColCount-1] := 50;
-  grdStat.ColWidths[grdStat.ColCount-1]     := 50
+  grdDXCCStat.ColWidths[grdStatSum.ColCount-1] := 50;
+  grdStatSum.ColWidths[grdStatSum.ColCount-1]     := 50
 end;
 
 procedure TfrmDXCCStat.CreateModeStatistic;
@@ -523,9 +524,9 @@ var
       end;
       BandPos := BandPos + 1;
       if dmData.Q.Fields[1].AsString = '' then
-        grdStat.Cells[BandPos,Row] := '0'
+        grdStatSum.Cells[BandPos,Row] := '0'
       else
-        grdStat.Cells[BandPos,Row] := dmData.Q.Fields[1].AsString;
+        grdStatSum.Cells[BandPos,Row] := dmData.Q.Fields[1].AsString;
       dmData.Q.Next
     end
   end;
@@ -582,18 +583,18 @@ const
   C_SEL = 'select band,count(distinct adif) from cqrlog_main where adif <> 0 and ';
 
 begin
-  grdStat.ColWidths[0] := 110;
-  grdStat.Cells[0,1] := 'DXCC';
-  grdStat.Cells[0,2] := 'DXCC CFM';
+  grdStatSum.ColWidths[0] := 110;
+  grdStatSum.Cells[0,1] := 'DXCC';
+  grdStatSum.Cells[0,2] := 'DXCC CFM';
 
-  grdStat.Cells[0,4] := 'DXCC PHONE';
-  grdStat.Cells[0,5] := 'DXCC CFM PHONE';
+  grdStatSum.Cells[0,4] := 'DXCC PHONE';
+  grdStatSum.Cells[0,5] := 'DXCC CFM PHONE';
 
-  grdStat.Cells[0,6] := 'DXCC CW';
-  grdStat.Cells[0,7] := 'DXCC CFM CW';
+  grdStatSum.Cells[0,6] := 'DXCC CW';
+  grdStatSum.Cells[0,7] := 'DXCC CFM CW';
 
-  grdStat.Cells[0,8] := 'DXCC DIGI';
-  grdStat.Cells[0,9] := 'DXCC CFM DIGI';
+  grdStatSum.Cells[0,8] := 'DXCC DIGI';
+  grdStatSum.Cells[0,9] := 'DXCC CFM DIGI';
 
   ShowDel := cqrini.ReadBool('Program','ShowDeleted',False);
 
@@ -1192,22 +1193,22 @@ var
   y   : Integer;
   sum : Word;
 begin
-  grdStat.ColCount := grdStat.ColCount+1;
-  grdStat.Cells[grdStat.ColCount-1,0] := 'Total';
+  grdStatSum.ColCount := grdStatSum.ColCount+1;
+  grdStatSum.Cells[grdStatSum.ColCount-1,0] := 'Total';
 
-  for y:=1 to grdStat.RowCount-1 do
+  for y:=1 to grdStatSum.RowCount-1 do
   begin
-    if grdStat.Cells[0,y] = '' then
+    if grdStatSum.Cells[0,y] = '' then
       Continue;
     sum := 0;
-    for i:=1 to grdStat.ColCount -1 do
+    for i:=1 to grdStatSum.ColCount -1 do
     begin
-      if grdStat.Cells[i,y] <> '' then
-        sum := sum + StrToInt(grdStat.Cells[i,y])
+      if grdStatSum.Cells[i,y] <> '' then
+        sum := sum + StrToInt(grdStatSum.Cells[i,y])
       else
-        grdStat.Cells[i,y] := '0'
+        grdStatSum.Cells[i,y] := '0'
     end;
-    grdStat.Cells[grdStat.ColCount-1,y] := IntToStr(sum)
+    grdStatSum.Cells[grdStatSum.ColCount-1,y] := IntToStr(sum)
   end
 end;
 

--- a/src/uVersion.pas
+++ b/src/uVersion.pas
@@ -10,7 +10,7 @@ const
   cRELEAS     = 2;
   cBUILD      = 1;
 
-  cBUILD_DATE = '2021-08-28';
+  cBUILD_DATE = '2021-08-30';
 
 implementation
 


### PR DESCRIPTION
 Complete layout fix, no code changes.

 **Goal_1:** To make Wkd/Cfm Grid vertically autosized to see all 10 rows all the time without the use of vertical scroll bar. I think this is the main interest grid.
 Status by countries/bands grid is big and needs scrolling anyway.

 **Goal_2:** To fix PHONE group box anchoring so that CWM line does not drop over bottom border line with QT5 widgets.

 Renamed lfm components (for easier location during pos/anchoring)
 Redesigned positions and anchoring
 Added W/C_Gird constraints.minheight setting by font size in form show procedure. Tries to keep all 10 rows visible without scrolling.