### PR TITLE
dded support for exporting digital modes correct, /node/3293

### DIFF
--- a/src/fEDIExport.lfm
+++ b/src/fEDIExport.lfm
@@ -216,6 +216,25 @@ object frmEDIExport: TfrmEDIExport
     NumbersOnly = True
     TabOrder = 4
   end
+  object lblDigitalModes: TLabel
+    Left = 8
+    Height = 17
+    Top = 296
+    Width = 137
+    Caption = 'Digital Modes:'
+    ParentColor = False
+  end
+  object edtDigitalModes: TEdit
+    AnchorSideLeft.Control = lblContestName
+    AnchorSideLeft.Side = asrBottom
+    AnchorSideTop.Side = asrBottom
+    Left = 122
+    Height = 25
+    Top = 292
+    Width = 307
+    BorderSpacing.Left = 15
+    TabOrder = 6
+  end
   object lblError: TLabel
     Left = 8
     Height = 17

--- a/src/fEDIExport.pas
+++ b/src/fEDIExport.pas
@@ -6,7 +6,7 @@ interface
 
 uses
   Classes, SysUtils, FileUtil, LResources, Forms, Controls, Graphics, Dialogs,
-  StdCtrls, ComCtrls, LCLType, LazFileUtils;
+  StdCtrls, ComCtrls, LCLType, LazFileUtils, StrUtils;
 
 type
 
@@ -25,6 +25,7 @@ type
     edtAntenna: TEdit;
     edtAntennaHeightGroundLevel: TEdit;
     edtTxPower: TEdit;
+    edtDigitalModes: TEdit;
     Label1: TLabel;
     lblError: TLabel;
     lblAntennaHeight: TLabel;
@@ -36,6 +37,7 @@ type
     lblDone: TLabel;
     lblRxEquipment: TLabel;
     lblTxPower: TLabel;
+    lblDigitalModes: TLabel;
     pbExport: TProgressBar;
     procedure btnExportClick(Sender: TObject);
     procedure Button1Click(Sender: TObject);
@@ -72,6 +74,7 @@ begin
   edtContestName.Text := cqrini.ReadString('EdiExport','ContestName','');
   edtTxEquipment.Text := cqrini.ReadString('EdiExport','TxEquipment','');
   edtTxPower.Text := cqrini.ReadString('EdiExport','TxPower','');
+  edtDigitalModes.Text := cqrini.ReadString('EdiExport','DigitalModes','');
   edtRxEquipment.Text := cqrini.ReadString('EdiExport','RxEquipment','');
   edtAntenna.Text := cqrini.ReadString('EdiExport','Antenna','');
   edtAntennaHeightGroundLevel.Text := cqrini.ReadString('EdiExport','AntennaHeightGroundLevel','');
@@ -85,6 +88,7 @@ begin
   cqrini.WriteString('EdiExport','ContestName',edtContestName.Text);
   cqrini.WriteString('EdiExport','TxEquipment',edtTxEquipment.Text);
   cqrini.WriteString('EdiExport','TxPower',edtTxPower.Text);
+  cqrini.WriteString('EdiExport','DigitalModes',edtDigitalModes.Text);
   cqrini.WriteString('EdiExport','RxEquipment',edtRxEquipment.Text);
   cqrini.WriteString('EdiExport','Antenna',edtAntenna.Text);
   cqrini.WriteString('EdiExport','AntennaHeightGroundLevel',edtAntennaHeightGroundLevel.Text);
@@ -103,6 +107,11 @@ begin
     'SSTV': Result := '8';
     'ATV':  Result := '9';
   end; //case
+  if Result = '0' then
+  begin
+    if PosEx(mode, edtDigitalModes.Text) > 0 then
+      Result := '7';
+  end; //if
 end;
 
 function TfrmEDIExport.EdiBand(band: string): String;


### PR DESCRIPTION
As it is now mode code '0' is exported for a QSO when there is no match between the TX mode and the standardized TX modes in IARU-R1 VHF Handbook page 94. This is in line with the standard. But the mode code "7" a.k.a. "RTTY - MGM" (MGM = Machine Generated Mode) is a generic TX mode for all digital modes like FT4, FT8 etc.

Given that there are new digital modes created literally every day a way of mapping these digital modes to mode code "7" would be beneficial. My proposal below proposes a field and when the TX mode matches that field the mode code "7" is used.