### PR TITLE
Fix for DXCC Ref edit/save

### DIFF
--- a/src/fNewQSO.pas
+++ b/src/fNewQSO.pas
@@ -1277,6 +1277,7 @@ begin
     end;
     edtDate.ReadOnly  := False;
     mComment.ReadOnly := False;
+    edtDXCCRef.ReadOnly:=True;  //we allow only DXCCs from list, no free type
   end;
   sbtnQRZ.Visible        := False;
   sbtnLoTW.Visible       := False;
@@ -3241,10 +3242,17 @@ begin
   //Writeln('OldPfx:',old_pfx);
   //Writeln('ChangeDXCC:',ChangeDXCC);
 
+  {
   if (old_call = edtCall.Text) and (old_adif <> adif) then
     ChangeDXCC := True; //if user chooses another country by direct enter to the edtDXCCref
                      //without clicking to btnDXCCRef
 
+   OH1KH 2022.12.30
+
+    Above does not work as EDITQSO does not properly set adif and old_adif from qso data from database.
+    Force changes always via btnDXCCRef.
+    Otherwise EditQSO changes to DXCCref are not saved. (because old_adf & adif values are false set)
+    }
   if not TryStrToFloat(edtRXFreq.Text, RxFreq) then
     RxFreq := 0;
 
@@ -3401,7 +3409,8 @@ begin
   dmData.qQSOBefore.Close;
 
   was_call := edtCall.Text;
-  edtCall.Text := ''; //calls ClearAll
+  edtCall.Text := ''; //calls ClearAll  (except when EDITQSO to be sure that callsign changes do not clear all)
+  if EditQso then ClearAll;
   old_ccall := '';
   old_cfreq := '';
   old_cmode := '';
@@ -4138,6 +4147,7 @@ begin
 
       waz := q.Fields[8].AsString;
       itu := q.Fields[7].AsString;
+      adif:= q.Fields[9].AsInteger;
       dmUtils.ModifyWAZITU(waz,itu);
       edtWAZ.Text        := waz;
       edtITU.Text        := itu;
@@ -5516,6 +5526,7 @@ begin
         end;
         edtDate.ReadOnly  := False;
         mComment.ReadOnly := False;
+        edtDXCCRef.ReadOnly:=True;  //we allow only DXCCs from list, no free type
       end;
       ShowMain := (fEditQSO or fViewQSO) and (not fromNewQSO);
       ClearAll;
@@ -6508,6 +6519,7 @@ begin
   end;
   edtDate.ReadOnly  := fViewQSO;
   mComment.ReadOnly := fViewQSO;
+  edtDXCCRef.ReadOnly:=True;  //we allow only DXCCs from list, no free type
   edtCall.SetFocus
 end;
 


### PR DESCRIPTION
	Once again user request appeared to modify and save DXCC ref.
	Decided to look at it.

	To my surprise I found that saving user edited DXCC Ref value
	was nearly done!
	There was just one line missing and it made me think it could be
	just a bug from earlier times.
	When DXCCRef was selected from list opened from btnDXCCref it was set
	to NewQSO, but variable adif's value was forgotten to set.
	That's why selected new DXCCRef was never saved.

	During testing I found out that edtDXCCRef.ReadOnly that was set
	in fNewQSO.lfm was reseted mysteriosly.
	Reason was ClearAll procedure that set all readonly values to
	false forgetting to set edtDXCCRef back to true.
	Later I found two places  more  in source doing the same.

	ReadOnly prevents "user defined" DXCCs to be entered. All must come
	from the DXCC list (that, I think, is a good thing).

	That lead to removing of line that should have been set ChangeDXCC
	boolean true if old and new calls were same but old and new adifs
	were different.
	That is not needed now when typing is disabled, and on the other hand
	it never worked as EDITQSO did not set proper adif and old_adif
	values at start.
	Including that manually entered prefix was never checked to set
	corresponding adif integer.

	Yet one bug more was found when EDITQSO was saved. Then there were
	not ClearAll procedure called leaving some edited qso data to NewQSO
	columns.
	ClearAll was refused to run "normal" way when callsign column was
	cleared and EDITQSO true.
	That is because during EDITQSO it can be cleared by user and so would
	clear all data during edit.
	If EDITQSO is true ClearAll must be called separately at btnSaveClick
	procedure.