### PR TITLE
Fix to rigctld and preferences

### DIFF
--- a/src/fPreferences.pas
+++ b/src/fPreferences.pas
@@ -1195,6 +1195,7 @@ var
   int  : integer;
   KeyType: TKeyType;
 begin
+  cqrini.SetCache(True);
   cqrini.WriteString('Station', 'Call', edtCall.Text);
   cqrini.WriteString('Station', 'Name', edtName.Text);
   cqrini.WriteString('Station', 'QTH', edtQTH.Text);
@@ -1798,6 +1799,7 @@ begin
   dmData.LoadClubsSettings;
   dmData.LoadZipSettings;
   dmUtils.UpdateHelpBrowser;
+  cqrini.SetCache(False);
 end;
 
 procedure TfrmPreferences.FormCreate(Sender: TObject);

--- a/src/uMyIni.pas
+++ b/src/uMyIni.pas
@@ -37,6 +37,7 @@ type
     procedure ReadSection(const Section: string; Strings: TStrings;ToLocal : Boolean=FALSE);
     procedure ReadSectionRaw(const Section: string; Strings: TStrings);
     procedure LoadLocalSectionsList;
+    procedure SetCache(c:boolean=false);
 end;
 
 var
@@ -52,6 +53,12 @@ begin
   lini := TMemIniFile.Create(LocalIniFile);
   ini.CacheUpdates :=false;    //should be as default, but is it?
   lini.CacheUpdates :=false;
+end;
+
+procedure TMyIni.SetCache(c:boolean=false);
+Begin
+  ini.CacheUpdates :=c;
+  lini.CacheUpdates :=c;
 end;
 
 function TMyIni.ReadString(const Section, Ident, Default: string): string;

--- a/src/uRigControl.pas
+++ b/src/uRigControl.pas
@@ -44,9 +44,13 @@ type TRigControl = class
     fTXOffset    : Double;
     fMorse       : boolean;
     fPower       : boolean;
+    fPowerON	 : boolean;
     fGetVfo      : boolean;
 
-    AllowCommand      : integer; //things to do before start polling
+    AllowCommand        : integer; //for command priority
+    ErrorRigctldConnect : Boolean;
+    ConnectionDone      : Boolean;
+    PowerOffIssued      : Boolean;
 
     function  RigConnected   : Boolean;
     function  StartRigctld   : Boolean;
@@ -55,6 +59,7 @@ type TRigControl = class
 
     procedure OnReceivedRigctldConnect(aSocket: TLSocket);
     procedure OnConnectRigctldConnect(aSocket: TLSocket);
+    procedure OnErrorRigctldConnect(const msg: string; aSocket: TLSocket);
     procedure OnRigPollTimer(Sender: TObject);
 
 public
@@ -94,6 +99,8 @@ public
     //can rig send CW
     property Power      : Boolean read fPower;
     //can rig switch power
+    property PowerON      : Boolean write fPowerON;
+    //may rig switch power on at start
     property CanGetVfo  : Boolean read fGetVfo;
     //can rig show vfo (many Icoms can not)
     property LastError   : String  read fLastError;
@@ -141,6 +148,7 @@ implementation
 constructor TRigControl.Create;
 begin
   RigCommand := TStringList.Create;
+  RigCommand.Sorted:=False;
   fDebugMode := False;
   if DebugMode then Writeln('In create');
   fRigCtldHost := 'localhost';
@@ -152,10 +160,15 @@ begin
   tmrRigPoll   := TTimer.Create(nil);
   tmrRigPoll.Enabled := False;
   VfoStr       := ''; //defaults to non-"--vfo" (legacy) mode
+  fPowerON     := true;  //we do this via rigctld startup parameter autopower_on
+  fGetVfo      := true;   //defaut these true
+  fMorse       := true;
+  PowerOffIssued := false;
   if DebugMode then Writeln('All objects created');
-  tmrRigPoll.OnTimer     := @OnRigPollTimer;
+  tmrRigPoll.OnTimer       := @OnRigPollTimer;
   RigctldConnect.OnReceive := @OnReceivedRigctldConnect;
   RigctldConnect.OnConnect := @OnConnectRigctldConnect;
+  RigctldConnect.OnError   := @OnErrorRigctldConnect;
 end;
 
 function TRigControl.StartRigctld : Boolean;
@@ -170,6 +183,9 @@ begin
   index:=0;
   paramList := TStringList.Create;
   paramList.Delimiter := ' ';
