### PR TITLE
Fixes to mode/submode handling

### DIFF
--- a/help/h1.html
+++ b/help/h1.html
@@ -320,8 +320,47 @@ Some <strong>TRX like ICOM don't have support for this in HamLib. To get mode se
 all values to 0 (zero).</strong>
 </p><p><strong>User definable digital modes</strong> can be set up in a separate box. Use comma
 as a separator, ie. MYMODE1,MYMODE2 etc.<br>
-If user adds digital modes (submode names) exactly as written in this table <a href="https://adif.org/312/ADIF_312.htm#Mode_Enumeration">ADIF.org: Mode_Enumeration</a> ADIF export will place correct mode and submode tags to exported file.
- Submode list is copied at 2021-08-25 and may need updating of source code some day in future.
+user should add digital modes (submode names) exactly as written in this table <a href="https://adif.org/312/ADIF_312.htm#Mode_Enumeration">ADIF.org: Mode_Enumeration</a> 
+If mode is missing from <strong>NewQSO/mode</strong> selection list and not added to <strong>User defined digital modes</strong> it may prevent ADIF import causing "wrong mode" error.
+</p><p>
+<strong>Note:</strong><br>
+Cqrlog uses internally modefied mode name. We call it here <strong>CqrMode</strong>. CqrMode is created from ADIF mode and submode with conversion table. CqrMode is mainly ADIF submode if it exist, with some exceptions.
+<br>Cqrlog will create four files in ~/.config/cqrlog folder for this use if they do not exist. One is a brief <strong>README_modefiles</strong> explaining three other files purposes.
+<br><br>If files exist they are not overwritten keeping possible user changes there. How ever user must do backups by himself if files are edited from original format.
+These files apply to all logs created. They are not log based.
+<ul>
+<li><strong>submode_mode.txt</strong>
+<br> This file holds submode=mode pairs used to convert incoming mode+submode pair to CqrMode that mainly is the submode.
+<br><br> All pairs must be in uppercase format. User can add or delete mode pairs with text editor if definition at
+<br> <a href="https://adif.org/312/ADIF_312.htm#Mode_Enumeration">ADIF.org: Mode_Enumeration</a> changes. 
+<br>"Self invented" mode names should not be used! Just one mode pair is accepted in one line.
+<br> The first line is never read (lower case). It just shows the order of submode and mode.
+<br><br>This file is used also when qso record is ADIF exported. Then CqrMode is converted back to mode+sumbode tags.
+<br>
+</li>
+<li><strong>import_mode.txt</strong>
+<br>This file holds a list of deprecated ADIF submodes that are accepted only for input. They are used in CqrModes but they will never be ADIF exported out from Cqrlog.
+<br><br> All lines must be in uppercase format. User can add or delete lines with text editor if definition at
+<br> <a href="https://adif.org/312/ADIF_312.htm#Mode_Enumeration">ADIF.org: Mode_Enumeration</a> changes. 
+<br>"Self invented" mode names should not be used!  Just one mode is accepted in one line.
+<br> The first line is never read (lower case). It just shows the meaning of then list. 
+<br><br>This file is used also when qso record is ADIF exported. It prevents submode in list to export and only mode is exported.
+<br>
+
+</li>
+<li><strong>exception_mode.txt</strong>
+<br>This file holds submode=mode pairs used to convert incoming mode+submode pair to CqrMode when CqrMode can not use ADIF submode directly.
+<br>For example by ADIF definition mode SSB  has submodes USB and LSB. How ever Cqrlog does not use those as CqrMode, but uses only SSB.
+ Then CqrMode is converted as SSB. How ever after exception the mode can not have it's submode back when exporting ADIF from Cqrlog.
+<br><br>This file can also have conversion from rigctld given mode to ADIF mode. For example with IC7300 rigctld shows mode PACKETUSB if rig is set to usb and data mode:
+<br> then this file can convert PACKETUSB to PKT that is ADIF standard format.
+<br><br> All pairs must be in uppercase format. User can add or delete mode pairs with text editor when needed.
+<br>How ever in case of outgoing modes (outgoing mode is at right side of mode pair) <a href="https://adif.org/312/ADIF_312.htm#Mode_Enumeration">ADIF.org: Mode_Enumeration</a> should be used.
+<br>"Self invented" mode names should not be used! Just one mode pair is accepted in one line.
+<br> The first line is never read (lower case). It just shows the order of submode and mode.
+</li>
+</ul>
+
 </p>
 <p align=center><img src=img/line.png></p>
 <a name=ah9><h2><strong>QTH Profiles</strong></h2></a>

