### PR TITLE
Small fixes

### DIFF
--- a/src/dData.lfm
+++ b/src/dData.lfm
@@ -987,4 +987,25 @@ object dmData: TdmData
     left = 576
     top = 144
   end
+  object dsrFreqs: TDataSource
+    DataSet = qFreqs
+    Left = 80
+    Top = 355
+  end
+  object trFreqs: TSQLTransaction
+    Active = False
+    Action = caNone
+    Left = 80
+    Top = 280
+  end
+  object qFreqs: TSQLQuery
+    FieldDefs = <>
+    BeforeOpen = qBandsBeforeOpen
+    Transaction = trFreqs
+    Params = <>
+    Macros = <>
+    ParseSQL = False
+    Left = 80
+    Top = 210
+   end
 end

--- a/src/dData.pas
+++ b/src/dData.pas
@@ -55,11 +55,14 @@ type
   { TdmData }
 
   TdmData = class(TDataModule)
+    dsrFreqs: TDataSource;
     dsrSQLConsole: TDatasource;
     dsrLogList: TDatasource;
     dsrmQ: TDatasource;
     mQ: TSQLQuery;
     Q2: TSQLQuery;
+    qFreqs: TSQLQuery;
+    trFreqs: TSQLTransaction;
     trQ2: TSQLTransaction;
     qSQLConsole: TSQLQuery;
     scCommon: TSQLScript;
@@ -87,6 +90,7 @@ type
     qRbnMon: TSQLQuery;
     qFreqMem: TSQLQuery;
     trW: TSQLTransaction;
+    trWorkedContests: TSQLTransaction;
     W1: TSQLQuery;
     trW1: TSQLTransaction;
     W: TSQLQuery;

--- a/src/fFreq.lfm
+++ b/src/fFreq.lfm
@@ -126,7 +126,7 @@ object frmFreq: TfrmFreq
     end
   end
   object dsrFreq: TDataSource
-    DataSet = dmData.qBands
+    DataSet = dmData.qFreqs
     left = 130
     top = 57
   end

--- a/src/fFreq.pas
+++ b/src/fFreq.pas
@@ -51,8 +51,8 @@ end;
 procedure TfrmFreq.FormClose(Sender : TObject; var CloseAction : TCloseAction);
 begin
   dmUtils.SaveWindowPos(frmFreq);
-  if dmData.trBands.Active then
-    dmData.trBands.Rollback
+  if dmData.trFreqs.Active then
+    dmData.trFreqs.Rollback
 end;
 
 procedure TfrmFreq.dbgrdFreqColumnSized(Sender : TObject);
@@ -71,14 +71,14 @@ var
 begin
   with TfrmChangeFreq.Create(frmFreq) do
   try
-    band             := dmData.qBands.Fields[1].AsString;
-    edtBegin.Text    := FloatToStr(dmData.qBands.Fields[2].AsFloat);
-    edtEnd.Text      := FloatToStr(dmData.qBands.Fields[3].AsFloat);
-    edtCW.Text       := FloatToStr(dmData.qBands.Fields[4].AsFloat);
-    edtRTTY.Text     := FloatToStr(dmData.qBands.Fields[5].AsFloat);
-    edtSSB.Text      := FloatToStr(dmData.qBands.Fields[6].AsFloat);
-    edtRXOffset.Text := FloatToStr(dmData.qBands.Fields[7].AsFloat);
-    edtTXOffset.Text := FloatToStr(dmData.qBands.Fields[8].AsFloat);
+    band             := dmData.qFreqs.Fields[1].AsString;
+    edtBegin.Text    := FloatToStr(dmData.qFreqs.Fields[2].AsFloat);
+    edtEnd.Text      := FloatToStr(dmData.qFreqs.Fields[3].AsFloat);
+    edtCW.Text       := FloatToStr(dmData.qFreqs.Fields[4].AsFloat);
+    edtRTTY.Text     := FloatToStr(dmData.qFreqs.Fields[5].AsFloat);
+    edtSSB.Text      := FloatToStr(dmData.qFreqs.Fields[6].AsFloat);
+    edtRXOffset.Text := FloatToStr(dmData.qFreqs.Fields[7].AsFloat);
+    edtTXOffset.Text := FloatToStr(dmData.qFreqs.Fields[8].AsFloat);
     ShowModal;
 
     if ModalResult = mrOK then
