### PR TITLE
Changed DXCluster Colors for Dark Mode

### DIFF
--- a/src/fBandMap.lfm
+++ b/src/fBandMap.lfm
@@ -112,7 +112,7 @@ object frmBandMap: TfrmBandMap
     Width = 259
     Align = alClient
     BevelOuter = bvNone
-    Color = clWhite
+    Color = clDefault
     Font.Height = -11
     Font.Name = 'Monospace'
     ParentColor = False

--- a/src/fDXCluster.lfm
+++ b/src/fDXCluster.lfm
@@ -204,7 +204,7 @@ object frmDXCluster: TfrmDXCluster
         Alignment = taLeftJustify
         BevelInner = bvLowered
         BevelOuter = bvLowered
-        Color = clWhite
+        Color = clDefault
         Font.CharSet = ANSI_CHARSET
         Font.Height = 12
         Font.Name = 'DejaVu Sans Mono 12'
@@ -343,7 +343,7 @@ object frmDXCluster: TfrmDXCluster
         BevelOuter = bvNone
         ClientHeight = 331
         ClientWidth = 699
-        Color = clWhite
+        Color = clDefault
         ParentColor = False
         TabOrder = 2
         object pnlChat: TPanel
@@ -353,7 +353,7 @@ object frmDXCluster: TfrmDXCluster
           Width = 699
           Align = alTop
           BevelOuter = bvNone
-          Color = 13890552
+          Color = clDefault
           ParentColor = False
           TabOrder = 0
         end

--- a/src/fDXCluster.pas
+++ b/src/fDXCluster.pas
@@ -428,7 +428,7 @@ begin
   TelSpots.Align       := alClient;
   TelSpots.setLanguage(1);
 
-  ChBckColor  := $00D3F3F8;
+  ChBckColor  := clWindow;
   pnlChat.Color := ChBckColor;
   ChatSpots             := TColorMemo.Create(pnlChat);
   ChatSpots.parent      := pnlChat;
@@ -1051,7 +1051,7 @@ var
   cfgAN  : Boolean;
   cfgOC  : Boolean;
 begin
-  sColor  := 0; //cerna
+  sColor  := clWindowText; //cerna
 
   EnterCriticalSection(csDXCPref);
   try
@@ -1119,9 +1119,9 @@ begin
   isLoTW := dmData.UsesLotw(call);
   isEQSL := dmDXCluster.UseseQSL(call);
 
-  //DXCluster - default Backgroundcolor white
+  //DXCluster - default Backgroundcolor
   //case lotw and eqsl is given, lotw will win
-  ThBckColor := clWhite;
+  ThBckColor := clWindow;
   if cfgeUseBackColor and isEQSL then
     ThBckColor := cfgeBckColor;
   if cfgUseBackColor and isLoTW then
@@ -1281,7 +1281,7 @@ begin
     end
   end;
   if index = 0 then
-    sColor := 0;
+    sColor := clWindowText;
   if index = 1 then
     sColor := cfgNewCountryColor;
   if index = 2 then


### PR DESCRIPTION
Changed hardcoded white background in DXCluster and BandMap to Default Color. Used theme-dependend clWindow and clWindowText for Item Colors.

PLEASE TEST BEFORE MERGING

This fix does have some unwanted sideeffects:
1) First line in DXCluster is Black, Don't know why.
2) Lines at the end of each item
3) Contrast of items is low (should't be: clWindowText should be inherited from Theme and match contrast with clWindow)
3) Aging colors don't seem to work with that fix. That's a real blocker.