### PR TITLE
Fix for adif import with date filter

### DIFF
--- a/src/fAdifImport.pas
+++ b/src/fAdifImport.pas
@@ -273,6 +273,7 @@ function TfrmAdifImport.fillTypeVariableWithTagData(h:longint;var data:string;va
 
     fillTypeVariableWithTagData:=true;
     data := trim(data);
+
     case h of
     h_BAND                          :d.BAND:=TrimDataLen(adifTag,data,l_BAND);
     h_CALL                          :d.CALL:=TrimDataLen(adifTag,data,l_CALL);
@@ -400,6 +401,7 @@ begin
     if not IsQsoDateInRange then
     begin
       Inc(FFilteredOutRecNr);
+      initializeTypeVariable(d);
       exit;
     end;
     d.LOTW_QSLSDATE := dmUtils.ADIFDateToDate(d.LOTW_QSLSDATE);

--- a/src/uVersion.pas
+++ b/src/uVersion.pas
@@ -10,7 +10,7 @@ const
   cRELEAS     = 2;
   cBUILD      = 1;
 
-  cBUILD_DATE = '2021-11-12';
+  cBUILD_DATE = '2021-11-17';
 
 implementation
 


### PR DESCRIPTION
	Fixed adif import when date filter is used. If qso was rejected by date the typevariable was not initialized before next qso.

	Thanks to N3GB for reporting the bug.