@@ -106,29 +106,29 @@ const
 var
   i : Integer;
 begin
-  if dmData.trBands.Active then
-    dmData.trBands.Rollback;
+  if dmData.trFreqs.Active then
+    dmData.trFreqs.Rollback;
 
-  dmData.qBands.SQL.Text := C_SEL;
-  dmData.trBands.StartTransaction;
-  dmData.qBands.Open;
+  dmData.qFreqs.SQL.Text := C_SEL;
+  dmData.trFreqs.StartTransaction;
+  dmData.qFreqs.Open;
 
   dbgrdFreq.Columns[0].Visible := False;
 
   if (band<>'') then
   begin
-    dmData.qBands.DisableControls;
+    dmData.qFreqs.DisableControls;
     try
-      dmData.qBands.First;
-      while not dmData.qBands.Eof do
+      dmData.qFreqs.First;
+      while not dmData.qFreqs.Eof do
       begin
-        if (dmData.qBands.Fields[1].AsString=band) then
+        if (dmData.qFreqs.Fields[1].AsString=band) then
           break
         else
-          dmData.qBands.Next
+          dmData.qFreqs.Next
       end
     finally
-      dmData.qBands.EnableControls
+      dmData.qFreqs.EnableControls
     end
   end;
 

--- a/src/fNewQSO.pas
+++ b/src/fNewQSO.pas
@@ -811,7 +811,7 @@ uses dUtils, fChangeLocator, fChangeOperator, dDXCC, dDXCluster, dData, fMain, f
      fTRXControl, fPreferences, fSplash, fDXCluster, fDXCCStat,fQSLMgr, fSendSpot,
      fQSODetails, fWAZITUStat, fDOKStat, fIOTAStat, fGraphStat, fImportProgress, fBandMap,
      fLongNote, fRefCall, fKeyTexts, fCWType, fExportProgress, fPropagation, fCallAttachment,
-     fQSLViewer, fCWKeys, uMyIni, fDBConnect, fAbout, uVersion, fChangelog,
+     fQSLViewer, fCWKeys, uMyIni, fDBConnect, fAbout, uVersion, fChangelog, fCallbook,
      fBigSquareStat, fSCP, fRotControl, fLogUploadStatus, fRbnMonitor, fException, fCommentToCall,
      fRemind, fContest, fXfldigi, dMembership, dSatellite;
 
@@ -1625,139 +1625,51 @@ begin
   tmrEnd.Enabled   := False;
   tmrStart.Enabled := False;
 
+  //save showing states those ones that needs to be restored
+
   if Assigned(cqrini) then
   begin
+    cqrini.WriteBool('Window','pDK0WCY',frmPropDK0WCY.Showing);
+    cqrini.WriteBool('Window','WorkedGrids',frmWorkedGrids.Showing );
+    cqrini.WriteBool('Window','RBNMonitor',frmRBNMonitor.Showing);
+    cqrini.WriteBool('Window','CWType',frmCWType.Showing );
+    cqrini.WriteBool('Window','LogUploadStatus', frmLogUploadStatus.Showing);
+    cqrini.WriteBool('Window','ROT',frmRotControl.Showing);
     cqrini.WriteBool('Window','CWKeys',frmCWKeys.Showing);
+    cqrini.WriteBool('Window','SCP',frmSCP.Showing);
+    cqrini.WriteBool('Window','Prop',frmPropagation.Showing);
+    cqrini.WriteBool('Window','BandMap',frmBandMap.Showing );
+    cqrini.WriteBool('Window','Details',frmQSODetails.Showing );
+    cqrini.WriteBool('Window','Dxcluster',frmDXCluster.Showing);
+    cqrini.WriteBool('Window','Grayline',frmGrayline.Showing);
+    cqrini.WriteBool('Window','TRX',frmTRXControl.Showing );
+    cqrini.WriteBool('Window','QSOList',frmMain.Showing );
+  end;
 
-    //I have to close window manually because of bug in lazarus.
+  // then close windows.
 
