### PR TITLE
Fix for Hamlib CW

### DIFF
--- a/src/cqrlog.lpi
+++ b/src/cqrlog.lpi
@@ -901,7 +901,6 @@
     </CodeGeneration>
     <Linking>
       <Debugging>
-        <GenerateDebugInfo Value="False"/>
         <DebugInfoType Value="dsDwarf2Set"/>
       </Debugging>
     </Linking>

--- a/src/uCWKeying.pas
+++ b/src/uCWKeying.pas
@@ -119,6 +119,9 @@ type
 
   TCWHamLib = class(TCWDevice)
     private
+      ParamChkVfo: boolean;
+      WaitChkVfo: integer;
+      VfoStr : String;
       AllowCW : Boolean;
       fActive : Boolean;
       fSpeed  : Word;
@@ -699,8 +702,36 @@ begin
   if DebugMode then
      Writeln('CWint connected to hamlib');
 
-  tcp.SendMessage('fmv'+LineEnding);
-  SetSpeed(fSpeed)
+  VfoStr := '';
+  ParamChkVfo :=false;
+  WaitChkVfo:=5; // wait max 5 rcvd blocks
+  tcp.SendMessage('+\chk_vfo'+LineEnding);
+  if DebugMode then
+     Writeln('CW send +\chk_vfo');
+end;
+
+procedure TCWHamLib.OnReceived(aSocket: TLSocket);
+begin
+  if aSocket.GetMessage(Rmsg) > 0 then
+   begin
+     Rmsg := StringReplace(Rmsg,LineEnding,' ',[rfReplaceAll]);
+     if (( not ParamChkVfo ) and (WaitChkVfo>0))then
+       Begin
+         dec(WaitChkVfo);
+         if (pos('CHKVFO',Uppercase(Rmsg))>0) then
+         Begin
+           if (pos('1',Rmsg)>0) then
+                                  VfoStr:=' currVFO';
+           if DebugMode then
+               Writeln('CW commands need parameter: ',VfoStr);
+           WaitChkVfo:=0;
+           SetSpeed(fSpeed);
+         end;
+        ParamChkVfo:= WaitChkVfo < 1;
+       end;
+     if DebugMode then
+         Writeln('HLresp MSG:',Rmsg,':');
+   end;
 end;
 
 procedure TCWHamLib.OnHamLibError(const msg: AnsiString; aSocket: TLSocket);
@@ -725,28 +756,24 @@ begin
   tcp.Connect(fDevice,StrToInt(fPort));
 end;
 
-procedure TCWHamLib.OnReceived(aSocket: TLSocket);
-begin
-  if aSocket.GetMessage(Rmsg) > 0 then
-   begin
-    Rmsg := StringReplace(Rmsg,LineEnding,' ',[rfReplaceAll]);
-    if DebugMode then Writeln('HLresp MSG:',Rmsg,':');
-   end;
-end;
 procedure TCWHamLib.WaitMorse;
 begin
-  tcp.SendMessage('\wait_morse' +LineEnding);
+  tcp.SendMessage('\wait_morse'+VfoStr+LineEnding);
+  if DebugMode then
+         Writeln('CW: \wait_morse');
 end;
 
 procedure TCWHamLib.SetSpeed(speed : Word);
+var      tmp:String;
 begin
   if Speed>fMaxSpeed then speed:= fMaxSpeed;
   if Speed<fMinSpeed then speed:= fMinSpeed;
   fSpeed := speed;
+  tmp:= 'L'+VfoStr+' KEYSPD '+IntToStr(speed)+LineEnding;
   if fActive then
-    tcp.SendMessage('L KEYSPD '+IntToStr(speed)+LineEnding);
+    tcp.SendMessage(tmp);
   if fDebugMode then
-    Writeln('CW speed changed to:',fSpeed)
+    Writeln('CW speed changed to:',fSpeed,'  ',tmp)
 end;
 
 function TCWHamLib.GetSpeed  : Word;
@@ -810,7 +837,8 @@ var
 
                         while ((rpt > 0) and AllowCW) do
                           Begin
-                             if fDebugMode then  Writeln('HLsend MSG:','b'+t+':');
+                             if fDebugMode then
+                               Writeln('HLsend MSG:','b'+t+':');
                              Rmsg:='';
                              tcp.SendMessage('b'+t+LineEnding);
                              dec(rpt);

--- a/src/uVersion.pas
+++ b/src/uVersion.pas
@@ -10,7 +10,7 @@ const
   cRELEAS     = 2;
   cBUILD      = 1;
 
-  cBUILD_DATE = '2021-10-11';
+  cBUILD_DATE = '2021-10-14';
 
 implementation
 


### PR DESCRIPTION
	Fixed hamlib CW to work if rigctld was started with parameter "--vfo"
	or without it.
	Fixes issue #450

Squashed commit of the following:

commit ce9ffa3dbca36d4184561c13ccade84ef4fbdcdf
Author: OH1KH <oh1kh@sral.fi>
Date:   Thu Oct 14 20:03:47 2021 +0300

     Small changes and then testing. Seems to be ok now

commit 5b7e56bdbd99d04a29f0a29ceccc44d432bd47a9
Author: OH1KH <oh1kh@sral.fi>
Date:   Thu Oct 14 14:36:34 2021 +0300

    set speed works now. Need still testing

commit f0db148a6c309b706d22005c94d1a498f5c70950
Author: OH1KH <oh1kh@sral.fi>
Date:   Thu Oct 14 12:20:58 2021 +0300

    starting to fix hamlib cw when '--vfo' is used