--- a/src/dLogUpload.pas
+++ b/src/dLogUpload.pas
@@ -514,6 +514,10 @@ begin
     time_on := Q2.FieldByName('time_on').AsString;
     time_on := copy(time_on,1,2) + copy(time_on,4,2);
 
+    //2022-05-05 OH1KH I do not know (I can not test) are mode+submode pairs needed with log uploads
+    // or is the CqrMode ok here ???????
+    //If mode+submode needed then  use dmUtils.ModeFromCqr to get mode and submode at this point
+    // (look sample from fLoTWExport.pas line 453-460)
     adif := GetAdifValue('QSO_DATE',qsodate)+GetAdifValue('TIME_ON',time_on)+
             GetAdifValue('CALL',Q2.FieldByName('callsign').AsString)+
             GetAdifValue('BAND',Q2.FieldByName('band').AsString)+

--- a/src/dUtils.lfm
+++ b/src/dUtils.lfm
@@ -1,26 +1,26 @@
 object dmUtils: TdmUtils
   OnCreate = DataModuleCreate
+  OnDestroy = DataModuleDestroy
   OldCreateOrder = False
   Height = 300
   HorizontalOffset = 365
   VerticalOffset = 366
   Width = 400
-  PPI = 96
   object HelpDatabase: THTMLHelpDatabase
     BaseURL = 'file:///usr/share/cqrlog/help'
     AutoRegister = True
     KeywordPrefix = 'help/'
-    left = 176
-    top = 40
+    Left = 176
+    Top = 40
   end
   object HelpViewer: THTMLBrowserHelpViewer
     BrowserParams = '%s'
     AutoRegister = True
-    left = 272
-    top = 40
+    Left = 272
+    Top = 40
   end
   object Datasource1: TDataSource
-    left = 56
-    top = 48
+    Left = 56
+    Top = 48
   end
 end

--- a/src/fCabrilloExport.pas
+++ b/src/fCabrilloExport.pas
@@ -208,6 +208,8 @@ begin
 end;
 
 function TfrmCabrilloExport.CabrilloMode(mode: string): String;
+//2022-05-05 OH1KH It seems that Cabrilllo mode can be CqrMode (mainly CW,SSB,AM,FM,RTTY)(I.E. no mode+submode pairs needed)
+//otherwise use dmUtils.ModeFromCqr to get mode and submode at this function
 begin
   Result := '';
   case mode of

--- a/src/fEDIExport.pas
+++ b/src/fEDIExport.pas
@@ -102,6 +102,8 @@ begin
 end;
 
 function TfrmEDIExport.EdiMode(mode: string): String;
+//2022-05-05 OH1KH It seems that EDI mode can be CqrMode (I.E. no mode+submode pairs needed)
+//otherwise use dmUtils.ModeFromCqr to get mode and submode at this point
 begin
   Result := '0';
   case mode of

--- a/src/fExportProgress.pas
+++ b/src/fExportProgress.pas
@@ -188,7 +188,10 @@ var
                      srx, stx_string, srx_string, contestname, Darc_Dok : String);
 
   var
-     station_callsign : String;
+     station_callsign  : String;
+     OutMode,
+     OutSubmode        :String;
+
   begin
     station_callsign := cqrini.ReadString('Station', 'Call', '');
     leng := 0;
