### PR TITLE
Fix to QSO offline input

### DIFF
--- a/src/fNewQSO.pas
+++ b/src/fNewQSO.pas
@@ -3435,7 +3435,10 @@ begin
           frmMain.dbgrdMain.SetFocus
         end
         else
-          edtCall.SetFocus;
+         Begin
+          if cbOffline.Checked then edtDate.SetFocus
+                               else edtCall.SetFocus;
+         end;
      end;
 
 end;
@@ -3711,6 +3714,11 @@ begin
     mComment.SetFocus;
     key := 0
   end;
+  if ((key = VK_TAB) and cbOffline.Checked and (edtCall.Text='') and (not AnyRemoteOn)) then
+   Begin
+     edtCall.SetFocus;
+     key := 0
+   end;
 end;
 
 
@@ -5816,8 +5824,11 @@ end;
 procedure TfrmNewQSO.mCommentKeyDown(Sender: TObject; var Key: Word;
   Shift: TShiftState);
 begin
-  if key = VK_TAB then
-    edtCall.SetFocus;
+  if ((key = VK_TAB) and (not AnyRemoteOn)) then
+    Begin
+     edtCall.SetFocus;
+     key := 0
+    end;
 end;
 
 procedure TfrmNewQSO.mCommentKeyUp(Sender: TObject; var Key: Word;


### PR DESCRIPTION
    	When Offline checkbox is checked and first qso typed in and saved
    	cursor will return to QsoDate column instead of Callsign column.
    	Then when date is set, moved with TAB to start time and then moved
    	with TAB to end time the nex TAB while in end time column will focus
    	to callsign column.
    	This happens only if callsign cloumn is empty (not when in edit qso)

    	This makes qso manual feed from paper log easier as things start
    	from date and tabulation continues in chronological order:
    	date,start,end,call,freq, mode .. etc and when qso is saved
    	return is again to date column.

Squashed commit of the following:

commit 51e1c90bb51ab5b4626dd6c54b37cc22d8468420
Author: OH1KH <oh1kh@sral.fi>
Date:   Mon Aug 22 10:25:11 2022 +0300

    Fix remote situation

commit 896479695797e88de0abd9dc4436c960b96451b4
Author: OH1KH <oh1kh@sral.fi>
Date:   Sun Aug 21 15:56:41 2022 +0300

    Fix to QSO offline input

    	When Offline checkbox is checked and first qso typed in and saved
    	cursor will return to QsoDate column instead of Callsign column.
    	Then when date is set, moved with TAB to start time and then moved
    	with TAB to end time the nex TAB while in end time column will focus
    	to callsign column.
    	This happens only if callsign cloumn is empty (not when in edit qso)

    	This makes qso manual feed from paper log easier as things start
    	from date and tabulation continues in chronological order:
    	date,start,end,call,freq, mode .. etc and when qso is saved
    	returns is again to date column.