### PR TITLE
Fix for Contest

### DIFF
--- a/src/fContest.pas
+++ b/src/fContest.pas
@@ -120,6 +120,8 @@ begin
          frmNewQSO.edtQth.Text  :='';        //and qrz, if one wants)
          frmNewQSO.edtGrid.Text :='';        //otherwise we do not get cursor at the end of call
          edtCall.SetFocus;
+         edtCall.SelStart:=length(edtCall.Text);
+         edtCall.SelLength:=0;
       //else
       if Assigned(frmNewQSO.CWint) then
         frmNewQSO.CWint.StopSending;

--- a/src/uVersion.pas
+++ b/src/uVersion.pas
@@ -10,7 +10,7 @@ const
   cRELEAS     = 2;
   cBUILD      = 1;
 
-  cBUILD_DATE = '2021-11-16';
+  cBUILD_DATE = '2021-11-20';
 
 implementation
 


### PR DESCRIPTION
	Fixed 1st ESC to return cursor at the end of callsign without selecting any text. Now adding suffix to partial callsign can continue after 1st ESC right away.