### PR TITLE
Fix to Cabrillo export and fldixi xmlrpc help.

### DIFF
--- a/help/fldxml.html
+++ b/help/fldxml.html
@@ -77,10 +77,11 @@ selection to use XmlRpC.</br>With selection you can choose “the old way” for
 address.</br>
 If you use fldigi on other PC remember to open firewall at fldigi-PC side for TCP traffic to port 7362 from your local network.</p>
 
-<p>Parameter &quot;Drop after SyncErr &gt;&quot; automates remote mode closing when fldigi is closed. But as it may affect also (in slow PCs) fldigi started by cqrlog it can be changed. 0 disables, 1-20 means timer rounds until drop.
- When closing happens it leaves text &quot;Socket error, check fldigi!&quot; to NewQSO field &quot;Comment QSO&quot;.
- </p><p> In all cases fldigi must be started from command line with parameter: <b>fldigi --xmlrpc-server-port 7362</b>
-</br>When closing fldgi properly and answering YES to save setup changes the next start should open xmlrpc server without parameters from usual icon.</p>
+<p>Parameter <b>&quot;Drop after SyncErr &gt;&quot; </b> automates remote mode closing when fldigi is closed. Because SyncError happens when fldigi can not be reached it can cause remote mode closing already at start of entering remote mode in case PC is slow and fldigi is set to start when entering remote mode.
+<br>Therefore the value should be big enough to give time for fldigi to start. Value 0 disables drop, 1-20 means timer rounds to wait before drop the remote mode.
+<br>In case of remote mode drop happens it leaves text <b> &quot;Socket error, check fldigi!&quot; </b>to NewQSO field <b> &quot;Comment QSO&quot; </b> to give information that remote mode dropped by sync error. I.E. fldigi could not be connected. 
+ </p><p> In all cases fldigi must be started from command line with parameter: <b>fldigi --xmlrpc-server-port 7362</b> at least once.
+</br>When closing fldgi properly and answering YES to &quot; save setup changes &quot; question the next start should open xmlrpc server without parameters from usual icon.</p>
 
 <a name=fl3><h3>Use</h3></a>
 <p><img src="img/fxml9.png"  width="446" height="117">

--- a/src/fCabrilloExport.pas
+++ b/src/fCabrilloExport.pas
@@ -382,6 +382,7 @@ type
  end;
 var
   f,r        : TextFile;
+  RejectQso  : boolean;
   tmp        : String;
   mycall,call,
   myloc, loc,
@@ -456,7 +457,10 @@ begin
                               +mb_IconQuestion)=mrYes then
       DeleteFileUTF8(edtCabFileName.Text)
     else
-      exit
+      exit;
+    Application.ProcessMessages;   //closes hanging message box with QT5
+    sleep(10);                     //sleep and
+    Application.ProcessMessages;   //second time is needed for GTK2 to work same way
   end;
   if (trim(edtCabFileName.Text)='') then
   begin
@@ -482,97 +486,93 @@ begin
     begin
       tmp:='';
       // Check for missing mandatory fields
-      if (
-          (dmData.qCQRLOG.FieldByName('qsodate').AsString  = '')
-       or (dmData.qCQRLOG.FieldByName('time_on').AsString  = '')
-       or (dmData.qCQRLOG.FieldByName('callsign').AsString = '')
-       or (CabrilloBandToFreq(dmData.qCQRLOG.FieldByName('band').AsString) = '')  //warc or missing band
-       or (dmData.qCQRLOG.FieldByName('mode').AsString  = '')  //missing mode
-         ) then
-      begin
-        writeln(r,dmData.qCQRLOG.FieldByName('qsodate').AsString,' ',
-                dmData.qCQRLOG.FieldByName('time_on').AsString,' ',
-                dmData.qCQRLOG.FieldByName('callsign').AsString,' ',
-                dmData.qCQRLOG.FieldByName('band').AsString,' ',
-                dmData.qCQRLOG.FieldByName('mode').AsString ,' ',
-                CabrilloBandToFreq(dmData.qCQRLOG.FieldByName('band').AsString));
-        pbCabExport.StepIt;
-        dmData.qCQRLOG.Prior;
-        Continue;
-      end;
+      if (dmData.qCQRLOG.FieldByName('qsodate').AsString  = '') then
+                                                           tmp:=tmp+'Missing qsodate, ';
+      if (dmData.qCQRLOG.FieldByName('time_on').AsString  = '') then
+                                                           tmp:=tmp+'Missing time_on, ';
+      if (dmData.qCQRLOG.FieldByName('callsign').AsString = '') then
+                                                           tmp:=tmp+'Missing callsign, ';
+      if (CabrilloBandToFreq(dmData.qCQRLOG.FieldByName('band').AsString) = '') then
+                                                           tmp:=tmp+'Missing or WARC band, ';
+      if (dmData.qCQRLOG.FieldByName('mode').AsString  = '') then
+                                                           tmp:=tmp+'Missing mode, ';
 