@@ -219,120 +222,11 @@ var
     if ExCall then
       SaveTag(dmUtils.StringToADIF('<CALL',dmUtils.RemoveSpaces(call)),leng);
     if ExMode then
-    begin
-      case Mode of
-        'PACKET'                   : begin tmp := '<MODE:3>PKT'; SaveTag(tmp,leng); end;
-        //these modes come from ICOM rig (IC7300) when DATA is selected with USB,LSB,FM or AM
-        //and checkbox "auto" for mode is selected in NewQSO
-        //There is not clear what mode is then actually used (depends on additional program in use)
-        //but we put them all to PKT category here
-        'PKTUSB'                   : begin tmp := '<MODE:3>PKT'; SaveTag(tmp,leng); end;
-        'PKTLSB'                   : begin tmp := '<MODE:3>PKT'; SaveTag(tmp,leng); end;
-        'PKTFM'                    : begin tmp := '<MODE:3>PKT'; SaveTag(tmp,leng); end;
-        'PKTAM'                    : begin tmp := '<MODE:3>PKT'; SaveTag(tmp,leng); end;
-
-        //definitions by https://adif.org/312/ADIF_312.htm#Mode_Enumeration
-
-        'CHIP64','CHIP128'         : begin tmp := '<MODE:4>CHIP<SUBMODE:'+IntToStr(length(Mode))+'>'+Mode;SaveTag(tmp,leng);end;
-        'PCW'                      : begin tmp := '<MODE:2>CW<SUBMODE:'+IntToStr(length(Mode))+'>'+Mode;SaveTag(tmp,leng);end;
-        'DOM-M','DOM4','DOM5',
-        'DOM8','DOM11','DOM16',
-        'DOM22','DOM44','DOM88',
-        'DOMINOEX','DOMINOF'       : begin tmp := '<MODE:6>DOMINO<SUBMODE:'+IntToStr(length(Mode))+'>'+Mode;SaveTag(tmp,leng);end;
-        'FELDHELL',                 //this is non standard that fldigi uses
-        'FMHELL','FSKHELL',
-        'HELL80','HELLX5',
-        'HELLX9','HFSK',
-        'PSKHELL','SLOWHELL'       : begin tmp := '<MODE:4>HELL<SUBMODE:'+IntToStr(length(Mode))+'>'+Mode;SaveTag(tmp,leng);end;
-        'ISCAT-A','ISCAT-B'        : begin tmp := '<MODE:5>ISCAT<SUBMODE:'+IntToStr(length(Mode))+'>'+Mode;SaveTag(tmp,leng);end;
-        'JT4A','JT4B','JT4C',
-        'JT4D','JT4E','JT4F',
-        'JT4G'                     : begin tmp := '<MODE:3>JT4<SUBMODE:'+IntToStr(length(Mode))+'>'+Mode;SaveTag(tmp,leng);end;
-        'JT9-1','JT9-2','JT9-5',
-        'JT9-10','JT9-30',
-        'JT9A','JT9B','JT9C',
-        'JT9D','JT9E','JT9E FAST',
-        'JT9F','JT9F FAST','JT9G',
-        'JT9G FAST','JT9H',
-        'JT9H FAST'                 : begin tmp := '<MODE:3>JT9<SUBMODE:'+IntToStr(length(Mode))+'>'+Mode;SaveTag(tmp,leng);end;
-        'FSQCALL','FST4','FST4W',
-        'FT4','JS8','JTMS','MFSK4',
-        'MFSK8','MFSK11','MFSK16',
-        'MFSK22','MFSK31','MFSK32',
-        'MFSK64','MFSK64L',
-        'MFSK128'                   : begin tmp := '<MODE:4>MFSK<SUBMODE:'+IntToStr(length(Mode))+'>'+Mode;SaveTag(tmp,leng);end;
-         //OLIVIA is exception #1
-        'OPERA-BEACON',
-        'OPERA-QSO'                 : begin tmp := '<MODE:5>OPERA<SUBMODE:'+IntToStr(length(Mode))+'>'+Mode;SaveTag(tmp,leng);end;
-        'PAC2','PAC3','PAC4'        : begin tmp := '<MODE:3>PAC<SUBMODE:'+IntToStr(length(Mode))+'>'+Mode;SaveTag(tmp,leng);end;
-        'PAX2'                      : begin tmp := '<MODE:3>PAX<SUBMODE:'+IntToStr(length(Mode))+'>'+Mode;SaveTag(tmp,leng);end;
-        '8PSK125','8PSK125F',
-        '8PSK125FL','8PSK250',
-        '8PSK250F','8PSK250FL',
-        '8PSK500','8PSK500F',
-        '8PSK1000','8PSK1000F',
-        '8PSK1200F','FSK31','PSK10',
-        'PSK31','PSK63','PSK63F',
-        'PSK63RC4','PSK63RC5',
-        'PSK63RC10','PSK63RC20',
-        'PSK63RC32','PSK125',
-        'PSK125C12','PSK125R',
-        'PSK125RC10','PSK125RC12',
-        'PSK125RC16','PSK125RC4',
-        'PSK125RC5','PSK250',
-        'PSK250C6','PSK250R',
-        'PSK250RC2','PSK250RC3',
-        'PSK250RC5','PSK250RC6',
-        'PSK250RC7','PSK500',
-        'PSK500C2','PSK500C4',
-        'PSK500R','PSK500RC2',
-        'PSK500RC3','PSK500RC4',
-        'PSK800C2','PSK800RC2',
-        'PSK1000','PSK1000C2',
-        'PSK1000R','PSK1000RC2',
-        'PSKAM10','PSKAM31',
-        'PSKAM50','PSKFEC31',
-        'QPSK31','QPSK63',
-        'QPSK125','QPSK250',
-        'QPSK500','SIM31'           : begin tmp := '<MODE:3>PSK<SUBMODE:'+IntToStr(length(Mode))+'>'+Mode;SaveTag(tmp,leng);end;
-        'QRA64A','QRA64B','QRA64C',
-        'QRA64D','QRA64E'           : begin tmp := '<MODE:5>QRA64<SUBMODE:'+IntToStr(length(Mode))+'>'+Mode;SaveTag(tmp,leng);end;
-        'ROS-EME','ROS-HF',
-        'ROS-MF'                    : begin tmp := '<MODE:3>ROS<SUBMODE:'+IntToStr(length(Mode))+'>'+Mode;SaveTag(tmp,leng);end;
-        'ASCI','ASCII'              : begin tmp := '<MODE:4>RTTY<SUBMODE:'+IntToStr(length(Mode))+'>'+Mode;SaveTag(tmp,leng);end;
-        'LSB','USB'                 : begin tmp := '<MODE:3>SSB<SUBMODE:'+IntToStr(length(Mode))+'>'+Mode;SaveTag(tmp,leng);end;
-        'THOR-M','THOR4','THOR5',
-        'THOR8','THOR11','THOR16',
-        'THOR22','THOR25X4',
-        'THOR50X1','THOR50X2',
-        'THOR100'                   : begin tmp := '<MODE:4>THOR<SUBMODE:'+IntToStr(length(Mode))+'>'+Mode;SaveTag(tmp,leng);end;
-        'THRBX','THRBX1','THRBX2',
-        'THRBX4','THROB1','THROB2',
-        'THROB4'                    : begin tmp := '<MODE:4>THRB<SUBMODE:'+IntToStr(length(Mode))+'>'+Mode;SaveTag(tmp,leng);end;
-        'AMTORFEC','GTOR','NAVTEX',
-        'SITORB'                    : begin tmp := '<MODE:3>TOR<SUBMODE:'+IntToStr(length(Mode))+'>'+Mode;SaveTag(tmp,leng);end;
-
-      else           begin
-                      //exceptions follow
-                      if pos('OLIVIA',mode)=1 then
-                        //fldigi marks them with "-" that is against standard " "
-                        //also there are more BW definitions than standard: will pass them all
-                        begin
-                             mode := StringReplace(mode,'-',' ',[rfReplaceAll]);
-                             tmp := '<MODE:6>OLIVIA<SUBMODE:'+IntToStr(length(Mode))+'>'+Mode;SaveTag(tmp,leng);
-                        end
-                       else
-                     //exceptions end
-                       Begin
-                        tmp := '<MODE';
-                        SaveTag(dmUtils.StringToADIF(tmp,Mode),leng);
-                       end;
-                     end;
-      end;
-
-
-
-
+    Begin
+        dmUtils.ModeFromCqr(mode,OutMode,OutSubmode,dmData.DebugLevel>=1);
+        SaveTag(dmUtils.StringToADIF('<MODE',OutMode),leng);
+        if OutSubmode<>'' then
+                          SaveTag(dmUtils.StringToADIF('<SUBMODE',OutSubmode),leng);
     end;
     if ExFreq then
     begin

