### PR TITLE
Fix for RBNMonitor

### DIFF
--- a/src/fRbnMonitor.pas
+++ b/src/fRbnMonitor.pas
@@ -475,8 +475,8 @@ var
   user   : String;
 begin
   RbnMonThread := TRBNThread.Create(True);
-  RbnMonThread.FreeOnTerminate := True;
-  RbnMonThread.OnShowSpot := @SynRbnMonitor;
+  RbnMonThread.FreeOnTerminate :=  False;// True; I think this causes abrt in terminate (TfrmRbnMonitor.acDisconnectExecute) because procedure has freeAndNil (does free twice)
+  RbnMonThread.OnShowSpot := @SynRbnMonitor; //shows up when RBN traffic is high like IARU HF contest and connect is tried to close or filter adjusted
   RbnMonThread.Start;
 
   LoadConfigToThread;


### PR DESCRIPTION
	During high traffic (IARU HF contest) it suddenly showed up
	that either editing filter or disconnecting monitor caused
	error message (Abort/Ok).
	By debug assembler the error happens in thread close section.

	Found out that RBNThread has FreeOnTerminate set True and
	procedure acTerminate first terminates thread and then tries to
	FreeAndNil it.
	This looks like double free for me and tried to set
	FreeOnTerminate :=False and problem disappeared.
	I am not quite sure is this true effect or just some other
	thing changed.
	Anyhow it should not do any harm this way, I think.

	When this kind of problem apperars it also (but random) leads
	to Cqrlog starting problem when it dies at start.
	This happens at NewQSO/FormShow where ShowMOdal (of DBconnect) seems
	to produce mrOK:=false condition.
	After several start attempts it suddenly clears and program opens.
	Looks like mysterious thread/memory leak or something.