### PR TITLE
Fix for contest form callsign column

### DIFF
--- a/src/fContest.pas
+++ b/src/fContest.pas
@@ -399,7 +399,6 @@ begin
   else
     frmSCP.mSCP.Clear
 end;
-
 procedure TfrmContest.edtCallKeyDown(Sender: TObject; var Key: word;
   Shift: TShiftState);
 begin
@@ -408,12 +407,15 @@ begin
     Key := 0;
     SelectNext(Sender as TWinControl, True, True);
   end;
+   if not (key in [VK_A..VK_Z, VK_0..VK_9,
+    VK_LCL_SLASH, VK_DELETE,VK_BACK,VK_RIGHT,VK_LEFT]) then
+     key := 0;
 end;
 
 procedure TfrmContest.edtCallKeyPress(Sender: TObject; var Key: char);
 begin
-  if not (key in ['a'..'z', 'A'..'Z', '0'..'9',
-    '/', chr(VK_DELETE), chr(VK_BACK), chr(VK_RIGHT), chr(VK_LEFT)]) then
+  if not (key in ['a'..'z','A'..'Z', '0'..'9',
+    '/',#08]) then
     key := #0;
 end;
 

--- a/src/fContest.pas
+++ b/src/fContest.pas
@@ -407,8 +407,8 @@ begin
     Key := 0;
     SelectNext(Sender as TWinControl, True, True);
   end;
-   if not (key in [VK_A..VK_Z, VK_0..VK_9,
-    VK_LCL_SLASH, VK_DELETE,VK_BACK,VK_RIGHT,VK_LEFT]) then
+   if not (key in [VK_A..VK_Z, VK_0..VK_9,VK_NUMPAD0..VK_NUMPAD9,
+    VK_LCL_SLASH, VK_DELETE,VK_BACK,VK_RIGHT,VK_LEFT,VK_TAB]) then
      key := 0;
 end;
 

--- a/src/uVersion.pas
+++ b/src/uVersion.pas
@@ -21,7 +21,7 @@ const
   cRELEAS     = 0;
   cBUILD      = 1;
 
-  cBUILD_DATE = '2022-07-05';
+  cBUILD_DATE = '2022-12-30';
 
 implementation
 


### PR DESCRIPTION
	Due to weird way Lazarus/FPC handles key inputs callsign column
	allowed few characters to be entered in addition of A..Z,0..9 and slash.

	One of these characters ' (single quote) causes SQL error when
	latest pull request "contest_upgrade" is added because it will
	check duplicates on fly during callsign is entered.
	Accidental pressing of single quote key causes then SQL error.

	Current master code does not find this error as duplicate is
	checked after exit from callsign column and then the text is trimmed
	before dupe check.

	As this code is same for master and "contest_upgrade" PR this
	fix can be added even if "contest_upgrade" PR is never accepted.

	More information:
	https://gitlab.com/freepascal.org/lazarus/lazarus/-/issues/40067