--- a/src/fLoTWExport.pas
+++ b/src/fLoTWExport.pas
@@ -365,10 +365,12 @@ end;
 
 function TfrmLoTWExport.ExportToAdif : Word;
 var
-  f    : TextFile;
-  tmp  : String  = '';
-  nr   : Integer = 1;
-  date : String;
+  f         : TextFile;
+  tmp       : String  = '';
+  nr        : Integer = 1;
+  date,
+  ModeOut,
+  SubmodeOut: String;
 begin
   if FileExists(FileName) then
     DeleteFile(FileName);
@@ -447,35 +449,15 @@ begin
 
       tmp := dmUtils.StringToADIF('<CALL',dmUtils.RemoveSpaces(dmData.Q1.FieldByName('callsign').AsString));
       Writeln(f,tmp);
-      case dmData.Q1.FieldByName('mode').AsString of
-         'JS8'        :   begin
-                            tmp := '<MODE:4>MFSK';
-                            Writeln(f,tmp);
-                            tmp := '<SUBMODE:3>JS8';
-                            Writeln(f,tmp);
-                          end;
-         'FT4'        :   begin
-                            tmp := '<MODE:4>MFSK';
-                            Writeln(f,tmp);
-                            tmp := '<SUBMODE:3>FT4';
-                            Writeln(f,tmp);
-                          end;
-         'FST4'        :   begin
-                            tmp := '<MODE:4>MFSK';
-                            Writeln(f,tmp);
-                            tmp := '<SUBMODE:4>FST4';
-                            Writeln(f,tmp);
-                          end;
-         'PACKET'      :  begin
-                              tmp := '<MODE:3>PKT';
-                              Writeln(f,tmp);
-                          end;
-        else
-           begin
-              tmp := dmUtils.StringToADIF('<MODE',dmData.Q1.FieldByName('mode').AsString);
-              Writeln(f,tmp);
-            end;
-       end;
+
+      dmUtils.ModeFromCqr(dmData.Q1.FieldByName('mode').AsString,ModeOut,SubmodeOut,dmData.DebugLevel >= 1);
+      tmp := dmUtils.StringToADIF('<MODE',ModeOut);
+      Writeln(f,tmp);
+      if SubmodeOut<>'' then
+                        Begin
+                          tmp := dmUtils.StringToADIF('<SUBMODE',SubmodeOut);
+                          Writeln(f,tmp);
+                        end;
 
       tmp :=dmUtils.StringToADIF( '<BAND' , dmData.Q1.FieldByName('band').AsString);
       Writeln(f,tmp);

