### PR TITLE
Using GTK3

### DIFF
--- a/src/lnet/lib/lclnet.pas
+++ b/src/lnet/lib/lclnet.pas
@@ -76,6 +76,10 @@ implementation
   {$i lclgtkeventer.inc}
 {$endif}
 
+{$ifdef LCLGTK3}
+  {$i lclgtkeventer.inc}
+{$endif}
+
 {$ifdef LCLQT}
   {$i lclgtkeventer.inc} // identical code ;)
 {$endif}

--- a/src/uVersion.pas
+++ b/src/uVersion.pas
@@ -9,6 +9,9 @@ const
   {$IFDEF LCLGtk2}
   cVERSION    = cVersionBase+' Gtk2';
   {$ENDIF}
+   {$IFDEF LCLGtk3}
+  cVERSION    = cVersionBase+' Gtk3';
+  {$ENDIF}
   {$IFDEF LCLQt5}
   cVERSION    = cVersionBase+' QT5';
   {$ENDIF}
@@ -18,7 +21,7 @@ const
   cRELEAS     = 0;
   cBUILD      = 1;
 
-  cBUILD_DATE = '2022-06-29';
+  cBUILD_DATE = '2022-06-08';
 
 implementation
 


### PR DESCRIPTION
	With these small fixes Cqrlog compiles with Gtk3 widgets.
	How ever running compiled program causes several widget errors.

	You can see similar errors with Gtk2 if Cqrlog is started from
	console. Difference is just that Gtk2 errors do not kill the
	program like it happens with Gtk3 widgets in use.

	So this is just a start to gtk3 and (lot of) work needs still
	to be done if one wants to use Gtk3 widgets with Cqrlog.