### PR TITLE
Added CW macros

### DIFF
--- a/help/h26.html
+++ b/help/h26.html
@@ -57,8 +57,11 @@
 		<li>%h - greeting GM/GA/GE calculated from the %c station location time</li>
 		<br>
 		<li>%xn  - contest exchange serial number</li>
-		<li>%xm  - contest exchange message</li>
 		<li>%xns - contest exchenge serial number sends 9->N and 0->T</li>
+		<li>%xnr - contest exchange serial number received</li>
+		<li>%xnrs- contest exchenge serial number received sends 9->N and 0->T</li>
+		<li>%xm  - contest exchange message</li>
+		<li>%xmr - contest exchange message received</li>
 		<li>%xrs - full contest exchange RST+SerialNR+Message sends 9->N and 0->T.<br>
 		(May be used always instead of %rs as if serNR and Message are empty just sends plain report.)</li>
 		</li><li> + or - in macro text will increase/decrease CW speed by 5WPM/one mark. 

--- a/src/dUtils.pas
+++ b/src/dUtils.pas
@@ -275,7 +275,7 @@ type
     function  ExtractZipCode(qth : String; Position : Integer) : String;
     function  GetLabelBand(freq : String) : String;
     function  GetAdifBandFromFreq(MHz : string): String;
-    function  GetCWMessage(Key,call,rst_s,stx,stx_str,HisName,HelloMsg, text: String) : String;
+    function  GetCWMessage(Key,call,rst_s,stx,stx_str,srx,srx_str,HisName,HelloMsg, text: String) : String;
     function  RigGetcmd(r : String): String;
     function  GetLastQSLUpgradeDate : TDateTime;
     function  GetLastDOKUpgradeDate : TDateTime;
@@ -2728,7 +2728,7 @@ begin
   Result := LowerCase(GetBandFromFreq(freq));
 end;
 