+  if pos('AUTO_POWER',UpperCase(RigCtldArgs))=0 then
+    if fPowerON then RigCtldArgs:= RigCtldArgs+' -C auto_power_on=1'
+     else RigCtldArgs:= RigCtldArgs+' -C auto_power_on=0';
   paramList.DelimitedText := RigCtldArgs;
   rigProcess.Parameters.Clear;
   while index < paramList.Count do
@@ -204,6 +220,8 @@ end;
 function TRigControl.RigConnected  : Boolean;
 const
   ERR_MSG = 'Could not connect to rigctld';
+var
+  RetryCount : integer;
 
 begin
   if fDebugMode then
@@ -250,33 +268,52 @@ begin
 
   RigctldConnect.Host := fRigCtldHost;
   RigctldConnect.Port := fRigCtldPort;
+  RetryCount          := 1;
+  ErrorRigctldConnect := False;
+  ConnectionDone      := False;
 
-  if RigctldConnect.Connect(fRigCtldHost,fRigCtldPort) then //this does not work as connection indicator, is always true!!
-                                                            //even when it can not connect rigctld.
-  begin
-    if fDebugMode then Writeln('Waiting for rigctld @ ',fRigCtldHost,':',fRigCtldPort);
-    result := True;
-    AllowCommand:=-1;
-    ParmHasVfo:=0;   //default: "--vfo" is not used as start parameter
-    tmrRigPoll.Interval := fRigPoll;
-    tmrRigPoll.Enabled  := True;
-    RigCommand.Clear;
+  if RigctldConnect.Connect(fRigCtldHost,fRigCtldPort) then//this does not work as connection indicator, is always true!!
+   Begin
+     repeat
+     begin
+        //if fDebugMode then
+                      Writeln('Waiting for rigctld ',RetryCount,' @ ',fRigCtldHost,':',fRigCtldPort);
+        if  ErrorRigctldConnect then
+            Begin
+              ErrorRigctldConnect := False;
+              RigctldConnect.Connect(fRigCtldHost,fRigCtldPort);
+            end;
+        inc(RetryCount);
+        sleep(1000);
+        Application.ProcessMessages;
+      end;
+     until (ConnectionDone or (Retrycount > 10)) ;
+
+   if ConnectionDone then
+    result := True
+   else
+    begin
+     if fDebugMode then Writeln('RETRY ERROR: *NOT* connected to rigctld @ ',fRigCtldHost,':',fRigCtldPort);
+     fLastError := ERR_MSG;
+     Result     := False
+    end
   end
-  else begin
-    if fDebugMode then Writeln('ERROR: *NOT* connected to rigctld @ ',fRigCtldHost,':',fRigCtldPort);
+  else
+   begin
+    if fDebugMode then Writeln('SETTINGS ERROR: *NOT* connected to rigctld @ ',fRigCtldHost,':',fRigCtldPort);
     fLastError := ERR_MSG;
     Result     := False
-  end
+   end
 end;
 
 procedure TRigControl.SetCurrVFO(vfo : TVFO);
 begin
   case vfo of
     VFOA : Begin
-                RigCommand.Add('V VFOA');//sendCommand.SendMessage('V VFOA'+LineEnding);
+                RigCommand.Add('+\set_vfo VFOA');//sendCommand.SendMessage('V VFOA'+LineEnding);
            end;
     VFOB : Begin
-                RigCommand.Add('V VFOB');//sendCommand.SendMessage('V VFOB'+LineEnding);
+                RigCommand.Add('+\set_vfo VFOB');//sendCommand.SendMessage('V VFOB'+LineEnding);
            end;
   end; //case
   AllowCommand:=1; //call queue
@@ -286,49 +323,49 @@ procedure TRigControl.SetModePass(mode : TRigMode);
 begin
   if (mode.mode='CW') and fRigSendCWR then
     mode.mode := 'CWR';
-  RigCommand.Add('+M'+VfoStr+' '+mode.mode+' '+IntToStr(mode.pass));
+  RigCommand.Add('+\set_mode'+VfoStr+' '+mode.mode+' '+IntToStr(mode.pass));
   AllowCommand:=1; //call queue
 end;
 
 procedure TRigControl.SetFreqKHz(freq : Double);
 begin
-  RigCommand.Add('+F'+VfoStr+' '+FloatToStr(freq*1000-TXOffset*1000000));
+  RigCommand.Add('+\set_freq'+VfoStr+' '+FloatToStr(freq*1000-TXOffset*1000000));
   AllowCommand:=1; //call queue
 end;
 procedure TRigControl.ClearRit;
 begin
