### PR TITLE
Fixes to Contest

### DIFF
--- a/src/fContest.lfm
+++ b/src/fContest.lfm
@@ -1,12 +1,12 @@
 object frmContest: TfrmContest
   Left = 370
-  Height = 154
+  Height = 153
   Top = 281
   Width = 700
   HelpType = htKeyword
   HelpKeyword = 'help/contest.html'
   Caption = 'Contest'
-  ClientHeight = 154
+  ClientHeight = 153
   ClientWidth = 700
   OnClose = FormClose
   OnCreate = FormCreate
@@ -608,7 +608,7 @@ object frmContest: TfrmContest
     AnchorSideBottom.Control = Owner
     Left = 0
     Height = 18
-    Top = 136
+    Top = 135
     Width = 700
     Panels = <    
       item
@@ -646,10 +646,22 @@ object frmContest: TfrmContest
     State = cbChecked
     TabOrder = 18
   end
+  object lblSpeed: TLabel
+    AnchorSideLeft.Control = cmbContestName
+    AnchorSideLeft.Side = asrBottom
+    AnchorSideTop.Control = cmbContestName
+    AnchorSideTop.Side = asrCenter
+    Left = 564
+    Height = 1
+    Top = 17
+    Width = 1
+    BorderSpacing.Left = 18
+    ParentColor = False
+  end
   object tmrESC2: TTimer
     Enabled = False
     OnTimer = tmrESC2Timer
-    left = 544
-    top = 8
+    Left = 672
+    Top = 112
   end
 end

--- a/src/fContest.pas
+++ b/src/fContest.pas
@@ -31,6 +31,7 @@ type
     edtRSTr: TEdit;
     edtSRX: TEdit;
     edtSRXStr: TEdit;
+    lblSpeed: TLabel;
     lblContestName: TLabel;
     lblCall: TLabel;
     lblRSTs: TLabel;
@@ -143,8 +144,8 @@ begin
     else
     if Assigned(frmNewQSO.CWint) then
       frmNewQSO.CWint.SendText(dmUtils.GetCWMessage(
-        dmUtils.GetDescKeyFromCode(Key),frmNewQSO.edtCall.Text,
-      frmNewQSO.edtHisRST.Text, frmNewQSO.edtContestSerialSent.Text,frmNewQSO.edtContestExchangeMessageSent.Text,
+        dmUtils.GetDescKeyFromCode(Key),edtCall.Text,
+      edtRSTs.Text, edtSTX.Text,edtSTXStr.Text,
       frmNewQSO.edtName.Text,frmNewQSO.lblGreeting.Caption,''));
     key := 0;
   end;
@@ -156,6 +157,7 @@ begin
       speed := frmNewQSO.CWint.GetSpeed + 2;
       frmNewQSO.CWint.SetSpeed(speed);
       frmNewQSO.sbNewQSO.Panels[4].Text := IntToStr(speed) + 'WPM';
+      lblSpeed.Caption:= frmNewQSO.sbNewQSO.Panels[4].Text;
     end;
     key := 0;
   end;
@@ -167,6 +169,7 @@ begin
       speed := frmNewQSO.CWint.GetSpeed - 2;
       frmNewQSO.CWint.SetSpeed(speed);
       frmNewQSO.sbNewQSO.Panels[4].Text := IntToStr(speed) + 'WPM';
+      lblSpeed.Caption:= frmNewQSO.sbNewQSO.Panels[4].Text;
     end;
     key := 0;
   end;
@@ -393,6 +396,7 @@ begin
   sbContest.Panels[2].Width := 65;
   sbContest.Panels[3].Width := 65;
   sbContest.Panels[4].Width := 20;
+  lblSpeed.Caption:= frmNewQSO.sbNewQSO.Panels[4].Text;
 end;
 
 procedure TfrmContest.btnHelpClick(Sender : TObject);

--- a/src/fNewQSO.pas
+++ b/src/fNewQSO.pas
@@ -6612,6 +6612,7 @@ end;
 procedure TfrmNewQSO.SavePosition;
 begin
   dmUtils.SaveWindowPos(frmNewQSO);
+  if frmContest.Showing then dmUtils.SaveWindowPos(frmContest);
   cqrini.WriteBool('NewQSO','StatBar',sbNewQSO.Visible);
   cqrini.SaveToDisk
 end;

--- a/src/uVersion.pas
+++ b/src/uVersion.pas
@@ -10,7 +10,7 @@ const
   cRELEAS     = 2;
   cBUILD      = 1;
 
-  cBUILD_DATE = '2021-08-30';
+  cBUILD_DATE = '2021-09-19';
 
 implementation
 


### PR DESCRIPTION
After SAC CW 2021 following fixes needed:

	- initial size was a bit too small hiding some checkboxes
	- position and size saving works now also when cqrlog (NewQSO) is closed while contest form is open
	- added CW speed indicator to right side of contest name combo box
	- CW contents are now fetched from contest window (previously from NewQSO)
	  That makes macro %c (callsign) work also when parital call is written. I.E. can send partial call to ask the complete call.