-function TdmUtils.GetCWMessage(Key,call,rst_s,stx,stx_str,HisName,HelloMsg, text : String) : String;
+function TdmUtils.GetCWMessage(Key,call,rst_s,stx,stx_str,srx,srx_str,HisName,HelloMsg, text : String) : String;
 {
  %mc - my callsign
  %mn - my name
@@ -2741,9 +2741,12 @@ function TdmUtils.GetCWMessage(Key,call,rst_s,stx,stx_str,HisName,HelloMsg, text
  %c  - callsign
  %h - greeting GM/GA/GE calculated from the %c station location time
 
- %xn  - contest exchenge serial number
+ %xn  - contest exchange serial number
+ %xnr - contest exchange seral number received
  %xm  - contest exchange message
+ %xmr - contest exchange message received
  %xns - contest exchenge serial number sends 9->N and 0->T
+ %xnrs- contest exchange message received sends 9->N and 0->T
  %xrs - full contest exchange RST+SerialNR+Message sends 9->N and 0->T.
         Can be used "always" as if serNR and/or Message are empty just sends plain report.
 
@@ -2758,6 +2761,7 @@ var
   myqth  : String = '';
   rst_sh : String = '';
   stx_sh : String = '';
+  srx_sh : String = '';
   con_ex : String = '';
 
 begin
@@ -2776,25 +2780,39 @@ begin
     stx_sh := StringReplace(stx,'9','N',[rfReplaceAll, rfIgnoreCase]);
     stx_sh := StringReplace(stx_sh,'0','T',[rfReplaceAll, rfIgnoreCase]);//replace zeros, too
 
+    srx_sh := StringReplace(srx,'9','N',[rfReplaceAll, rfIgnoreCase]);
+    srx_sh := StringReplace(srx_sh,'0','T',[rfReplaceAll, rfIgnoreCase]);//replace zeros, too
+
     con_ex := rst_sh;
     if stx_sh <>'' then con_ex:=con_ex+' '+stx_sh;
     if stx_str <>'' then con_ex:=con_ex+' '+stx_str;
+
+    Result := StringReplace(Result,'%xnrs',srx_sh,[rfReplaceAll, rfIgnoreCase]);
+    Result := StringReplace(Result,'%xnr',srx,[rfReplaceAll, rfIgnoreCase]);
+    Result := StringReplace(Result,'%xns',stx_sh,[rfReplaceAll, rfIgnoreCase]);
+    Result := StringReplace(Result,'%xn',stx,[rfReplaceAll, rfIgnoreCase]);
+
+    Result := StringReplace(Result,'%xmr',srx_str,[rfReplaceAll, rfIgnoreCase]);
+    Result := StringReplace(Result,'%xm',stx_str,[rfReplaceAll, rfIgnoreCase]);
+
+    Result := StringReplace(Result,'%xrs',con_ex,[rfReplaceAll, rfIgnoreCase]);
+    Result := StringReplace(Result,'%rs',rst_sh,[rfReplaceAll, rfIgnoreCase]);
+    Result := StringReplace(Result,'%r',rst_s,[rfReplaceAll, rfIgnoreCase]);
+
+    Result := StringReplace(Result,'%n',HisName,[rfReplaceAll, rfIgnoreCase]);
 
     Result := StringReplace(Result,'%mc',mycall,[rfReplaceAll, rfIgnoreCase]);
     Result := StringReplace(Result,'%ml',myloc,[rfReplaceAll, rfIgnoreCase]);
     Result := StringReplace(Result,'%mn',myname,[rfReplaceAll, rfIgnoreCase]);
     Result := StringReplace(Result,'%mq',myqth,[rfReplaceAll, rfIgnoreCase]);
 
-    Result := StringReplace(Result,'%xrs',con_ex,[rfReplaceAll, rfIgnoreCase]);
-    Result := StringReplace(Result,'%rs',rst_sh,[rfReplaceAll, rfIgnoreCase]);
-    Result := StringReplace(Result,'%r',rst_s,[rfReplaceAll, rfIgnoreCase]);
-    Result := StringReplace(Result,'%n',HisName,[rfReplaceAll, rfIgnoreCase]);
-    Result := StringReplace(Result,'%c',call,[rfReplaceAll, rfIgnoreCase]);
     Result := StringReplace(Result,'%h',HelloMsg,[rfReplaceAll, rfIgnoreCase]);
 
-    Result := StringReplace(Result,'%xns',stx_sh,[rfReplaceAll, rfIgnoreCase]);
-    Result := StringReplace(Result,'%xn',stx,[rfReplaceAll, rfIgnoreCase]);
-    Result := StringReplace(Result,'%xm',stx_str,[rfReplaceAll, rfIgnoreCase]);
+    Result := StringReplace(Result,'%c',call,[rfReplaceAll, rfIgnoreCase]);
+
+
+
+
 
     if dmData.DebugLevel>=1 then Writeln('Sending:',Result)
 end;

--- a/src/fCWType.pas
+++ b/src/fCWType.pas
@@ -140,6 +140,7 @@ procedure TfrmCWType.btnF1MouseEnter(Sender: TObject);
 begin
   frmCWType.lblToShowMouseOverText.Caption:=dmUtils.GetCWMessage('F1',frmNewQSO.edtCall.Text,
       frmNewQSO.edtHisRST.Text, frmNewQSO.edtContestSerialSent.Text,frmNewQSO.edtContestExchangeMessageSent.Text,
+      frmNewQSO.edtContestSerialReceived.Text,frmNewQSO.edtContestExchangeMessageReceived.Text,
       frmNewQSO.edtName.Text,frmNewQSO.lblGreeting.Caption,'');
 end;
 
@@ -154,6 +155,7 @@ begin
   if Assigned(frmNewQSO.CWint) and (frmNewQSO.cmbMode.Text='CW') then
    frmNewQSO.CWint.SendText(dmUtils.GetCWMessage('F2',frmNewQSO.edtCall.Text,
       frmNewQSO.edtHisRST.Text, frmNewQSO.edtContestSerialSent.Text,frmNewQSO.edtContestExchangeMessageSent.Text,
+      frmNewQSO.edtContestSerialReceived.Text,frmNewQSO.edtContestExchangeMessageReceived.Text,
       frmNewQSO.edtName.Text,frmNewQSO.lblGreeting.Caption,''))
     else ShowMessage('Radio:   Not in CW mode!'+LineEnding+'or'+LineEnding+'CW interface:   No keyer defined! ');
 end;
@@ -162,6 +164,7 @@ procedure TfrmCWType.btnF10MouseEnter(Sender: TObject);
 begin
   frmCWType.lblToShowMouseOverText.Caption:=dmUtils.GetCWMessage('F10',frmNewQSO.edtCall.Text,
       frmNewQSO.edtHisRST.Text, frmNewQSO.edtContestSerialSent.Text,frmNewQSO.edtContestExchangeMessageSent.Text,
+      frmNewQSO.edtContestSerialReceived.Text,frmNewQSO.edtContestExchangeMessageReceived.Text,
       frmNewQSO.edtName.Text,frmNewQSO.lblGreeting.Caption,'');
 end;
 
@@ -171,6 +174,7 @@ begin
   if Assigned(frmNewQSO.CWint) and (frmNewQSO.cmbMode.Text='CW') then
    frmNewQSO.CWint.SendText(dmUtils.GetCWMessage('F10',frmNewQSO.edtCall.Text,
       frmNewQSO.edtHisRST.Text, frmNewQSO.edtContestSerialSent.Text,frmNewQSO.edtContestExchangeMessageSent.Text,
+      frmNewQSO.edtContestSerialReceived.Text,frmNewQSO.edtContestExchangeMessageReceived.Text,
       frmNewQSO.edtName.Text,frmNewQSO.lblGreeting.Caption,''))
     else ShowMessage('Radio:   Not in CW mode!'+LineEnding+'or'+LineEnding+'CW interface:   No keyer defined! ');
 end;
@@ -186,6 +190,7 @@ begin
   if Assigned(frmNewQSO.CWint) and (frmNewQSO.cmbMode.Text='CW') then
    frmNewQSO.CWint.SendText(dmUtils.GetCWMessage('F1',frmNewQSO.edtCall.Text,
       frmNewQSO.edtHisRST.Text, frmNewQSO.edtContestSerialSent.Text,frmNewQSO.edtContestExchangeMessageSent.Text,
+      frmNewQSO.edtContestSerialReceived.Text,frmNewQSO.edtContestExchangeMessageReceived.Text,
       frmNewQSO.edtName.Text,frmNewQSO.lblGreeting.Caption,''))
     else ShowMessage('Radio:   Not in CW mode!'+LineEnding+'or'+LineEnding+'CW interface:   No keyer defined! ');
 end;
@@ -194,6 +199,7 @@ procedure TfrmCWType.btnF2MouseEnter(Sender: TObject);
 begin
   frmCWType.lblToShowMouseOverText.Caption:=dmUtils.GetCWMessage('F2',frmNewQSO.edtCall.Text,
       frmNewQSO.edtHisRST.Text, frmNewQSO.edtContestSerialSent.Text,frmNewQSO.edtContestExchangeMessageSent.Text,
+      frmNewQSO.edtContestSerialReceived.Text,frmNewQSO.edtContestExchangeMessageReceived.Text,
       frmNewQSO.edtName.Text,frmNewQSO.lblGreeting.Caption,'');
 end;
 
@@ -208,6 +214,7 @@ begin
   if Assigned(frmNewQSO.CWint) and (frmNewQSO.cmbMode.Text='CW') then
    frmNewQSO.CWint.SendText(dmUtils.GetCWMessage('F3',frmNewQSO.edtCall.Text,
       frmNewQSO.edtHisRST.Text, frmNewQSO.edtContestSerialSent.Text,frmNewQSO.edtContestExchangeMessageSent.Text,
+      frmNewQSO.edtContestSerialReceived.Text,frmNewQSO.edtContestExchangeMessageReceived.Text,
       frmNewQSO.edtName.Text,frmNewQSO.lblGreeting.Caption,''))
     else ShowMessage('Radio:   Not in CW mode!'+LineEnding+'or'+LineEnding+'CW interface:   No keyer defined! ');
 end;
@@ -216,6 +223,7 @@ procedure TfrmCWType.btnF3MouseEnter(Sender: TObject);
 begin
   frmCWType.lblToShowMouseOverText.Caption:=dmUtils.GetCWMessage('F3',frmNewQSO.edtCall.Text,
        frmNewQSO.edtHisRST.Text, frmNewQSO.edtContestSerialSent.Text,frmNewQSO.edtContestExchangeMessageSent.Text,
+       frmNewQSO.edtContestSerialReceived.Text,frmNewQSO.edtContestExchangeMessageReceived.Text,
       frmNewQSO.edtName.Text,frmNewQSO.lblGreeting.Caption,'');
 end;
 
@@ -230,6 +238,7 @@ begin
   if Assigned(frmNewQSO.CWint) and (frmNewQSO.cmbMode.Text='CW') then
    frmNewQSO.CWint.SendText(dmUtils.GetCWMessage('F4',frmNewQSO.edtCall.Text,
       frmNewQSO.edtHisRST.Text, frmNewQSO.edtContestSerialSent.Text,frmNewQSO.edtContestExchangeMessageSent.Text,
+      frmNewQSO.edtContestSerialReceived.Text,frmNewQSO.edtContestExchangeMessageReceived.Text,
       frmNewQSO.edtName.Text,frmNewQSO.lblGreeting.Caption,''))
     else ShowMessage('Radio:   Not in CW mode!'+LineEnding+'or'+LineEnding+'CW interface:   No keyer defined! ');
 end;
@@ -238,6 +247,7 @@ procedure TfrmCWType.btnF4MouseEnter(Sender: TObject);
 begin
   frmCWType.lblToShowMouseOverText.Caption:=dmUtils.GetCWMessage('F4',frmNewQSO.edtCall.Text,
       frmNewQSO.edtHisRST.Text, frmNewQSO.edtContestSerialSent.Text,frmNewQSO.edtContestExchangeMessageSent.Text,
+      frmNewQSO.edtContestSerialReceived.Text,frmNewQSO.edtContestExchangeMessageReceived.Text,
       frmNewQSO.edtName.Text,frmNewQSO.lblGreeting.Caption,'');
 end;
 
@@ -252,6 +262,7 @@ begin
   if Assigned(frmNewQSO.CWint) and (frmNewQSO.cmbMode.Text='CW') then
    frmNewQSO.CWint.SendText(dmUtils.GetCWMessage('F5',frmNewQSO.edtCall.Text,
       frmNewQSO.edtHisRST.Text, frmNewQSO.edtContestSerialSent.Text,frmNewQSO.edtContestExchangeMessageSent.Text,
+      frmNewQSO.edtContestSerialReceived.Text,frmNewQSO.edtContestExchangeMessageReceived.Text,
       frmNewQSO.edtName.Text,frmNewQSO.lblGreeting.Caption,''))
     else ShowMessage('Radio:   Not in CW mode!'+LineEnding+'or'+LineEnding+'CW interface:   No keyer defined! ');
 end;
@@ -260,6 +271,7 @@ procedure TfrmCWType.btnF5MouseEnter(Sender: TObject);
 begin
   frmCWType.lblToShowMouseOverText.Caption:=dmUtils.GetCWMessage('F5',frmNewQSO.edtCall.Text,
       frmNewQSO.edtHisRST.Text, frmNewQSO.edtContestSerialSent.Text,frmNewQSO.edtContestExchangeMessageSent.Text,
+      frmNewQSO.edtContestSerialReceived.Text,frmNewQSO.edtContestExchangeMessageReceived.Text,
       frmNewQSO.edtName.Text,frmNewQSO.lblGreeting.Caption,'');
 end;
 
@@ -274,6 +286,7 @@ begin
   if Assigned(frmNewQSO.CWint) and (frmNewQSO.cmbMode.Text='CW') then
    frmNewQSO.CWint.SendText(dmUtils.GetCWMessage('F6',frmNewQSO.edtCall.Text,
       frmNewQSO.edtHisRST.Text, frmNewQSO.edtContestSerialSent.Text,frmNewQSO.edtContestExchangeMessageSent.Text,
+      frmNewQSO.edtContestSerialReceived.Text,frmNewQSO.edtContestExchangeMessageReceived.Text,
       frmNewQSO.edtName.Text,frmNewQSO.lblGreeting.Caption,''))
     else ShowMessage('Radio:   Not in CW mode!'+LineEnding+'or'+LineEnding+'CW interface:   No keyer defined! ');
 end;
@@ -282,6 +295,7 @@ procedure TfrmCWType.btnF6MouseEnter(Sender: TObject);
 begin
   frmCWType.lblToShowMouseOverText.Caption:=dmUtils.GetCWMessage('F6',frmNewQSO.edtCall.Text,
       frmNewQSO.edtHisRST.Text, frmNewQSO.edtContestSerialSent.Text,frmNewQSO.edtContestExchangeMessageSent.Text,
+      frmNewQSO.edtContestSerialReceived.Text,frmNewQSO.edtContestExchangeMessageReceived.Text,
       frmNewQSO.edtName.Text,frmNewQSO.lblGreeting.Caption,'');
 end;
 
@@ -296,6 +310,7 @@ begin
   if Assigned(frmNewQSO.CWint) and (frmNewQSO.cmbMode.Text='CW') then
    frmNewQSO.CWint.SendText(dmUtils.GetCWMessage('F7',frmNewQSO.edtCall.Text,
       frmNewQSO.edtHisRST.Text, frmNewQSO.edtContestSerialSent.Text,frmNewQSO.edtContestExchangeMessageSent.Text,
+      frmNewQSO.edtContestSerialReceived.Text,frmNewQSO.edtContestExchangeMessageReceived.Text,
       frmNewQSO.edtName.Text,frmNewQSO.lblGreeting.Caption,''))
     else ShowMessage('Radio:   Not in CW mode!'+LineEnding+'or'+LineEnding+'CW interface:   No keyer defined! ');
 end;
@@ -304,6 +319,7 @@ procedure TfrmCWType.btnF7MouseEnter(Sender: TObject);
 begin
   frmCWType.lblToShowMouseOverText.Caption:=dmUtils.GetCWMessage('F7',frmNewQSO.edtCall.Text,
       frmNewQSO.edtHisRST.Text, frmNewQSO.edtContestSerialSent.Text,frmNewQSO.edtContestExchangeMessageSent.Text,
+      frmNewQSO.edtContestSerialReceived.Text,frmNewQSO.edtContestExchangeMessageReceived.Text,
       frmNewQSO.edtName.Text,frmNewQSO.lblGreeting.Caption,'');
 end;
 
@@ -318,6 +334,7 @@ begin
   if Assigned(frmNewQSO.CWint) and (frmNewQSO.cmbMode.Text='CW') then
    frmNewQSO.CWint.SendText(dmUtils.GetCWMessage('F8',frmNewQSO.edtCall.Text,
       frmNewQSO.edtHisRST.Text, frmNewQSO.edtContestSerialSent.Text,frmNewQSO.edtContestExchangeMessageSent.Text,
+      frmNewQSO.edtContestSerialReceived.Text,frmNewQSO.edtContestExchangeMessageReceived.Text,
       frmNewQSO.edtName.Text,frmNewQSO.lblGreeting.Caption,''))
     else ShowMessage('Radio:   Not in CW mode!'+LineEnding+'or'+LineEnding+'CW interface:   No keyer defined! ');
 end;
@@ -326,6 +343,7 @@ procedure TfrmCWType.btnF8MouseEnter(Sender: TObject);
 begin
   frmCWType.lblToShowMouseOverText.Caption:=dmUtils.GetCWMessage('F8',frmNewQSO.edtCall.Text,
       frmNewQSO.edtHisRST.Text, frmNewQSO.edtContestSerialSent.Text,frmNewQSO.edtContestExchangeMessageSent.Text,
+      frmNewQSO.edtContestSerialReceived.Text,frmNewQSO.edtContestExchangeMessageReceived.Text,
       frmNewQSO.edtName.Text,frmNewQSO.lblGreeting.Caption,'');
 end;
 
@@ -340,6 +358,7 @@ begin
   if Assigned(frmNewQSO.CWint) and (frmNewQSO.cmbMode.Text='CW') then
    frmNewQSO.CWint.SendText(dmUtils.GetCWMessage('F9',frmNewQSO.edtCall.Text,
       frmNewQSO.edtHisRST.Text, frmNewQSO.edtContestSerialSent.Text,frmNewQSO.edtContestExchangeMessageSent.Text,
+      frmNewQSO.edtContestSerialReceived.Text,frmNewQSO.edtContestExchangeMessageReceived.Text,
       frmNewQSO.edtName.Text,frmNewQSO.lblGreeting.Caption,''))
     else ShowMessage('Radio:   Not in CW mode!'+LineEnding+'or'+LineEnding+'CW interface:   No keyer defined! ');
 end;
@@ -348,6 +367,7 @@ procedure TfrmCWType.btnF9MouseEnter(Sender: TObject);
 begin
   frmCWType.lblToShowMouseOverText.Caption:=dmUtils.GetCWMessage('F9',frmNewQSO.edtCall.Text,
       frmNewQSO.edtHisRST.Text, frmNewQSO.edtContestSerialSent.Text,frmNewQSO.edtContestExchangeMessageSent.Text,
+      frmNewQSO.edtContestSerialReceived.Text,frmNewQSO.edtContestExchangeMessageReceived.Text,
       frmNewQSO.edtName.Text,frmNewQSO.lblGreeting.Caption,'');
 end;
 

--- a/src/fContest.lfm
+++ b/src/fContest.lfm
@@ -13,7 +13,7 @@ object frmContest: TfrmContest
   OnHide = FormHide
   OnKeyDown = FormKeyDown
   OnShow = FormShow
-  LCLVersion = '2.0.12.0'
+  LCLVersion = '2.2.4.0'
   object edtCall: TEdit
     AnchorSideLeft.Control = lblContestName
     AnchorSideTop.Control = lblCall
@@ -100,6 +100,7 @@ object frmContest: TfrmContest
     Top = 59
     Width = 50
     MaxLength = 6
+    OnChange = edtSRXChange
     OnExit = edtSRXExit
     OnKeyDown = edtCallKeyDown
     OnKeyPress = edtSTXKeyPress

--- a/src/fContest.pas
+++ b/src/fContest.pas
@@ -72,6 +72,7 @@ type
     procedure edtCallExit(Sender: TObject);
     procedure edtCallKeyDown(Sender: TObject; var Key: word; Shift: TShiftState);
     procedure edtCallKeyPress(Sender: TObject; var Key: char);
+    procedure edtSRXChange(Sender: TObject);
     procedure edtSRXStrChange(Sender: TObject);
     procedure edtSRXExit(Sender: TObject);
     procedure edtSTXStrEnter(Sender: TObject);
@@ -178,7 +179,7 @@ begin
     if Assigned(frmNewQSO.CWint) then
       frmNewQSO.CWint.SendText(dmUtils.GetCWMessage(
         dmUtils.GetDescKeyFromCode(Key),edtCall.Text,
-      edtRSTs.Text, edtSTX.Text,edtSTXStr.Text,
+      edtRSTs.Text, edtSTX.Text,edtSTXStr.Text,edtSRX.Text,edtSRXStr.Text,
       frmNewQSO.edtName.Text,frmNewQSO.lblGreeting.Caption,''));
     key := 0;
   end;
@@ -417,6 +418,11 @@ begin
     key := #0;
 end;
 
+procedure TfrmContest.edtSRXChange(Sender: TObject);
+begin
+  frmNewQSO.edtContestSerialReceived.Text:=edtSRX.Text;
+end;
+
 procedure TfrmContest.edtSRXStrChange(Sender: TObject);
 begin
   if ((chkLoc.Checked) and (MsgIs=1 ))then
@@ -430,6 +436,7 @@ begin
    if ( Length(edtSRXStr.Text) > 6 )then
           edtSRXStr.Text:=copy(edtSRXStr.Text,1,6); //accept only 6chr locator input here
   end;
+  frmNewQSO.edtContestExchangeMessageReceived.Text:=edtSRXStr.Text;
 end;
 procedure TfrmContest.edtSRXExit(Sender: TObject);
 begin

--- a/src/fNewQSO.pas
+++ b/src/fNewQSO.pas
@@ -5548,6 +5548,7 @@ begin
           if Assigned(CWint) and (cmbMode.Text='CW') then
           CWint.SendText(dmUtils.GetCWMessage(dmUtils.GetDescKeyFromCode(Key),frmNewQSO.edtCall.Text,
             frmNewQSO.edtHisRST.Text, frmNewQSO.edtContestSerialSent.Text,frmNewQSO.edtContestExchangeMessageSent.Text,
+            frmNewQSO.edtContestSerialReceived.Text,frmNewQSO.edtContestExchangeMessageReceived.Text,
             frmNewQSO.edtName.Text,frmNewQSO.lblGreeting.Caption,''))
            else if (cmbMode.Text='CW') then ShowMessage('CW interface:  No keyer defined for current radio!');
        end;
@@ -7023,7 +7024,7 @@ end;
 
 procedure TfrmNewQSO.SendSpot;
 var
-  call,rst_s,stx,stx_str,HisName,HelloMsg : String;
+  call,rst_s,stx,stx_str,srx,srx_str,HisName,HelloMsg : String;
   tmp  : String;
   ModRst,
   HMLoc :String;
@@ -7042,6 +7043,8 @@ begin
       rst_s := edtHisRST.Text;
       stx :=  edtContestSerialSent.Text;
       stx_str:=edtContestExchangeMessageSent.Text;
+      srx :=  edtContestSerialReceived.Text;
+      srx_str:=edtContestExchangeMessageReceived.Text;
       HisName:= edtName.Text;
       tmp := 'DX ' + FloatToStrF(f,ffFixed,8,1) + ' ' + call;
       ModRst := cmbMode.Text+' '+ rst_s;
@@ -7065,7 +7068,7 @@ begin
     dmData.trQ.Rollback;
     tmp  := 'DX ' + freq + ' ' + call;
 
-    dmData.Q.SQL.Text := 'SELECT mode,rst_s,loc,prop_mode,my_loc,stx,stx_string,name FROM cqrlog_main ORDER BY qsodate DESC, time_on DESC LIMIT 1';
+    dmData.Q.SQL.Text := 'SELECT mode,rst_s,loc,prop_mode,my_loc,stx,stx_string,srx,srx_string,name FROM cqrlog_main ORDER BY qsodate DESC, time_on DESC LIMIT 1';
     dmData.trQ.StartTransaction;
     if dmData.DebugLevel >=1 then
       Writeln(dmData.Q.SQL.Text);
@@ -7075,7 +7078,9 @@ begin
     rst_s := dmData.Q.Fields[1].AsString;
     stx :=  dmData.Q.Fields[5].AsString;
     stx_str:=dmData.Q.Fields[6].AsString;
-    HisName:= dmData.Q.Fields[7].AsString;
+    srx :=  dmData.Q.Fields[7].AsString;
+    srx_str:=dmData.Q.Fields[8].AsString;
+    HisName:= dmData.Q.Fields[9].AsString;
     dmData.Q.Close();
     dmData.trQ.Rollback;
 
@@ -7092,6 +7097,8 @@ begin
     Srst_s := rst_s;
     Sstx := stx ;
     Sstx_str:=stx_str;
+    Ssrx := srx ;
+    Ssrx_str:=srx_str;
     SHisName:= HisName;
     SHelloMsg:=HelloMsg;
     ShowModal;

--- a/src/fSendSpot.pas
+++ b/src/fSendSpot.pas
@@ -49,6 +49,8 @@ type
     Srst_s,
     Sstx,
     Sstx_str,
+    Ssrx,
+    Ssrx_str,
     SHisName,
     SHelloMsg  :String;
     { public declarations }
@@ -86,6 +88,7 @@ end;
 procedure TfrmSendSpot.btnUsrClick(Sender: TObject);
 begin
   UsrString := cqrini.ReadString('DXCluster', 'UsrMsg', '');
+  UsrString:=dmUtils.GetCWMessage('',Scall,Srst_s,Sstx,Sstx_str,Ssrx,Ssrx_str,SHisName,SHelloMsg,UsrString);
   if pos(UsrString, edtSpot.Text) = 0 then
      edtSpot.Text := edtSpot.Text+' '+UsrString;
 end;
@@ -132,7 +135,7 @@ begin
      btnCancel.Click;
    end;
   UsrString := cqrini.ReadString('DXCluster', 'UsrMsg', '');
-  UsrString:=dmUtils.GetCWMessage('',Scall,Srst_s,Sstx,Sstx_str,SHisName,SHelloMsg,UsrString);
+  UsrString:=dmUtils.GetCWMessage('',Scall,Srst_s,Sstx,Sstx_str,Ssrx,Ssrx_str,SHisName,SHelloMsg,UsrString);
   btnUsr.Hint:=UsrString;
   btnLoc.Hint:= HisMyLoc;
   btnModRst.Hint:= ModeRst;

--- a/src/frCWKeys.pas
+++ b/src/frCWKeys.pas
@@ -105,6 +105,7 @@ procedure TfraCWKeys.btnF1MouseEnter(Sender: TObject);
 begin
   self.lblToShowMouseOverTextCwKeys.Caption:=dmUtils.GetCWMessage('F1',frmNewQSO.edtCall.Text,
       frmNewQSO.edtHisRST.Text, frmNewQSO.edtContestSerialSent.Text,frmNewQSO.edtContestExchangeMessageSent.Text,
+      frmNewQSO.edtContestSerialReceived.Text,frmNewQSO.edtContestExchangeMessageReceived.Text,
       frmNewQSO.edtName.Text,frmNewQSO.lblGreeting.Caption,'');
 end;
 
@@ -112,6 +113,7 @@ procedure TfraCWKeys.btnF10MouseEnter(Sender: TObject);
 begin
   self.lblToShowMouseOverTextCwKeys.Caption:=dmUtils.GetCWMessage('F10',frmNewQSO.edtCall.Text,
       frmNewQSO.edtHisRST.Text, frmNewQSO.edtContestSerialSent.Text,frmNewQSO.edtContestExchangeMessageSent.Text,
+      frmNewQSO.edtContestSerialReceived.Text,frmNewQSO.edtContestExchangeMessageReceived.Text,
       frmNewQSO.edtName.Text,frmNewQSO.lblGreeting.Caption,'');
 end;
 
@@ -129,6 +131,7 @@ procedure TfraCWKeys.btnF2MouseEnter(Sender: TObject);
 begin
   self.lblToShowMouseOverTextCwKeys.Caption:=dmUtils.GetCWMessage('F2',frmNewQSO.edtCall.Text,
       frmNewQSO.edtHisRST.Text, frmNewQSO.edtContestSerialSent.Text,frmNewQSO.edtContestExchangeMessageSent.Text,
+      frmNewQSO.edtContestSerialReceived.Text,frmNewQSO.edtContestExchangeMessageReceived.Text,
       frmNewQSO.edtName.Text,frmNewQSO.lblGreeting.Caption,'');
 end;
 
@@ -141,6 +144,7 @@ procedure TfraCWKeys.btnF3MouseEnter(Sender: TObject);
 begin
   self.lblToShowMouseOverTextCwKeys.Caption:=dmUtils.GetCWMessage('F3',frmNewQSO.edtCall.Text,
       frmNewQSO.edtHisRST.Text, frmNewQSO.edtContestSerialSent.Text,frmNewQSO.edtContestExchangeMessageSent.Text,
+      frmNewQSO.edtContestSerialReceived.Text,frmNewQSO.edtContestExchangeMessageReceived.Text,
       frmNewQSO.edtName.Text,frmNewQSO.lblGreeting.Caption,'');
 end;
 
@@ -153,6 +157,7 @@ procedure TfraCWKeys.btnF4MouseEnter(Sender: TObject);
 begin
   self.lblToShowMouseOverTextCwKeys.Caption:=dmUtils.GetCWMessage('F4',frmNewQSO.edtCall.Text,
      frmNewQSO.edtHisRST.Text, frmNewQSO.edtContestSerialSent.Text,frmNewQSO.edtContestExchangeMessageSent.Text,
+     frmNewQSO.edtContestSerialReceived.Text,frmNewQSO.edtContestExchangeMessageReceived.Text,
       frmNewQSO.edtName.Text,frmNewQSO.lblGreeting.Caption,'');
 end;
 
@@ -165,6 +170,7 @@ procedure TfraCWKeys.btnF5MouseEnter(Sender: TObject);
 begin
   self.lblToShowMouseOverTextCwKeys.Caption:=dmUtils.GetCWMessage('F5',frmNewQSO.edtCall.Text,
       frmNewQSO.edtHisRST.Text, frmNewQSO.edtContestSerialSent.Text,frmNewQSO.edtContestExchangeMessageSent.Text,
+      frmNewQSO.edtContestSerialReceived.Text,frmNewQSO.edtContestExchangeMessageReceived.Text,
       frmNewQSO.edtName.Text,frmNewQSO.lblGreeting.Caption,'');
 end;
 
@@ -177,6 +183,7 @@ procedure TfraCWKeys.btnF6MouseEnter(Sender: TObject);
 begin
   self.lblToShowMouseOverTextCwKeys.Caption:=dmUtils.GetCWMessage('F6',frmNewQSO.edtCall.Text,
       frmNewQSO.edtHisRST.Text, frmNewQSO.edtContestSerialSent.Text,frmNewQSO.edtContestExchangeMessageSent.Text,
+      frmNewQSO.edtContestSerialReceived.Text,frmNewQSO.edtContestExchangeMessageReceived.Text,
       frmNewQSO.edtName.Text,frmNewQSO.lblGreeting.Caption,'');
 end;
 
@@ -189,6 +196,7 @@ procedure TfraCWKeys.btnF7MouseEnter(Sender: TObject);
 begin
   self.lblToShowMouseOverTextCwKeys.Caption:=dmUtils.GetCWMessage('F7',frmNewQSO.edtCall.Text,
       frmNewQSO.edtHisRST.Text, frmNewQSO.edtContestSerialSent.Text,frmNewQSO.edtContestExchangeMessageSent.Text,
+      frmNewQSO.edtContestSerialReceived.Text,frmNewQSO.edtContestExchangeMessageReceived.Text,
       frmNewQSO.edtName.Text,frmNewQSO.lblGreeting.Caption,'');
 end;
 
@@ -201,6 +209,7 @@ procedure TfraCWKeys.btnF8MouseEnter(Sender: TObject);
 begin
   self.lblToShowMouseOverTextCwKeys.Caption:=dmUtils.GetCWMessage('F8',frmNewQSO.edtCall.Text,
       frmNewQSO.edtHisRST.Text, frmNewQSO.edtContestSerialSent.Text,frmNewQSO.edtContestExchangeMessageSent.Text,
+      frmNewQSO.edtContestSerialReceived.Text,frmNewQSO.edtContestExchangeMessageReceived.Text,
       frmNewQSO.edtName.Text,frmNewQSO.lblGreeting.Caption,'');
 end;
 
@@ -213,6 +222,7 @@ procedure TfraCWKeys.btnF9MouseEnter(Sender: TObject);
 begin
   self.lblToShowMouseOverTextCwKeys.Caption:=dmUtils.GetCWMessage('F9',frmNewQSO.edtCall.Text,
       frmNewQSO.edtHisRST.Text, frmNewQSO.edtContestSerialSent.Text,frmNewQSO.edtContestExchangeMessageSent.Text,
+      frmNewQSO.edtContestSerialReceived.Text,frmNewQSO.edtContestExchangeMessageReceived.Text,
       frmNewQSO.edtName.Text,frmNewQSO.lblGreeting.Caption,'');
 end;
 

--- a/src/uVersion.pas
+++ b/src/uVersion.pas
@@ -21,7 +21,7 @@ const
   cRELEAS     = 0;
   cBUILD      = 1;
 
-  cBUILD_DATE = '2022-07-05';
+  cBUILD_DATE = '2022-12-03';
 
 implementation
 


### PR DESCRIPTION
	Added CW macros:
	%xnr - contest exchange serial number received
	%xnrs- contest exchenge serial number received sends 9->N and 0->T
	%xmr - contest exchange message received

	Affects to an unimaginable number of places ...

	Fixed macro usage in SendSpot/Usr message.