### PR TITLE
Fix for ROT control

### DIFF
--- a/src/fRotControl.pas
+++ b/src/fRotControl.pas
@@ -120,7 +120,7 @@ begin
    mnuDirbtns.Checked:= not mnuDirbtns.Checked;
    btnLeft.Visible:=mnuDirbtns.Checked;
    btnRight.Visible:=mnuDirbtns.Checked;
-   cqrini.WriteBool('ROT','DirBtns',mnuDirbtns.Visible);
+   cqrini.WriteBool('ROT','DirBtns',mnuDirbtns.Checked);
 end;
 
 procedure TfrmRotControl.mnuMinMaxClick(Sender: TObject);

--- a/src/uVersion.pas
+++ b/src/uVersion.pas
@@ -18,7 +18,7 @@ const
   cRELEAS     = 2;
   cBUILD      = 1;
 
-  cBUILD_DATE = '2022-04-09';
+  cBUILD_DATE = '2022-05-12';
 
 implementation
 


### PR DESCRIPTION
	Turn left/right buttons did not keep their visible state over Cqrlog restart. Reported by Mick, MI0HOZ

	Fixed