### PR TITLE
Fixed ADIF export

### DIFF
--- a/src/fExportProgress.pas
+++ b/src/fExportProgress.pas
@@ -339,7 +339,7 @@ var
       if pos(',',freq) > 0 then
         freq[pos(',',freq)] := '.';
       SaveTag(dmUtils.StringToADIF('<FREQ',Freq),leng);
-      SaveTag(dmUtils.StringToADIF('<BAND',dmUtils.GetAdifBandFromFreq(Freq)),leng);
+      SaveTag(dmUtils.StringToADIF('<BAND',lowercase(dmUtils.GetAdifBandFromFreq(Freq))),leng);
     end;
     if ExRSTS then
       SaveTag(dmUtils.StringToADIF('<RST_SENT',ExtractWord(1,RSTS,[' '])),leng);

--- a/src/uVersion.pas
+++ b/src/uVersion.pas
@@ -19,7 +19,7 @@ const
   cBUILD      = 1;
 
 
-  cBUILD_DATE = '2022-01-27';
+  cBUILD_DATE = '2022-02-11';
 
 
 implementation


### PR DESCRIPTION
	Fixed BAND adif tag data to have lowcase "m" by adif standard.
	https://adif.org/312/ADIF_312_annotated.htm#Band_Enumeration

	If cqrlog adif is imported to program that uses stright adif standard
	without exeptions the band uppercase "M" causes problems.

	It is vice versa as in pull request https://github.com/ok2cqr/cqrlog/pull/482
	where lowcase "m" caused problems to cqrlog.

	Making export with "m" and accepting both cases in import should make everyone happy
	It can cause problems if cqrlog exported adif (with this version "m") is imported
	to older cqrlog. But I expect this kind of case happens more seldom.