-    if frmGrayline.Showing then
-    begin
-      frmGrayline.Close;
-      cqrini.WriteBool('Window','Grayline',True)
-    end
-    else
-      cqrini.WriteBool('Window','Grayline',False);
-
-    if frmTRXControl.Showing then
-    begin
-      frmTRXControl.Close;
-      cqrini.WriteBool('Window','TRX',True)
-    end
-    else begin
-      cqrini.WriteBool('Window','TRX',False)
-    end;
+    if (frmMonWsjtx <> nil)
+      and frmMonWsjtx.Showing     then  frmMonWsjtx.Close;
+    if frmContest.Showing         then  frmContest.Close;
+    if frmReminder.Showing        then  frmReminder.Close;
+    if frmPropDK0WCY.Showing      then  frmPropDK0WCY.Close;
+    if frmWorkedGrids.Showing     then  frmWorkedGrids.Close;
+    if frmRBNMonitor.Showing      then  frmRBNMonitor.Close;
+    if frmCWType.Showing          then  frmCWType.Close;
+    if frmLogUploadStatus.Showing then  frmLogUploadStatus.Close;
+    if frmRotControl.Showing      then  frmRotControl.Close;
+    if frmCWKeys.Showing          then  frmCWKeys.Close;
+    if frmSCP.Showing             then  frmSCP.Close;
+    if frmPropagation.Showing     then  frmPropagation.Close;
+    if frmBandMap.Showing         then  frmBandMap.Close;
+    if frmQSODetails.Showing      then  frmQSODetails.Close;
+    if frmDXCluster.Showing       then  frmDXCluster.Close;
+    if frmCallbook.Showing        then  frmCallbook.Close;
+    if frmGrayline.Showing        then  frmGrayline.Close;
     frmTRXControl.CloseRigs;
+    if frmTRXControl.Showing      then   frmTRXControl.Close;
+    if frmMain.Showing            then   frmMain.Close;
 
-    if frmRotControl.Showing then
-    begin
-      frmRotControl.Close;
-      cqrini.WriteBool('Window','ROT',True)
-    end
-    else
-      cqrini.WriteBool('Window','ROT',False);
-
-    if frmDXCluster.Showing then
-    begin
-      frmDXCluster.Close;
-      cqrini.WriteBool('Window','Dxcluster',True)
-    end
-    else
-      cqrini.WriteBool('Window','Dxcluster',False);
-
-    if frmQSODetails.Showing then
-    begin
-      frmQSODetails.Close;
-      cqrini.WriteBool('Window','Details',True)
-    end
-    else
-      cqrini.WriteBool('Window','Details',False);
-
-    if frmBandMap.Showing then
-    begin
-      frmBandMap.Close;
-      cqrini.WriteBool('Window','BandMap',True)
-    end
-    else
-      cqrini.WriteBool('Window','BandMap',False);
-
-    if frmPropagation.Showing then
-    begin
-      frmPropagation.Close;
-      cqrini.WriteBool('Window','Prop',True)
-    end
-    else
-      cqrini.WriteBool('Window','Prop',False);
-
-    if frmPropDK0WCY.Showing then
-    begin
-      frmPropDK0WCY.Close;
-      cqrini.WriteBool('Window','pDK0WCY',True)
-    end
-    else
-      cqrini.WriteBool('Window','pDK0WCY',False);
-
-   if frmWorkedGrids.Showing then
-    begin
-      frmWorkedGrids.Close;
-      cqrini.WriteBool('Window','WorkedGrids',True)
-    end
-    else
-      cqrini.WriteBool('Window','WorkedGrids',False);
-
-   if (frmMonWsjtx <> nil) and frmMonWsjtx.Showing then
-     begin
-       frmMonWsjtx.Close;
-     end;
-
-    if frmCWKeys.Showing then
-    begin
-      frmCWKeys.Close;
-      cqrini.WriteBool('Window','CWKeys',True)
-    end
-    else
-      cqrini.WriteBool('Window','CWKeys',False);
-
-    if frmSCP.Showing then
-    begin
-      cqrini.WriteBool('Window','SCP',True);
-      frmSCP.Close
-    end
-    else
-      cqrini.WriteBool('Window','SCP',False);
-
-    if frmMain.Showing then
-    begin
-      cqrini.WriteBool('Window','QSOList',True);
-      frmMain.Close
-    end
-    else
-      cqrini.WriteBool('Window','QSOList',False);
-
-    if frmLogUploadStatus.Showing then
-    begin
-      cqrini.WriteBool('Window','LogUploadStatus', True);
-      frmLogUploadStatus.Close
-    end
-    else
-      cqrini.WriteBool('Window','LogUploadStatus', False);
-
-    if frmCWType.Showing then
-    begin
-      cqrini.WriteBool('Window','CWType',True);
-      frmCWType.Close
-    end
-    else
-      cqrini.WriteBool('Window','CWType',False);
-
-    if frmRBNMonitor.Showing then
-    begin
-      cqrini.WriteBool('Window','RBNMonitor',True);
-      frmRBNMonitor.Close
-    end
-    else
-      cqrini.WriteBool('Window','RBNMonitor',False)
-  end
 end;
 
 procedure TfrmNewQSO.SaveSettings;
