### PR TITLE
Fix for opening certain filenames in the EDI file export.

### DIFF
--- a/src/fAdifImport.pas
+++ b/src/fAdifImport.pas
@@ -874,7 +874,7 @@ begin
   try
     prg := cqrini.ReadString('ExtView', 'txt', '');
     if prg<>'' then
-      dmUtils.RunOnBackground(prg + ' ' + OtF)
+      dmUtils.RunOnBackground(prg + ' ' + AnsiQuotedStr(OtF, '"'))
      else ShowMessage('No external text viewer defined!'+#10+'See: prefrences/External viewers');
   finally
    //done

--- a/src/fCabrilloExport.pas
+++ b/src/fCabrilloExport.pas
@@ -163,7 +163,7 @@ begin
   try
     prg := cqrini.ReadString('ExtView', 'txt', '');
     if prg<>'' then
-      dmUtils.RunOnBackground(prg + ' ' + f)
+      dmUtils.RunOnBackground(prg + ' ' + '"' + f + '"')
      else ShowMessage('No external text viewer defined!'+#10+'See: prefrences/External viewers');
   finally
    //done

--- a/src/fCabrilloExport.pas
+++ b/src/fCabrilloExport.pas
@@ -163,7 +163,7 @@ begin
   try
     prg := cqrini.ReadString('ExtView', 'txt', '');
     if prg<>'' then
-      dmUtils.RunOnBackground(prg + ' ' + '"' + f + '"')
+      dmUtils.RunOnBackground(prg + ' ' + AnsiQuotedStr(f, '"'))
      else ShowMessage('No external text viewer defined!'+#10+'See: prefrences/External viewers');
   finally
    //done

--- a/src/fCallAttachment.pas
+++ b/src/fCallAttachment.pas
@@ -58,7 +58,7 @@ begin
   CurrentDir := GetCurrentDir;
   try
     SetCurrentDir(flAttach.Directory);
-    dmUtils.RunOnBackground('/usr/bin/xdg-open' + ' "' + flAttach.FileName + '"');
+    dmUtils.RunOnBackground('/usr/bin/xdg-open' + ' ' + AnsiQuotedStr(flAttach.FileName, '"'));
   finally
     SetCurrentDir(CurrentDir)
   end;

--- a/src/fDbError.pas
+++ b/src/fDbError.pas
@@ -37,7 +37,7 @@ uses dUtils, dData;
 
 procedure TfrmDbError.btnOpenErrFileClick(Sender : TObject);
 begin
-  dmUtils.RunOnBackground('xdg-open ' + dmData.DataDir + 'mysql.err')
+  dmUtils.RunOnBackground('xdg-open ' + AnsiQuotedStr(dmData.DataDir + 'mysql.err', '"'))
 end;
 
 procedure TfrmDbError.btnVisitFAQClick(Sender : TObject);

--- a/src/fEDIExport.pas
+++ b/src/fEDIExport.pas
@@ -159,7 +159,7 @@ begin
   try
     prg := cqrini.ReadString('ExtView', 'txt', '');
     if prg<>'' then
-      dmUtils.RunOnBackground(prg + ' ' + edtFileName.Text)
+      dmUtils.RunOnBackground(prg + ' ' + '"' + edtFileName.Text + '"')
      else ShowMessage('No external text viewer defined!'+#10+'See: prefrences/External viewers');
   finally
    //done

--- a/src/fEDIExport.pas
+++ b/src/fEDIExport.pas
@@ -159,7 +159,7 @@ begin
   try
     prg := cqrini.ReadString('ExtView', 'txt', '');
     if prg<>'' then
-      dmUtils.RunOnBackground(prg + ' ' + '"' + edtFileName.Text + '"')
+      dmUtils.RunOnBackground(prg + ' ' + AnsiQuotedStr(edtFileName.Text, '"'))
      else ShowMessage('No external text viewer defined!'+#10+'See: prefrences/External viewers');
   finally
    //done

--- a/src/fNewQSO.pas
+++ b/src/fNewQSO.pas
@@ -7484,7 +7484,7 @@ begin
   btnSave.Enabled       := False;  //disable manual saving when remote is on
   tmrADIF.Interval      := 250;    //rate to read qsos from UDP (msec)
   if run and FileExists(ExtractWord(1,path,[' '])) then
-    dmUtils.RunOnBackground(path)
+    dmUtils.RunOnBackground(AnsiQuotedStr(path, '"'))
 end;
 
 


### PR DESCRIPTION
The feature for checking your EDI file when it has been created
will not open all filenames / paths.
The failing files / paths are those with one or more spaces in them.
The remedy is to quote the string. The same error exists in
the Cabrillo export as well.  (#517)