-  RigCommand.Add('+J'+VfoStr+' 0');
+  RigCommand.Add('+\set_rig'+VfoStr+' 0');
   AllowCommand:=1; //call queue
 end;
 procedure TRigControl.DisableRit;
 Begin
-  RigCommand.Add('+U'+VfoStr+' RIT 0');
+  RigCommand.Add('+\set_func'+VfoStr+' RIT 0');
   AllowCommand:=1; //call queue
 end;
 procedure TRigControl.SetSplit(up:integer);
 Begin
-  RigCommand.Add('+Z'+VfoStr+' '+IntToStr(up));
-  RigCommand.Add('+U'+VfoStr+' XIT 1');
+  RigCommand.Add('+\set_xit'+VfoStr+' '+IntToStr(up));
+  RigCommand.Add('+\set_func'+VfoStr+' XIT 1');
   AllowCommand:=1; //call queue
 end;
 procedure TRigControl.ClearXit;
 begin
-  RigCommand.Add('+Z'+VfoStr+' 0');
+  RigCommand.Add('+\set_xit'+VfoStr+' 0');
   AllowCommand:=1; //call queue
 end;
 procedure TRigControl.DisableSplit;
 Begin
-  RigCommand.Add('+U'+VfoStr+' XIT 0');
+  RigCommand.Add('+\set_func'+VfoStr+' XIT 0');
   AllowCommand:=1; //call queue
 end;
 procedure TRigControl.PttOn;
 begin
-  RigCommand.Add('+T'+VfoStr+' 1');
+  RigCommand.Add('+\set_ptt'+VfoStr+' 1');
   AllowCommand:=1; //call queue
 end;
 procedure TRigControl.PttOff;
 begin
-  RigCommand.Add('+T'+VfoStr+' 0');
+  RigCommand.Add('+\set_ptt'+VfoStr+' 0');
   AllowCommand:=1; //call queue
 end;
 procedure TRigControl.PwrOn;
@@ -339,11 +376,13 @@ procedure TRigControl.PwrOff;
 begin
   RigCommand.Add('+\set_powerstat 0');
   AllowCommand:=1; //call queue
+  PowerOffIssued:=true;
 end;
 procedure TRigControl.PwrStBy;
 begin
   RigCommand.Add('+\set_powerstat 2');
   AllowCommand:=1; //call queue
+  PowerOffIssued:=true;
 end;
 procedure TRigControl.UsrCmd(cmd:String);
 begin
@@ -465,24 +504,27 @@ var
   a,b : TExplodeArray;
   i   : Integer;
   f   : Double;
+  Hit : boolean;
 begin