@@ -3069,7 +2981,11 @@ begin
                       5,6       : edtContestName.Text := ContestName[ContestNr]+'-QSO';
                  end;
                  case ContestNr of
-                      1,2,3,4   :  edtContestSerialReceived.Text := copy( edtContestSerialReceived.Text,1,6); //Max Db length=6
+                      1,2,3,4   : Begin
+                                       edtContestSerialReceived.Text := copy( edtContestSerialReceived.Text,1,6); //Max Db length=6
+                                       if (frmContest.Showing and (frmContest.cmbContestName.Text<>'')) then
+                                            edtContestName.Text :=frmContest.cmbContestName.Text;
+                                  end;
                  end;
            end;
            //----------this is not yet in wsjt-x 2.2.2 and JTDX 2.1.0rc151------------------
@@ -3987,6 +3903,7 @@ begin
   end;
   RunST('stop.sh'); //run "when cqrlog is closing" -script
   sleep(1000); //give scirpt time to use rigctld if that is needed
+  Application.ProcessMessages;
   if  AnyRemoteOn then DisableRemoteMode;
   CloseAllWindows;
   SaveSettings;

--- a/src/uVersion.pas
+++ b/src/uVersion.pas
@@ -21,7 +21,7 @@ const
   cRELEAS     = 0;
   cBUILD      = 1;
 
-  cBUILD_DATE = '2022-07-05';
+  cBUILD_DATE = '2022-10-25';
 
 implementation
 


### PR DESCRIPTION
**Contest name:**
	Fix for contest name in contests that have all modes in use
	CW/SSB/FM/MGM like NAC has.
	Then MGM qsos coming from WSJT-X will get name from Cqrlog contest
	name currnetly in contest window if it is open during remote.
	This overwrites WSJT-X predefined 4 contest names making all
	qsos in contest to have same contest name defined in contest window.

	Doing this Contest filter finds all qsos of contest right away.

**Preferences/bands/Frequencies:**
	Fixed double usage of query qBands. Preferences/bands/Frequencies list
	loose it's grid contents if Wsjt-x remote is on (behind) and CQ-monitor selected.

	dmUtils.FreqFromBand uses same qBand query!
	There is another double usage in DXcluster but because of Frequencies list is open
	DXSpot can not be clicked at same time and than hides the bug there.

**NewQSO/SaveAll procedure:**
	I wonder why there is comment about Lazarus bug? At least compiled by Lazarus 2.2.2
	this procedure can be fixed in shorter form.
	Also wonder why original had first frmTRXControl.close and after closing a call to
	frmTRXControl.CloseRigs ? I think that is wrong order.

Squashed commit of the following:

commit bf76e73333ac53e550f58468d0dfc373238d5c94
Author: OH1KH <oh1kh@sral.fi>
Date:   Sun Oct 23 18:04:16 2022 +0300

    Fixed saveall routine

commit 7fa57e3d26e5821f888ba1514965e31f18932a5b
Author: OH1KH <oh1kh@sral.fi>
Date:   Tue Oct 18 19:23:03 2022 +0300

    Fixed double usage of query qBands. Preferences/bands/Frequencies list it's grid contents if Wsjt-x remote was on and CQ-monitor selected. dmUtils.FreqFromBand uses same qBand query! (Could this happen also elswhere?)

commit 2b69915de2ff7edaa69911d0499632d16f98a92c
Author: OH1KH <oh1kh@sral.fi>
Date:   Mon Oct 17 11:27:29 2022 +0300

    Fix for contest name

    	Fix for contest name in contests that have all modes in use.
    	CW/SSB/FM/MGM like NAC has.
    	Then MGM qsos coming from WSJT-X will get name from contest
    	name in contest window if it is open during remote.
    	This overwrites WSJT-X predefined 4 contest names making all
    	qsos in contest to have same contest name defined in contest window.