### PR TITLE
Fix for contest

### DIFF
--- a/src/fContest.pas
+++ b/src/fContest.pas
@@ -763,7 +763,7 @@ end;
 
 procedure TfrmContest.ShowStatusBarInfo;
 begin
-  sbContest.Panels.Items[0].Text := StringReplace(Trim(frmNewQSO.mCountry.Text),#$0A,'|',[rfReplaceAll]);
+  sbContest.Panels.Items[0].Text := ExtractWord(1,Trim(frmNewQSO.mCountry.Text),[#$0A]);
   sbContest.Panels.Items[1].Text := 'WAZ: ' + frmNewQSO.lblWAZ.Caption;
   sbContest.Panels.Items[2].Text := 'ITU: ' + frmNewQSO.lblITU.Caption;
   sbContest.Panels.Items[3].Text := 'AZ: ' + frmNewQSO.lblAzi.Caption;

--- a/src/uVersion.pas
+++ b/src/uVersion.pas
@@ -18,7 +18,7 @@ const
   cRELEAS     = 2;
   cBUILD      = 1;
 
-  cBUILD_DATE = '2022-05-12';
+  cBUILD_DATE = '2022-05-28';
 
 implementation
 


### PR DESCRIPTION
	Fixed statusline[1] message to be only first line of NewQSO
	DXCC info leaving off possible dates of confirmation(s).

![Screenshot_20220528_124451](https://user-images.githubusercontent.com/12532164/170820158-f3578390-bdd0-44ba-b3e9-9bea38077973.png)

	Looks better now

![Screenshot_20220528_123904](https://user-images.githubusercontent.com/12532164/170820163-2588c740-d306-4b64-8a81-cc5eca119693.png)
.