-  if aSocket.GetMessage(msg) > 0 then
+  msg:='';
+  while ( aSocket.GetMessage(msg) > 0 ) do
   begin
     msg := StringReplace(upcase(trim(msg)),#$09,' ',[rfReplaceAll]); //note the char case upper for now on! Remove TABs
 
     if DebugMode then
-         Writeln('Msg from rig:|',msg,'|'+LineEnding);
+         Writeln('Msg from rig:',StringReplace(msg,LineEnding,'\',[rfReplaceAll]));
 
     a := Explode(LineEnding,msg);
     for i:=0 to Length(a)-1 do     //this handles received message line by line
     begin
+      Hit:=false;
       //Writeln('a[i]:',a[i]);
       if a[i]='' then Continue;
 
       //we send all commands with '+' prefix that makes receiving sort lot easier
       b:= Explode(' ', a[i]);
 
-      if b[0]='FREQUENCY:' then
+      if (b[0]='FREQUENCY:')then
        Begin
          if TryStrToFloat(b[1],f) then
            Begin
@@ -491,9 +533,10 @@ begin
           else
            fFReq := 0;
           AllowCommand:=1; //check pending commands
+          Hit:=true;
        end;
 
-      if b[0]='MODE:' then
+      if (b[0]='MODE:') then
        Begin
          fMode.raw  := b[1];
          fMode.mode :=  fMode.raw;
@@ -502,12 +545,13 @@ begin
          if fMode.mode = 'CWR' then
            fMode.mode := 'CW';
          AllowCommand:=1;
+         Hit:=true;
         end;
 
       //FT-920 returned VFO as MEM
       //Some rigs report VFO as Main,MainA,MainB or Sub,SubA,SubB
       //Hamlib dummy has also "None" could it be in some real rigs too?
-      if b[0]='VFO:' then
+      if (b[0]='VFO:') then
        Begin
          b:= Explode(' ', a[i]);
          case b[1] of
@@ -524,6 +568,7 @@ begin
             fVFO := VFOA;
          end;
          AllowCommand:=1;
+         Hit:=true;
         end;
 
 
@@ -535,6 +580,7 @@ begin
          if DebugMode then Writeln('"--vfo" checked:',ParmHasVfo);
          if ParmHasVfo > 0 then VfoStr:=' currVFO';  //note set leading one space to string!
          AllowCommand:=9; //next dump caps
+         Hit:=true;
         end;
 
        if b[0]='CHKVFO' then //Hamlib 3.1
@@ -545,54 +591,114 @@ begin
          if DebugMode then Writeln('"--vfo" checked:',ParmHasVfo);
          if ParmHasVfo > 0 then VfoStr:=' currVFO';  //note set leading one space to string!
          AllowCommand:=9; //next dump caps
+         Hit:=true;
         end;
 
       if pos('CAN SET POWER STAT:',a[i])>0 then
        Begin
          fPower:= b[4]='Y';
-         if DebugMode then Writeln('Switch power: ',fPower);
+         if DebugMode then Writeln('Cqrlog can switch power: ',fPower);
        end;
 
       if pos('CAN GET VFO:',a[i])>0 then
        Begin
          fGetVfo:= b[3]='Y';
-         if DebugMode then Writeln(LineEnding+'Get VFO: ',fGetVfo);
+         if DebugMode then Writeln(LineEnding+'Cqrlog can get VFO: ',fGetVfo);
        end;
 
-      if pos('CAN SEND MORSE:',a[i])>0 then
+      if pos('CAN SEND MORSE:',a[i])>0 then //this is the last to check from dump_caps
        Begin
          fMorse:= b[3]='Y';
-         if DebugMode then Writeln('Send Morse: ',fMorse,LineEnding);
-         if fPower then
-            AllowCommand:=8 //issue power on
-          else
-            AllowCommand:=1 //check pending commands
+         if DebugMode then Writeln('Cqrlog can send Morse: ',fMorse,LineEnding);
+          RigCommand.Clear;
+          AllowCommand:=1; //check pending commands (should not be any)
+          Hit:=true;
        end;
 
        if pos('SET_POWERSTAT:',a[i])>0 then
        Begin
-        if pos('1',a[i])>0 then //line may have 'STAT: 1' or 'STAT: CURRVFO 1'
+         Hit:=true;
+         if pos('1',a[i])>0 then //line may have 'STAT: 1' or 'STAT: CURRVFO 1'
           Begin
             if DebugMode then Writeln('Power on, start polling');
-            AllowCommand:=93; //check pending commands via delay
+            AllowCommand:=92; //check pending commands via delay Assume rig needs time to start
+            PowerOffIssued:=false;
           end
          else
           Begin
-            if DebugMode then Writeln('Power off, stop polling');
+            if DebugMode then Writeln('Power off, stop polling (0)');
             AllowCommand:=-1;
           end;
        end;
-   end;
-  end;
+
+
+       if (b[0]='RPRT') then
+       Begin
+         //if none of above hits what to expect we accept just report received to be the one
+         if not Hit then AllowCommand:=1;
+         if DebugMode then
+         case b[1] of
+                        '-1': Writeln('Invalid parameter');
+                        '-2': Writeln('Invalid configuration (serial,..)');
+                        '-3': Writeln('Memory shortage');
+                        '-4': Writeln('Function not implemented, but will be');
+                        '-5': Writeln('Communication timed out');
+                        '-6': Writeln('IO error, including open failed');
+                        '-7': Writeln('Internal Hamlib error, huh!');
+                        '-8': Writeln('Protocol error');
+                        '-9': Writeln('Command rejected by the rig');
+                        '-10': Writeln('Command performed, but arg truncated');
+                        '-11': Writeln('Function not available');
+                        '-12': Writeln('VFO not targetable');
+                        '-13': Writeln('Error talking on the bus');
+                        '-14': Writeln('Collision on the bus');
+                        '-15': Writeln('NULL RIG handle or any invalid pointer parameter in get arg');
+                        '-16': Writeln('Invalid VFO');
+                        '-17': Writeln('Argument out of domain of func');
+           end;
+       end;
+
+   end;  //line by line loop
+  end; //while msg
 
 
 end;
 procedure TRigControl.OnRigPollTimer(Sender: TObject);
 var
-  cmd : String;
-  i   : Integer;
+  cmd     : String;
+  i       : Integer;
+//-----------------------------------------------------------
+procedure DoRigPoll;
 begin
+ if PowerOffIssued then exit;
+ if  ParmHasVfo=2 then
+   begin
+     if fGetVfo then
+       cmd := '+f'+VfoStr+' +m'+VfoStr+' +v'+VfoStr+LineEnding //chk this with rigctld v3.1
+      else
+       cmd := '+f'+VfoStr+' +m'+VfoStr+LineEnding //do not ask vfo if rig can't / chk this with rigctld v3.1
+   end
+  else
+   begin
+     if fGetVfo then
+       cmd := '+f'+VfoStr+' +m'+VfoStr+' +v'+LineEnding
+      else
+       cmd := '+f'+VfoStr+' +m'+VfoStr+LineEnding //do not ask vfo if rig can't
+   end;
+
+ if DebugMode then
+     Write(LineEnding+'Poll Sending:'+cmd);
+ RigctldConnect.SendMessage(cmd);
+ AllowCommand:=-1; //waiting for reply
+end;
+
+//-----------------------------------------------------------
+begin
+ if DebugMode then
+               Writeln('Polling - allowcommand:',AllowCommand);
  case AllowCommand of
+     -1:  Exit;   //no sending allowed
+
      //delay up to 10 timer rounds with this selecting one of numbers
      99:  AllowCommand:=98;
      98:  AllowCommand:=97;
@@ -608,21 +714,21 @@ begin
      10:  Begin
                cmd:='+\chk_vfo'+LineEnding;
                if DebugMode then
-                     Writeln('Sending: '+cmd);
+                     Write(LineEnding+'Sending: '+cmd);
                RigctldConnect.SendMessage(cmd);
                AllowCommand:=-1; //waiting for reply
           end;
       9:  Begin
                cmd:='+\dump_caps'+LineEnding;
                 if DebugMode then
-                     Writeln('Sending: '+cmd);
+                     Write(LineEnding+'Sending: '+cmd);
                RigctldConnect.SendMessage(cmd);
                AllowCommand:=-1; //waiting for reply
           end;
       8:  Begin
                cmd:= '+\set_powerstat 1'+LineEnding;
                if DebugMode then
-                     Writeln('Sending: '+cmd);
+                     Write(LineEnding+'Sending: '+cmd);
                RigctldConnect.SendMessage(cmd);
                AllowCommand:=-1; //waiting for reply
           end;
@@ -631,38 +737,40 @@ begin
       1:  Begin
             if (RigCommand.Text<>'') then
               begin
-                 for i:=0 to RigCommand.Count-1 do
-                   Begin
-                     cmd := RigCommand.Strings[i]+LineEnding;
-                     RigctldConnect.SendMessage(cmd);
-                     if DebugMode then
-                          Writeln('Queue Sending: [',i,'] '+cmd);
-                   end
-               end;
-              RigCommand.Clear;
-              AllowCommand:=0; //polling
+                if DebugMode then
+                     write('Queue in:'+LineEnding,RigCommand.Text);
+                 cmd := Trim(RigCommand.Strings[0])+LineEnding;
+                  if DebugMode then
+                          Write(LineEnding+'Queue Sending[0]:',cmd);
+                 for i:=0 to RigCommand.Count-2 do
+                    RigCommand.Exchange(i,i+1);
+                  RigCommand.Delete(RigCommand.Count-1);
+                  if DebugMode then
+                     write('Queue out:'+LineEnding,RigCommand.Text);
+                  RigctldConnect.SendMessage(cmd);
+                  AllowCommand:=-1; //wait answer
+               end
+              else
+               DoRigPOll;
           end;
+
        //polling has lowest prority, do if there is nothing else to do
-       0:  begin
-               if  ParmHasVfo=2 then
-                 cmd := '+f'+VfoStr+' +m'+VfoStr+' +v'+VfoStr+LineEnding //chk this with rigctld v3.1
-                else
-                 cmd := '+f'+VfoStr+' +m'+VfoStr+' +v'+LineEnding;
+       0:  DoRigPoll;
 
-               if DebugMode then
-                   Writeln('Poll Sending: '+cmd);
-               RigctldConnect.SendMessage(cmd);
-               AllowCommand:=-1; //waiting for reply
-             end;
-
-          end;//case
-
-
+ end;//case
 end;
 procedure TRigControl.OnConnectRigctldConnect(aSocket: TLSocket);
 Begin
-  if DebugMode then
+    if DebugMode then
                    Writeln('Connected to rigctld');
+    ConnectionDone:=true;
+    ParmHasVfo:=0;   //default: "--vfo" is not used as start parameter
+    AllowCommand:=10;  //start with chk_vfo
+    RigCommand.Clear;
+    tmrRigPoll.Interval := fRigPoll;
+    tmrRigPoll.Enabled  := True;
+
+
     if RigChkVfo then
       Begin
         AllowCommand:=10;  //start with chkvfo
@@ -673,7 +781,14 @@ Begin
         AllowCommand:=9;  //otherwise start with dump caps
         ParmVfoChkd:=false;
       end;
-    RigCommand.Clear;
+
+end;
+procedure TRigControl.OnErrorRigctldConnect(const msg: string; aSocket: TLSocket);
+
+begin
+  ErrorRigctldConnect:= True;
+  if DebugMode then
+                   writeln(msg);
 end;
 
 procedure TRigControl.Restart;

--- a/src/uVersion.pas
+++ b/src/uVersion.pas
@@ -21,7 +21,7 @@ const
   cRELEAS     = 0;
   cBUILD      = 1;
 
-  cBUILD_DATE = '2022-07-05';
+  cBUILD_DATE = '2023-01-11';
 
 implementation
 


### PR DESCRIPTION
	Made several changes to uRigControl. Primary goal was to make
	Power-ON and OFF buttons work propely with USB connected IC7300.

	Made quite lot of changes while trying to find solution.
	That lead to a bit faster response to band and mode change
	buttons, but power on/off was not clearly improved.

	Finally hunted bug from rigctld and there it was:
	When IC7300 is USB connected and is started with "\set_powerstat 1"
	command rig does a small glitch to USB bus. Like pull and push USB
	socket from rig.
	That breaks receive interrupt of rigctld and it can send commands
	to rig, but receives always RPRT-5 (timeout, no data)

	To fix this I suggested to Mike, W9MDB, that if "\set_powerstat 1"
	leads to RPRT-5 rigctld should reset it's USB connection.
	That way things started to work.
	To get benefit of this Hamlib version should be from date 2023-01-10
	or later.

	Otherwise benfit is just a little faster TRXControl actions.

	While getting a bit speed decided to look also preferences closing
	that takes quite long time after OK is pressed.
	Allowing cqrini writing cache while closing preferences raised
	closing speed (with my PC) over %50.

	This fix can be applied to official version with or without
	PR #546 (fix4rigs). It should work with both.

Squashed commit of the following:

commit d6bf88aa8110d935fd08950143541535f7ea3e03
Author: OH1KH <oh1kh@sral.fi>
Date:   Mon Jan 9 10:59:52 2023 +0200

    Speeding up preferences save by setting cache on during preferences close. Speed increase over %50

commit 1d3234bb53bbf9f9c5e323199b2a05c55e16a671
Author: OH1KH <oh1kh@sral.fi>
Date:   Sat Jan 7 17:19:50 2023 +0200

    accepted just RPRT receied for misc commands (like user defined strings)

commit 3315dda5db5d3e14ebcc230433494df88a7043ea
Author: OH1KH <oh1kh@sral.fi>
Date:   Sat Jan 7 12:49:44 2023 +0200

    Fixing rig communication appeared to be harder than expected

commit 07eb91299475963433dc7e55b9b29c49712bd71c
Author: OH1KH <oh1kh@sral.fi>
Date:   Wed Jan 4 13:34:24 2023 +0200

    added powerON prperty

commit a6cc955bd6e7d7ddb73599e1b15db6383ce2abd2
Author: OH1KH <oh1kh@sral.fi>
Date:   Wed Jan 4 13:02:56 2023 +0200

    Fix for rigctld communication

    	Rigctld has a "property", at least with Icom ic7300, that if
    	Rig is powered OFF when rigctld is started it takes around
    	7 seconds before rigctld opens it's telnet server for connect requests.

    	If rig is powered rigtcld responses immediately.

    	This waiting time was not taken account in uRigControl.pas
    	Added a reconnect loop of 10 times with one second waiting periods.

    	Now Cqrlog can catch rigctld's telnet server and connect to it
    	despite rig is powered or not.