### PR TITLE
Fix for rig power on

### DIFF
--- a/src/fTRXControl.pas
+++ b/src/fTRXControl.pas
@@ -366,6 +366,8 @@ begin
   frmBandMap.CurrentBand := b;
   frmBandMap.CurrentFreq := f * 1000;
   frmBandMap.CurrentMode := m;
+  if Assigned(radio) then
+            pnlPower.Enabled:=radio.Power;
 end;
 
 function TfrmTRXControl.GetModeNumber(mode : String) : Cardinal;
@@ -669,7 +671,6 @@ begin
   end
   else begin
     pnlPower.Visible := True;
-    btPonClick(nil); //setting buttons visible sends PwrOn to sync button colors
     mnuShowPwr.Checked := True;
   end;
   cqrini.WriteBool('TRX', 'PowerButtons', pnlPower.Visible);
@@ -1087,36 +1088,34 @@ begin
 
   pnlPower.Visible := cqrini.ReadBool('TRX', 'PowerButtons', False);
   mnuShowPwr.Checked := pnlPower.Visible;
-  if pnlPower.Visible then btPonClick(nil);
-  // all rigs do not support rigctld power switching
-  //so we just put pwr button ON and send rigctld PWR ON cmd
-  //if rig does not support it that makes no harm.
-  //if supports we do know pwr state from now on.
+
+
 
   if not radio.Connected then
-  begin
-    FreeAndNil(radio);
-  end
+      begin
+        FreeAndNil(radio);
+      end
   else  //radio changed, restart CW interface
-  begin
-    //we check this again although preferences prevent false setting
-    if (cqrini.ReadBool('CW', 'NoReset', False) //is set: user does not want reset
-      and (cqrini.ReadInteger('CW', 'Type1', 0) =
-      cqrini.ReadInteger('CW', 'Type2', 0)) //both keyers are same
-      and (cqrini.ReadInteger('CW', 'Type1', 0) <> 4)  //type is not HamLib
-      ) then //no restart keyer it is same device for both radios.
     begin
-      if ((dmData.DebugLevel >= 1) or ((abs(dmData.DebugLevel) and 8) = 8)) then
-        Writeln('User ask: No reset and keyer not Hamlib: No restart by TRControl radio'
-          + n + ' change');
-    end
-    else begin
-      frmNewQSO.InitializeCW;
-      if ((dmData.DebugLevel >= 1) or ((abs(dmData.DebugLevel) and 8) = 8)) then
-        Writeln('CW keyer reloaded by TRControl radio' + n + ' change');
-    end;
+      //we check this again although preferences prevent false setting
+      if (cqrini.ReadBool('CW', 'NoReset', False) //is set: user does not want reset
+        and (cqrini.ReadInteger('CW', 'Type1', 0) =
+        cqrini.ReadInteger('CW', 'Type2', 0)) //both keyers are same
+        and (cqrini.ReadInteger('CW', 'Type1', 0) <> 4)  //type is not HamLib
+        ) then //no restart keyer it is same device for both radios.
+            begin
+              if ((dmData.DebugLevel >= 1) or ((abs(dmData.DebugLevel) and 8) = 8)) then
+                Writeln('User ask: No reset and keyer not Hamlib: No restart by TRControl radio'
+                  + n + ' change');
+            end
+      else
+        Begin
+          frmNewQSO.InitializeCW;
+          if ((dmData.DebugLevel >= 1) or ((abs(dmData.DebugLevel) and 8) = 8)) then
+            Writeln('CW keyer reloaded by TRControl radio' + n + ' change');
+        end;
 
-  end;
+    end;
 end;
 
 procedure TfrmTRXControl.SetMode(mode : String; bandwidth : Integer);
@@ -1425,20 +1424,24 @@ begin
 
   if Assigned(radio) then
   begin
-    case radio.GetCurrVFO of
+     if radio.CanGetVfo then
+     begin
+      case radio.GetCurrVFO of
       VFOA: begin
-        btnVFOA.Font.Color := clRed;
-        btnVFOB.Font.Color := clDefault;
-      end;
+              btnVFOA.Font.Color := clRed;
+              btnVFOB.Font.Color := clDefault;
+            end;
       VFOB: begin
-        btnVFOB.Font.Color := clRed;
-        btnVFOA.Font.Color := clDefault;
+              btnVFOB.Font.Color := clRed;
+              btnVFOA.Font.Color := clDefault;
+            end;
       end;
-      else begin
-        btnVFOB.Font.Color := clDefault;
-        btnVFOA.Font.Color := clDefault;
-      end;
-    end;
+     end
+    else
+     begin
+      btnVFOB.Font.Color := clDefault;
+      btnVFOA.Font.Color := clDefault;
+     end;
   end;
 end;
 

