### PR TITLE
Corrected the QRB calculation to be right for REG1, see /node/3292

### DIFF
--- a/src/azidis3.pas
+++ b/src/azidis3.pas
@@ -92,7 +92,8 @@ begin
   c := delx(loc1);
   d := dely(loc1);
   azim  := IntToStr(round(azimut(loc2)));
-  qrb   := IntToStr(round(dis));
+  // Adhere to REG1 QRB calculation, /node/3292
+  qrb   := IntToStr(trunc(dis) + 1);
 end;
 procedure LocToCoordinate(loc : String; var Latitude, Longitude : Real);
 begin


### PR DESCRIPTION
When exporting the EDI file there are sometimes a minor error in the distance calculation. The reason is that the function used do a round of the QRB calculation.

According to IARU-R1 VHF Handbook chapter 5.9.1, page 165, "For the amateur bands up to 10 GHz inclusive, points will be scored on the basis of one point per kilometre, i.e. the calculated distance in kilometres will be truncated to an integer value and 1 km will be added."

However this easy fix might have unwanted side-effects as the calculation is used elsewhere. If this can't be accepted a different function for "started kilometer distance" should be added.

Is it needed two have two different QRB calculations? One rounded and one "started kilometer".