### PR TITLE
Fix for adif headers

### DIFF
--- a/src/fAdifImport.pas
+++ b/src/fAdifImport.pas
@@ -1047,6 +1047,7 @@ begin
   else begin
     AssignFile(f,dmData.UsrHomeDir + ERR_FILE);
     Rewrite(f);
+    Writeln(f);
     Writeln(f,'ADIF export from CQRLOG for Linux version ' + dmData.VersionString);
     Writeln(f,'Copyright (C) ',YearOf(now),' by Petr, OK2CQR and Martin, OK1RR');
     Writeln(f,'Internet: http://www.cqrlog.com');

--- a/src/fExportProgress.pas
+++ b/src/fExportProgress.pas
@@ -547,6 +547,7 @@ begin   //TfrmExportProgress
 
   AssignFile(f, FileName);
   Rewrite(f);
+  Writeln(f);
   Writeln(f, 'ADIF export from CQRLOG for Linux version '+dmData.VersionString);
   Writeln(f, 'Copyright (C) ',YearOf(now),' by Petr, OK2CQR and Martin, OK1RR');
   Writeln(f);

--- a/src/fLoTWExport.pas
+++ b/src/fLoTWExport.pas
@@ -385,6 +385,7 @@ begin
   end;
 
   date := FormatDateTime('yyyy-mm-dd',now);
+  Writeln(f);
   Writeln(f, '<ADIF_VER:5>3.1.0');
   Writeln(f, '<CREATED_TIMESTAMP:15>',FormatDateTime('YYYYMMDD hhmmss',dmUtils.GetDateTime(0)));
   Writeln(f, 'ADIF export from CQRLOG for Linux version '+dmData.VersionString);

--- a/src/feQSLUpload.pas
+++ b/src/feQSLUpload.pas
@@ -104,6 +104,7 @@ begin
   AssignFile(f,FileName);
   try try
     Rewrite(f);
+    Writeln(f);
     Writeln(f, 'ADIF export from CQRLOG for Linux version '+dmData.VersionString);
     Writeln(f, 'Copyright (C) ',YearOf(now),' by Petr, OK2CQR and Martin, OK1RR');
     Writeln(f);


### PR DESCRIPTION
	Added one linefeed before first line of adif header.
	This makes linux command 'file' to detect adi files as text
	instead of music file.