### PR TITLE
Fix to label printing

### DIFF
--- a/src/fExLabelPrint.pas
+++ b/src/fExLabelPrint.pas
@@ -209,9 +209,17 @@ begin
 
       dmData.Q.ParamByName('id_cqrlog_main').AsInteger := dmData.qCQRLOG.FieldByName('id_cqrlog_main').AsInteger;
 
-      if dmUtils.IsQSLViaValid(dmData.qCQRLOG.FieldByName('qsl_via').AsString) then
+      //if QSOs are imported from other source they may not have QSLmgr set even it exists
+      //then we look from cqrlog's manager database before making label
+      if dmData.qCQRLOG.FieldByName('qsl_via').AsString='' then
+         dmData.QSLMgrFound(dmData.qCQRLOG.FieldByName('callsign').AsString,
+                            dmData.qCQRLOG.FieldByName('qsodate').AsString,
+                            qsl_via)
+       else
+         qsl_via := dmData.qCQRLOG.FieldByName('qsl_via').AsString;
+
+      if dmUtils.IsQSLViaValid(qsl_via) then
       begin
-        qsl_via := dmData.qCQRLOG.FieldByName('qsl_via').AsString;
         dmData.Q.ParamByName('idcall').AsString  := dmUtils.GetIDCall(qsl_via);
         dmData.Q.ParamByName('dxcc').AsString    := dmDXCC.id_country(dmData.Q.ParamByName('idcall').AsString,
                                                                      dmData.qCQRLOG.FieldByName('qsodate').AsDateTime);

--- a/src/uVersion.pas
+++ b/src/uVersion.pas
@@ -20,7 +20,7 @@ const
 
 
 
-  cBUILD_DATE = '2022-02-21';
+  cBUILD_DATE = '2022-03-01';
 
 
 implementation


### PR DESCRIPTION
If there are qsos that are imported from another program they may not have
QSL manager information. It is not added in adif import process even when cqrlog's
manger database has the information.

Normally this does not show up to user because if the qso is viewed or edited QSL manager information is fetched from database. In case of just view qso user may think manager info is OK.
How ever it is saved to qso record only when editing qso.

When user prints QSL labels they are then printed without manager info.

This fix checks QSL manager, and if empty, tries to find one from cqrlog's mgr database. If valid mgr is found it is added to QSL label, but not to original qso record keeping it clean.