--- a/src/fMain.pas
+++ b/src/fMain.pas
@@ -723,7 +723,8 @@ var
     if dmData.trQ.Active then
       dmData.trQ.RollBack;
     dmData.Q.SQL.Text := 'DELETE FROM cqrlog_main WHERE id_cqrlog_main = ' + IntToStr(idx);
-    WriteLn(dmData.Q.SQL.Text);
+    if dmData.DebugLevel >= 1 then
+                                  WriteLn(dmData.Q.SQL.Text);
     dmData.trQ.StartTransaction;
     dmData.Q.ExecSQL;
     dmData.trQ.Commit

--- a/src/fSOTAExport.pas
+++ b/src/fSOTAExport.pas
@@ -199,7 +199,10 @@ begin
               dmUtils.DateInSOTAFormat(dmData.Q.FieldByName('qsodate').AsDateTime)+',',
               StringReplace(dmData.Q.FieldByName('time_on').AsString,':','',[rfReplaceAll, rfIgnoreCase])+',',
               FormatFloat('0.00;;',dmData.Q.FieldByName('freq').AsFloat),'MHz,',
+              //2022-05-05 OH1KH It seems that SOTA mode can be CqrMode (mainly CW,SSB,FM,AM)(I.E. no mode+submode pairs needed)
+              //otherwise use dmUtils.ModeFromCqr to get mode and submode at this point
               dmData.Q.FieldByName('mode').AsString,',',
