### PR TITLE
Fix for QSO list

### DIFF
--- a/src/fNewQSO.pas
+++ b/src/fNewQSO.pas
@@ -3158,6 +3158,7 @@ var
   ShowMain : Boolean = False;
   date     : TDate;
   RxFreq   : Double = 0;
+  key      : word = $24; //Home-key
 begin
   ShowMain := (fEditQSO or fViewQSO) and (not fromNewQSO);
   if not cbOffline.Checked then
@@ -3398,7 +3399,7 @@ begin
   if not AnyRemoteOn then
                        UnsetEditLabel;
   dmData.qQSOBefore.Close;
-  fEditQSO := False;
+
   was_call := edtCall.Text;
   edtCall.Text := ''; //calls ClearAll
   old_ccall := '';
@@ -3409,7 +3410,14 @@ begin
     frmTRXControl.ClearRIT;
 
   if (cqrini.ReadBool('NewQSO','RefreshAfterSave', True) and frmMain.Showing) then
+   begin
     frmMain.acRefresh.Execute;
+    if not fEditQso then
+                  frmMain.dbgrdMainKeyUp(nil,key,[ssCtrl]); //shows last logged qso
+
+   end;
+
+  fEditQSO := False;
 
   UploadAllQSOOnline;
   if frmWorkedGrids.Showing then frmWorkedGrids.UpdateMap;

--- a/src/uVersion.pas
+++ b/src/uVersion.pas
@@ -21,7 +21,7 @@ const
   cRELEAS     = 0;
   cBUILD      = 1;
 
-  cBUILD_DATE = '2022-06-08';
+  cBUILD_DATE = '2022-07-04';
 
 implementation
 


### PR DESCRIPTION
	This fix will add simulated Ctrl+Home keypress after QSO list
	is refreshed.
	It happens only when "refresh data after save qso" is checked
	and moves selection on top of the log to view last saved qso.

	It does not affect QSO list selection point when QSO is saved from
	EditQso.

Squashed commit of the following:

commit 804314833a47198288063c56ce9c4c0c02ac58d0
Author: OH1KH <oh1kh@sral.fi>
Date:   Mon Jul 4 14:41:16 2022 +0300

    This is even better. Does not effect qso edit, just new qso

commit 3e67a21518a707dc3bd605359c4426cd2495b7af
Author: OH1KH <oh1kh@sral.fi>
Date:   Sat Jul 2 13:09:08 2022 +0300

    Another way, only when save. Is this any better?

commit 83138e6042ac3c9d92b873c33284cefdf3e13fa9
Author: OH1KH <oh1kh@sral.fi>
Date:   Sat Jul 2 12:25:24 2022 +0300

    Fix for qso list

    	Added simulated keypress "Ctrl+Home" after qso list refresh
    	to get last qso show up on top of list.