### PR TITLE
Fix to county storing

### DIFF
--- a/src/fNewQSO.pas
+++ b/src/fNewQSO.pas
@@ -6601,8 +6601,9 @@ begin
       if ((c_county <> '') and (edtCounty.Text='')) or AlwaysReplace or ReplaceZonesEtc then
       begin
         if (edtState.Text<>'') then
-          edtCounty.Text := edtState.Text+','+c_county
-        else
+        // what is the mind of adding state to county?? Remove...
+        // edtCounty.Text := edtState.Text+','+c_county
+        // else
           edtCounty.Text := c_county
       end
     end;  //county


### PR DESCRIPTION
	What is the mind of adding state to county and then storing that?
	It just duplicates the information because state exist in state column
	and county exist in county column.
	And it will also export as county => "state,county" because there is no
	removing routine before creating an export tag of county.

	Is there some reason doing this. If not, I think it should be removed.