-      // Check for single or ALL band
-      if ( category_band='') then
-          category_band:= dmData.qCQRLOG.FieldByName('band').AsString //initial band
-        else
-       begin
-          if (dmData.qCQRLOG.FieldByName('band').AsString <> category_band) then  //if other bands found then ALL
-            category_band := 'ALL';
-       end;
-        // Check for single or MIXED mode
-      if ( category_mode='') then
-          category_mode:= dmData.qCQRLOG.FieldByName('mode').AsString //initial mode
-        else
-       begin
-          if (dmData.qCQRLOG.FieldByName('mode').AsString <> category_mode) then  //if other modes found then MIXED
-            category_mode := 'MIXED';
-       end;
+      RejectQso := (tmp <> '');
 
-      loc  := copy(dmData.qCQRLOG.FieldByName('loc').AsString,1,4);
-      call := Format('%-'+edtCabCallWdt.Text+'.'+edtCabCallWdt.Text+'s', [dmData.qCQRLOG.FieldByName('callsign').AsString]);
-      adif := dmDXCC.id_country(call,date,pfx,cont,country,itu,waz,posun,lat,long);
-      TotalCountryList.Add(pfx);
+      if not RejectQso then
+       Begin
+              // Check for single or ALL band
+              if ( category_band='') then
+                  category_band:= dmData.qCQRLOG.FieldByName('band').AsString //initial band
+                else
+               begin
+                  if (dmData.qCQRLOG.FieldByName('band').AsString <> category_band) then  //if other bands found then ALL
+                    category_band := 'ALL';
+               end;
+                // Check for single or MIXED mode
+              if ( category_mode='') then
+                  category_mode:= dmData.qCQRLOG.FieldByName('mode').AsString //initial mode
+                else
+               begin
+                  if (dmData.qCQRLOG.FieldByName('mode').AsString <> category_mode) then  //if other modes found then MIXED
+                    category_mode := 'MIXED';
+               end;
 
-      if ((CountryToCount<>0) and (adif = CountryToCount)) then inc(UsrCountryCount);
-      case cont of
-             'NA':       Begin
-                           inc(Continents[0].QsoCount);
-                           if (pos(pfx,Continents[0].WkdPfxs)=0 )then
-                              Continents[0].WkdPfxs:= Continents[0].WkdPfxs+pfx+' ';
-                         end;
-             'SA':       Begin
-                           inc(Continents[1].QsoCount);
-                           if (pos(pfx,Continents[1].WkdPfxs)=0 )then
-                              Continents[1].WkdPfxs:= Continents[1].WkdPfxs+pfx+' ';
-                         end;
-             'OC':       Begin
-                           inc(Continents[2].QsoCount);
-                           if (pos(pfx,Continents[2].WkdPfxs)=0 )then
-                              Continents[2].WkdPfxs:= Continents[2].WkdPfxs+pfx+' ';
-                         end;
-             'AS':       Begin
-                           inc(Continents[3].QsoCount);
-                           if (pos(pfx,Continents[3].WkdPfxs)=0 )then
-                              Continents[3].WkdPfxs:= Continents[3].WkdPfxs+pfx+' ';
-                         end;
-             'EU':       Begin
-                           inc(Continents[4].QsoCount);
-                           if (pos(pfx,Continents[4].WkdPfxs)=0 )then
-                              Continents[4].WkdPfxs:= Continents[4].WkdPfxs+pfx+' ';
-                         end;
-             'AF':       Begin
-                           inc(Continents[5].QsoCount);
-                           if (pos(pfx,Continents[5].WkdPfxs)=0 )then
-                              Continents[5].WkdPfxs:= Continents[5].WkdPfxs+pfx+' ';
-                         end;
-       end; //case
+              loc  := copy(dmData.qCQRLOG.FieldByName('loc').AsString,1,4);
+              call := Format('%-'+edtCabCallWdt.Text+'.'+edtCabCallWdt.Text+'s', [dmData.qCQRLOG.FieldByName('callsign').AsString]);
+              adif := dmDXCC.id_country(call,date,pfx,cont,country,itu,waz,posun,lat,long);
+              TotalCountryList.Add(pfx);
 
