### PR TITLE
Fixes to adif import/export

### DIFF
--- a/src/fExportProgress.pas
+++ b/src/fExportProgress.pas
@@ -239,6 +239,7 @@ var
         'DOM8','DOM11','DOM16',
         'DOM22','DOM44','DOM88',
         'DOMINOEX','DOMINOF'       : begin tmp := '<MODE:6>DOMINO<SUBMODE:'+IntToStr(length(Mode))+'>'+Mode;SaveTag(tmp,leng);end;
+        'FELDHELL',                 //this is non standard that fldigi uses
         'FMHELL','FSKHELL',
         'HELL80','HELLX5',
         'HELLX9','HFSK',
@@ -260,10 +261,7 @@ var
         'MFSK22','MFSK31','MFSK32',
         'MFSK64','MFSK64L',
         'MFSK128'                   : begin tmp := '<MODE:4>MFSK<SUBMODE:'+IntToStr(length(Mode))+'>'+Mode;SaveTag(tmp,leng);end;
-        'OLIVIA 4/125','OLIVIA 4/250',
-        'OLIVIA 8/250','OLIVIA 8/500',
-        'OLIVIA 16/500','OLIVIA 16/1000',
-        'OLIVIA 32/1000'            : begin tmp := '<MODE:6>OLIVIA<SUBMODE:'+IntToStr(length(Mode))+'>'+Mode;SaveTag(tmp,leng);end;
+         //OLIVIA is exception #1
         'OPERA-BEACON',
         'OPERA-QSO'                 : begin tmp := '<MODE:5>OPERA<SUBMODE:'+IntToStr(length(Mode))+'>'+Mode;SaveTag(tmp,leng);end;
         'PAC2','PAC3','PAC4'        : begin tmp := '<MODE:3>PAC<SUBMODE:'+IntToStr(length(Mode))+'>'+Mode;SaveTag(tmp,leng);end;
@@ -315,10 +313,26 @@ var
         'SITORB'                    : begin tmp := '<MODE:3>TOR<SUBMODE:'+IntToStr(length(Mode))+'>'+Mode;SaveTag(tmp,leng);end;
 
       else           begin
+                      //exceptions follow
+                      if pos('OLIVIA',mode)=1 then
+                        //fldigi marks them with "-" that is against standard " "
+                        //also there are more BW definitions than standard: will pass them all
+                        begin
+                             mode := StringReplace(mode,'-',' ',[rfReplaceAll]);
+                             tmp := '<MODE:6>OLIVIA<SUBMODE:'+IntToStr(length(Mode))+'>'+Mode;SaveTag(tmp,leng);
+                        end
+                       else
+                     //exceptions end
+                       Begin
                         tmp := '<MODE';
                         SaveTag(dmUtils.StringToADIF(tmp,Mode),leng);
+                       end;
                      end;
       end;
+
+
+
+
     end;
     if ExFreq then
     begin

--- a/src/uVersion.pas
+++ b/src/uVersion.pas
@@ -10,7 +10,7 @@ const
   cRELEAS     = 2;
   cBUILD      = 1;
 
-  cBUILD_DATE = '2021-10-11';
+  cBUILD_DATE = '2021-10-15';
 
 implementation
 


### PR DESCRIPTION
        -fixed adif export submode exeption OLIVIA. Fldigi remote saves mode
        with "name-bw" while standard uses " "(space) instead. Replace "-"with " " done.
        There are more BWs in fldigi/olivia than standard. Now passes them all to submode.
        Noted that while fldigi shows modes in unstandard way (that is then transferred
        via remote xmlrpc to cqrlog) it writes its own adif export in stadard form (!!)

        -import will now place all submodes to mode ( issue #448 ) as there is no
        submode column in cqrlog's database. If submode is passed to mode lockSubMode
        is set in case qso record has mode and submode tags in reverse order.
        Lock is cleared on qso record save.

Squashed commit of the following:

commit d47e118ae1c02d97bc5edf27c265e2826f7933cc
Author: OH1KH <oh1kh@sral.fi>
Date:   Fri Oct 15 09:54:24 2021 +0300

    fix

commit 17d308d88f73518a8aa8cd0e2895e6fdc3ede859
Author: OH1KH <oh1kh@sral.fi>
Date:   Fri Oct 15 09:43:03 2021 +0300

    Version date

commit b23dda66166cd3e11baa7a99890afc5e6946a035
Merge: 44d6bca b1a40ed
Author: OH1KH <oh1kh@sral.fi>
Date:   Fri Oct 15 09:20:45 2021 +0300

    Merge branch 'master' into adif_submode_import

commit 44d6bcad850e6d4329a54a0e70bd3962c086ee17
Author: OH1KH <oh1kh@sral.fi>
Date:   Wed Oct 13 10:11:53 2021 +0300

    Fixes to adif import/export

    	-fixed adif export submode exeption OLIVIA. Fldigi remote saves mode
    	with name"-"bw while standard uses " "(space) instead. Replace "-"with " " done.
    	There are more BWs in fldigi/olivia than standard. Now passes them all to submode.
    	Noted that while fldigi shows modes in unstandard way (that is then transferred
    	via remote to cqrlog) it writes its own adif export in stadard form (!!)

    	-import will now place all submodes to mode (issue #448) as there is no
    	submode column in cqrlog's database. If submode is passed to mode lockSubMode
    	is set in case qso record has mode and submode tags in reverse order.
    	Lock is cleared on qso record save.