+
               dmData.Q.FieldByName('callsign').AsString,',',  //his callsign
               HisSota+',', //his summit
               note  //comments

--- a/src/fXfldigi.pas
+++ b/src/fXfldigi.pas
@@ -237,6 +237,7 @@ var
    Drop   :integer;
    tmp    :extended;
 
+
 begin
   frmNewQSO.tmrFldigi.Enabled := false;
   SockOK := true;
@@ -281,10 +282,12 @@ begin
                   mode:='';submode:='';
                   if SockOK then SockOK := PollFldigi('modem.get_mode',mode);
                   if SockOK then SockOK := PollFldigi('modem.get_submode',submode);
-                  if mode='' then  //old version of fldigi, make different query
+                  if mode='' then  //old version of fldigi get_mode not supported, make different query
+                     Begin
                       if SockOK then SockOK := PollFldigi('modem.get_name',mode);
-                  //cqrlog saves submode as mode
-                  if submode<>'' then mode := submode;
+                     end
+                    else
+                      mode:=dmUtils.ModeToCqr(mode,submode,dmData.DebugLevel>=1 );
                 end;
             2 : begin
                   mode := cqrini.ReadString('fldigi','defmode','RTTY');

--- a/src/feQSLUpload.pas
+++ b/src/feQSLUpload.pas
@@ -69,9 +69,12 @@ end;
 
 function TfrmeQSLUpload.ExportData(const FileName : String) : Boolean;
 var
-  nr  : integer = 0;
-  tmp : String = '';
-  f   : TextFile;
+  nr         : integer = 0;
+  tmp        : String = '';
+  ModeOut,
+  SubmodeOut : String;
+  f          : TextFile;
+
 begin
   QSOCount := 0;
   Result := True;
@@ -132,34 +135,14 @@ begin
       tmp := dmUtils.StringToADIF('<CALL' ,dmUtils.RemoveSpaces(dmData.Q.FieldByName('callsign').AsString));
       Writeln(f,tmp);
 