--- a/src/uVersion.pas
+++ b/src/uVersion.pas
@@ -21,7 +21,7 @@ const
   cRELEAS     = 0;
   cBUILD      = 1;
 
-  cBUILD_DATE = '2022-06-08';
+  cBUILD_DATE = '2022-06-30';
 
 implementation
 


### PR DESCRIPTION
	MI0HOZ reported that his rig closes ok from TRXControl P-off button
	but does not start from P-on button.
	I did know this before but always thought that it was my IC7300 "property".
	More careful testing did show that it is Cqrlog's bug.

   	If rig power off or stby  button is pressed and rig closed
    	Cqrlog continues polling. That stacks commands/responses and
    	when Power on button is pressed command is sent to rig but it may
    	take several minutes before action.

	This showed up totally new problem.
	Cqrlog "just throws out polling" to rigctld and assumes that there will be proper
	answer on return.
	How ever the code does not wait for return, it continues polling by timer
	even when there is no answer.
	It should not do so.

	For every command sent to rigctld there should be always some kind of reply
	coming back. Before that reply new timer based command(s) should not be sent.

	This tries to fix problem(s).
	At the start \chk_vfo and \dump_caps are asked (first if user has allowed that, default yes).
	Result of \chk_vfo modifies the polling format and result of \dump_caps is used to check
	if rig can do: get vfo, set_powerstat and send morse.

	At the moment used information is more cosmetic:
	If rig can not "get vfo" Trxcontrol's vfo "A" and "B" buttons are not colored by vfo in use.
	if rig can not "Set_powerstat" Trxcontrol's poer buttons are disabled.
	"Send mores" was planned to give warning if user tries to use Hamlib keyer with rig that
	does not support it, but it is not implemented yet.

	Then to more important things.
	Now rig polling is enabled by "ticket numbers". The poll timer itself runs all the time
	but "tickets" order what to do.

	This way the start commands can be done first by large numbers.
	Then all other issued commands have ticket number 1
	And finally, when nothing else to do, normal rig polling "the fmv" has poll number 0
	Ticket number -1 will disable polling. That is used when waiting for answer from rig
	and after power off command is issued to stop all rig requests, except power on command.

	This is third idea for fixing this problem and it seems to work better than previous ones.
	Testing is done with Icoms 7300 and 706 and hamlib dummy (#1) rig.



	While testing a new bug was found.
	rigctld passband settings had bug in man page where "-1"="keep current passband" was not
	told. It was ok in rigctl man pages instead. Proposed fix, and it is now done in Hamlib.

	How ever also Cqrlog had bug there. The passband variable was "word" that can not support
	negative numbers.
	Setting passband to "-1" in preferences/modes resulted passband setting of 65535 in rigctld.
	Fixed variable to be "integer" for negative value support.



Squashed commit of the following:

commit 0126a51ffb7b81d2c76dfc565643d80488a59c62
Author: OH1KH <oh1kh@sral.fi>
Date:   Thu Jun 30 12:41:26 2022 +0300

    version date

commit 00ed3aa437115d83c6aa08861f0e7d2168b57677
Author: OH1KH <oh1kh@sral.fi>
Date:   Mon Jun 27 10:28:28 2022 +0300

    Fixed passband '-1' setting

commit 0fb4345a3a584f91c8e89aa0c9be94dc83ab5f58
Author: OH1KH <oh1kh@sral.fi>
Date:   Mon Jun 27 10:21:07 2022 +0300

    Fixed passband '-1' setting

commit 1ea3a5c193ad3db60a728f3c3e8c3d6ab93187e3
Author: OH1KH <oh1kh@sral.fi>
Date:   Mon Jun 27 09:41:14 2022 +0300

    If rig can get vfo coloer TRXC vfo buttons,else not

commit a99edac732d15a354a0e3a10ef399107e53171dd
Author: OH1KH <oh1kh@sral.fi>
Date:   Mon Jun 27 09:04:10 2022 +0300

    restored queue send

commit cd1ba324376556d64cd7d38667a4609f514c736c
Author: OH1KH <oh1kh@sral.fi>
Date:   Mon Jun 27 08:28:52 2022 +0300

    connect indication

commit 1f1653ed7b634eda81586409fab3564273888513
Author: OH1KH <oh1kh@sral.fi>
Date:   Thu Jun 23 17:56:05 2022 +0300

    looks good, but connection status must be fixed

commit d54143de69950a6e80c578cf4049a418e909972c
Author: OH1KH <oh1kh@sral.fi>
Date:   Thu Jun 23 14:07:06 2022 +0300

    power on / off btns work now

commit 1332722a3a9483699735404af9ccc0ff322c44e9
Author: OH1KH <oh1kh@sral.fi>
Date:   Thu Jun 23 13:06:14 2022 +0300

    Third try to fix this uRigControl