-       if (length(loc)=4) then
-                         Begin
-                           if (pos(loc,Continents[6].WkdPfxs)=0 )then
-                            begin
-                              Continents[6].WkdPfxs:= Continents[6].WkdPfxs+loc+' ';
-                              inc(Continents[6].QsoCount);  //here not total, but different count
-                            end;
-                         end;
-      if (dmData.qCQRLOG.FieldByName('operator').AsString <> '') and (Operators.IndexOf(dmData.qCQRLOG.FieldByName('operator').AsString) < 0) then
-         Operators.Add(dmData.qCQRLOG.FieldByName('operator').AsString);
+              if ((CountryToCount<>0) and (adif = CountryToCount)) then inc(UsrCountryCount);
+              case cont of
+                     'NA':       Begin
+                                   inc(Continents[0].QsoCount);
+                                   if (pos(pfx,Continents[0].WkdPfxs)=0 )then
+                                      Continents[0].WkdPfxs:= Continents[0].WkdPfxs+pfx+' ';
+                                 end;
+                     'SA':       Begin
+                                   inc(Continents[1].QsoCount);
+                                   if (pos(pfx,Continents[1].WkdPfxs)=0 )then
+                                      Continents[1].WkdPfxs:= Continents[1].WkdPfxs+pfx+' ';
+                                 end;
+                     'OC':       Begin
+                                   inc(Continents[2].QsoCount);
+                                   if (pos(pfx,Continents[2].WkdPfxs)=0 )then
+                                      Continents[2].WkdPfxs:= Continents[2].WkdPfxs+pfx+' ';
+                                 end;
+                     'AS':       Begin
+                                   inc(Continents[3].QsoCount);
+                                   if (pos(pfx,Continents[3].WkdPfxs)=0 )then
+                                      Continents[3].WkdPfxs:= Continents[3].WkdPfxs+pfx+' ';
+                                 end;
+                     'EU':       Begin
+                                   inc(Continents[4].QsoCount);
+                                   if (pos(pfx,Continents[4].WkdPfxs)=0 )then
+                                      Continents[4].WkdPfxs:= Continents[4].WkdPfxs+pfx+' ';
+                                 end;
+                     'AF':       Begin
+                                   inc(Continents[5].QsoCount);
+                                   if (pos(pfx,Continents[5].WkdPfxs)=0 )then
+                                      Continents[5].WkdPfxs:= Continents[5].WkdPfxs+pfx+' ';
+                                 end;
+               end; //case
 
+               if (length(loc)=4) then
+                                 Begin
+                                   if (pos(loc,Continents[6].WkdPfxs)=0 )then
+                                    begin
+                                      Continents[6].WkdPfxs:= Continents[6].WkdPfxs+loc+' ';
+                                      inc(Continents[6].QsoCount);  //here not total, but different count
+                                    end;
+                                 end;
+              if (dmData.qCQRLOG.FieldByName('operator').AsString <> '') and (Operators.IndexOf(dmData.qCQRLOG.FieldByName('operator').AsString) < 0) then
+                 Operators.Add(dmData.qCQRLOG.FieldByName('operator').AsString);
+       end;   //skip with rejected ends
 
          if ( dmData.qCQRLOG.FieldByName('freq').AsFloat < 50 ) then
-                tmp:= 'QSO: '+Format('%5s',[FloatToStrF(dmData.qCQRLOG.FieldByName('freq').AsFloat*1000,ffFixed,0,0)])+' '
+                tmp:=tmp +  'QSO: '+Format('%5s',[FloatToStrF(dmData.qCQRLOG.FieldByName('freq').AsFloat*1000,ffFixed,0,0)])+' '
                else
-                tmp:= 'QSO: '+Format('%5s',[CabrilloBandToFreq(dmData.qCQRLOG.FieldByName('band').AsString)])+' ';
+                tmp:=tmp +  'QSO: '+Format('%5s',[CabrilloBandToFreq(dmData.qCQRLOG.FieldByName('band').AsString)])+' ';
 
          tmp:=tmp +
             CabrilloMode(dmData.qCQRLOG.FieldByName('mode').AsString)+' '+
@@ -619,10 +619,18 @@ begin
              if (cmbCabTailTxCount.Text<>'') then tmp:=tmp+' '+Format('%1s',[ cmbCabTailTxCount.Text]);
 
       if chkUpCase.Checked then tmp:=UpperCase(tmp);
-      s.Add(tmp);
 
-      inc(i);
+      if not RejectQso then
+         Begin
+             s.Add(tmp);      //add to cabrillo export
+             inc(i);
+         end
+       else
+             writeln(r,tmp); //add to rejected file
+
       pbCabExport.StepIt;
+      pbCabExport.Update;  //GTK2 needs this to show progress, QT5 works even without
+
       dmData.qCQRLOG.Prior
     end;
   except


### PR DESCRIPTION
	-Fixed Cabrillo Reject log QSO format to be same as in Cabrillo export file.
	-Added reject reason in front of every rejected qso line
	-Graphics fixes:
		-- "overwrite existing file" messagebox did not clear up after answering Yes or No
		-- Progress bar did not update when using GTK2 widgets

	-Tried to clear Fldigi xmlrpc help at "drop after sync error" part.