-      case dmData.Q.FieldByName('mode').AsString of
-      'JS8'   : begin
-                  tmp := '<MODE:4>MFSK';
-                  Writeln(f,tmp);
-                  tmp := '<SUBMODE:3>JS8';
-                  Writeln(f,tmp);
-                end;
-      'FT4'   : begin
-                  tmp := '<MODE:4>MFSK';
-                  Writeln(f,tmp);
-                  tmp := '<SUBMODE:3>FT4';
-                  Writeln(f,tmp);
-                end;
-      'FST4'  : begin
-                  tmp := '<MODE:4>MFSK';
-                  Writeln(f,tmp);
-                  tmp := '<SUBMODE:4>FST4';
-                  Writeln(f,tmp);
-                end;
-      'PACKET': begin
-                  tmp := '<MODE:3>PKT';
-                  Writeln(f,tmp);
-                end;
-      else      begin
-                  tmp := dmUtils.StringToADIF('<MODE',dmData.Q.FieldByName('mode').AsString);
-                  Writeln(f,tmp);
-                end;
-      end;
+      dmUtils.ModeFromCqr(dmData.Q.FieldByName('mode').AsString,ModeOut,SubmodeOut,dmData.DebugLevel >= 1);
+      tmp := dmUtils.StringToADIF('<MODE',ModeOut);
+      Writeln(f,tmp);
+      if SubmodeOut<>'' then
+                       Begin
+                         tmp := dmUtils.StringToADIF('<SUBMODE',SubmodeOut);
+                         Writeln(f,tmp);
+                       end;
 
       tmp := dmUtils.StringToADIF('<BAND' ,dmData.Q.FieldByName('band').AsString);
       Writeln(f,tmp);

--- a/src/uADIFhash.pas
+++ b/src/uADIFhash.pas
@@ -76,6 +76,7 @@ const l_LOTW_QSLSDATE = 10;            // lotw_qslsdate    date
 const l_LOTW_QSL_RCVD = 2;             // lotw_qslr        varchar(3)
 const l_LOTW_QSL_SENT = 2;             // lotw_qsls        varchar(3)
 const l_MODE = 12;                     // mode             varchar(12)
+const l_SUBMODE = 12;                  // submode          this is never stored, no database column. Just for cqrmode conversion
 const l_MY_GRIDSQUARE = 6;             // my_loc           varchar(10)
 const l_NAME = 40;//50;                     // name             varchar(40)
 const l_NOTES = 250;                   // notes.longremarks  varchar(256)

--- a/src/uVersion.pas
+++ b/src/uVersion.pas
@@ -18,7 +18,7 @@ const
   cRELEAS     = 2;
   cBUILD      = 1;
 
-  cBUILD_DATE = '2022-04-09';
+  cBUILD_DATE = '2022-05-05';
 
 implementation
 


### PR DESCRIPTION
This fix does not affect "classic" modes CW,AM,FM and SSB that already has had conversion from USB/LSB to SSB.

How ever there are hundreds of submodes in adif standard.

IMHO the idea of mode and submode is not very clever. I would like to see all submodes
to be modes, and then then there would be modegroups instead.
This way mode would be mandatory information and modegroup just makes genres of them if that is needed for awards or other kinds of grouping.

But we have to live with this. This fix makes conversion from mode+submode to "CqrMode"
that mainly is submode in ADIF standard. How ever there are some exceptions.

A part of submodes are "for import only" by ADIF standard. They should be accepted in
import, but never exported. It seems that at least eQSL does not follow that standard
sending mode:RTTY submode:ASCI in doenwload if user has uploaded it that way to eQSL.

Another execptions come from Cqrlog itself. Mentioned submodes LSB and USB are logged
in Cqrlog as SSB (that is the mode, not submode).
Then rigctld may set mode to PACKET, USBPACKET... etc. with Icom rigs in data mode.
This, if logged that way, is not ADIF standard mode and must be converted to PKT that
is ADIF standard mode.

To do these conversions we need function/procedure "ModeToCqr()" and "ModeFromCqr()"
Those functions use conversion tables from files "submode_mode.txt" (the main mode/submode table), "import_mode.txt" (table of import only submodes) and "exception_mode.txt" (special conversion for Cqrlog in/out)

