### PR TITLE
Add XW-3 (CAS-9) satellite

### DIFF
--- a/ctyfiles/sat_name.tab
+++ b/ctyfiles/sat_name.tab
@@ -77,3 +77,4 @@ XW-2C|Hope 2C (CAS-3C)
 XW-2D|Hope 2D (CAS-3D)
 XW-2E|Hope 2E (CAS-3E)
 XW-2F|Hope 2F (CAS-2F)
+XW-3|CAS-9


### PR DESCRIPTION
Add new SAT to be launched. See
https://amsat-uk.org/2021/12/18/xw-3-cas-9-launch/