### PR TITLE
Fix for county storing

### DIFF
--- a/src/fNewQSO.pas
+++ b/src/fNewQSO.pas
@@ -6600,9 +6600,9 @@ begin
       edtState.Text := c_state;
       if ((c_county <> '') and (edtCounty.Text='')) or AlwaysReplace or ReplaceZonesEtc then
       begin
-        if (edtState.Text<>'') then
+        if ((edtState.Text<>'') and (c_county <> '')) then //chk c_county.Might be empty because above if-and-or-or  passes it wnen empty
           edtCounty.Text := edtState.Text+','+c_county
-        else
+          else
           edtCounty.Text := c_county
       end
     end;  //county

--- a/src/uVersion.pas
+++ b/src/uVersion.pas
@@ -18,7 +18,7 @@ const
   cRELEAS     = 2;
   cBUILD      = 1;
 
-  cBUILD_DATE = '2022-04-09';
+  cBUILD_DATE = '2022-05-12';
 
 implementation
 


### PR DESCRIPTION
        Revised PR #503 
        As it seems to be adif.org/"sponsor defined code format" to add comma 
        separated state as prefix to county name we accept that.

        But, at least with non payed QRZ accounts, some calls like W1AW show out
        without county then state prefix may not be added to empty county name.

        Fixed that.

Squashed commit of the following:

commit 9c794672350702d5dbad53070ee42aa4934e5e78
Author: OH1KH <oh1kh@sral.fi>
Date:   Thu May 12 11:18:12 2022 +0300

    Fix for county storing

    	State prefix may not be added to empty county name.

commit 5e3f35a13f8c81d4eb0484c4e19df48e65198f49
Author: OH1KH <oh1kh@sral.fi>
Date:   Tue May 10 12:46:06 2022 +0300

    Fix to county storing

    	What is the mind of adding state to county and then storing that?
    	It just duplicates the information because state exist in state column
    	and county exist in county column.

    	Is there some reason doing this. If not I think it should be removed.