![image](https://user-images.githubusercontent.com/12532164/167242305-a3e76de0-f9a0-4b64-a579-f34c9583cf55.png)

If files do not exist they are created at Cqrlog start to ~/.config/cqrlog folder with breaf "README_modefiles" explanation file.
After that files are not touched and user can make changes by himself without programming and compile if something changes in ADIF standard.
Files are loaded to String Lists at Cqrlog start.

"ModeToCqr()" and "ModeFromCqr()" usage is added to all routines that uses ADIF import or export.

Excluding online logging. I do not use them, can not test, and did not find explanation of their API and mode/submode usage there.

There is still work to do with exports as I have seen that there are many export routines
doing same kind of jobs that could be combined to one "common export" or "create adif record" procedure. That maybe later...

---------------

Help files updated (Quick start/modes)

---------------

Improved external database server's backups script. Makes now one common mysqldump from all
cqr* databases and separate dumps from each one with date/time stamp on filename.

---------------

Squashed commit of the following:

commit dc1ca22633eefa9365961a551e6b9d1585f23cc8
Author: OH1KH <oh1kh@sral.fi>
Date:   Fri May 6 17:35:47 2022 +0300

    Fixed some comments

commit 4ec5ddf25c37de627a5d8fc876add35aee5f6de9
Author: OH1KH <oh1kh@sral.fi>
Date:   Thu May 5 20:03:17 2022 +0300

    Changed modefile directory. Updated help files

commit 7a0c5de47f5e3de58f4ab9f364892bdc92f1aa62
Author: OH1KH <oh1kh@sral.fi>
Date:   Thu May 5 13:10:03 2022 +0300

    Assigned and tested eQSL and LoTW uploads. For other uploads: checked them, but cannot be sure with online logs (I can not test them)

commit dfb35ef2df5bec37913d3150f9dc5afb2386b477
Author: OH1KH <oh1kh@sral.fi>
Date:   Thu May 5 11:18:45 2022 +0300

    Tested eQSl and LoTW downloads

commit 79a2072d21cc82db4028362b4da58a02f637d5ea
Author: OH1KH <oh1kh@sral.fi>
Date:   Wed May 4 19:06:11 2022 +0300

    Fixed debug printing. Tested: adif export and import

commit 5f86f8899c6c9b3d8fbd849115d8ef3147166e73
Author: OH1KH <oh1kh@sral.fi>
Date:   Wed May 4 11:47:53 2022 +0300

    Tested: fldigi remote ipc and xmlrpc, fldigi (old version) xmlrpc, adif remote

commit 88774fcd12556fb59043805f211be07f7d9dd7c7
Author: OH1KH <oh1kh@sral.fi>
Date:   Wed May 4 10:31:27 2022 +0300

    Fixed external database's backups script

commit 3f4198f0ce4dfb1d227cd9b06798294ec1a7d457
Author: OH1KH <oh1kh@sral.fi>
Date:   Tue May 3 11:48:35 2022 +0300

    fixed adif import and export. TODO: test all adif import/export, lotw/eqsl import/export, remotes: fldigi ipc/xml, adif

commit 891674a2346e0f402d301711e32a7dcdba697aef
Author: OH1KH <oh1kh@sral.fi>
Date:   Sun May 1 17:35:33 2022 +0300

    new conversion now in: fldigixml,adifremote, fldigiipc,lotw and eqsl import. Partilly added also to adif import but this is not finished yet

commit 050b35f3e69ea7254c71590874c50d46f7a9f3f6
Author: OH1KH <oh1kh@sral.fi>
Date:   Sat Apr 30 10:01:56 2022 +0300

    Ficed naming, created a debug procedure and put in use with fldigi(others still need appending)

commit a03c1758851d19a5f7f5fccbf09b5638da583f6f
Author: OH1KH <oh1kh@sral.fi>
Date:   Fri Apr 29 13:30:31 2022 +0300

    Mode conversion idea works now.
    creates convert files if they do not exist in ctyfiles folder.
    Fileas are loaded from Cqrlog start, so user can edit files
    if needed new mode conversions without doing compile.

    fxfldigi.pas still has testing lines, must remove

    todo
    take conversions in use (adif ex/import, eQSL, Lotw, adif remote, fldigi remote)