### PR TITLE
Fix spelling errors in the help files

### DIFF
--- a/help/adif.html
+++ b/help/adif.html
@@ -41,8 +41,8 @@ function goBack() {
 
 <a name=fl1><h2><strong>ADIF logger remote</strong></h2></a>
 <img src="img/adif1.png" name="1"  border="0"/>
-<p>ADIF remote connection (former "N1MM+ remote logger") is just for copying logged qso infromation from other program like wsjt-x or js8call (or similars that support this kind of logging) to cqrlog.
-There is no other finctionality than just transfer the logged data.
+<p>ADIF remote connection (former "N1MM+ remote logger") is just for copying logged qso information from other program like wsjt-x or js8call (or similars that support this kind of logging) to cqrlog.
+There is no other functionality than just transfer the logged data.
 <br><br> ADIF remote can read adif tags from UDP datagram as follows:
 <ul>
     <li> 1) Datagram has full adif export including proper header and one or more qso records.(used by wsjt-x primary UDP datagram)</li>
@@ -56,15 +56,15 @@ There is no other finctionality than just transfer the logged data.
 </br>Settings must be done at wsjt-x or js8call Settings/reporting. At least checking the checkbox. Port and address values can be defaults.
 </br></br>
 <img src="img/adif3b.png" name="3"  border="0"/>
-</br></br>If N1MM is run in virtual machine or second computer the IP address of cqrlog computer must be used. Otherwise, when running under same Linux localhost addtess 127.0.0.1 can be used also with N1MM+
+</br></br>If N1MM is run in virtual machine or second computer the IP address of cqrlog computer must be used. Otherwise, when running under same Linux localhost address 127.0.0.1 can be used also with N1MM+
 
 </p><p>
 <img src="img/adif2.png" name="2"  border="0"/></br></br>
 When remote is selected you will see <b>remote ADIF</b> with red font. This will change when UDP frame is received.
-</br> Case 1) (see list abowe) it turns to <b>REMOTE ADIF</b>
-</br> Case 2) (see list abowe) it turns to <b>rmt ADIF hdless</b>
-</br> Case 3) (see list abowe) it turns to <b>rmt ADIF JS8CALL</b>
-</br> Case 4) (see list abowe) it turns to <b>rmt ADIF N1MM+</b>
+</br> Case 1) (see list above) it turns to <b>REMOTE ADIF</b>
+</br> Case 2) (see list above) it turns to <b>rmt ADIF hdless</b>
+</br> Case 3) (see list above) it turns to <b>rmt ADIF JS8CALL</b>
+</br> Case 4) (see list above) it turns to <b>rmt ADIF N1MM+</b>
 </br></br>
 <b>Note:</b> when case 3) frame is received ADIF remote can not receive any other type frames until remote is disabled and again enabled. This is because some versions of js8call send both json and headereless logging frames that would lead to double logging of qsos.
 </br></br>

--- a/help/contest.html
+++ b/help/contest.html
@@ -53,7 +53,7 @@ Contest window has a simple dupe check that turns typed duplicate callsign bold 
 </p>
 <p>
 <b>HOTKEYS</b> work like with <a href="h20.html">New QSO window</a>.
-<ul><li> <b>2x ESC</b> clears all fileds</li>
+<ul><li> <b>2x ESC</b> clears all fields</li>
 <li>Note: <b>1x ESC</b> returns cursor back to Call-field (if cursor is in some of the other fields like RSTr) and places cursor at the end of callsign for possible repairs.<br>
   It also halts CW memory output if it is just running.</li>
 <li> <b> F1..F10 </b>send CW macros etc.</li>
@@ -69,7 +69,7 @@ Contest window has following fields and checkboxes:<br>
 <li><b>SPACE is TAB</b> when checked space bar acts like TAB-key moving to next field. <b>Note:</b>This prevents typing space (perhaps needed in MSG fields).</li>
 <li><b>Dupe check</b> Default checked.
 <li><b>from YY-MM-DD</b> Button to set duplicate check start date (I.E. contest start date). Must be set if you have all qsos in same log. 
-<br>If every contest has it's own log can be as default (1900-01-01). Button is not visible if <b>Ignore dupes</b> is set.
+<br>If every contest has its own log can be as default (1900-01-01). Button is not visible if <b>Ignore dupes</b> is set.
 <li><b>NoMode4Dupe</b> Means that same callsign can be worked again on same band if mode is different.
 </li>
 <li><b>Ignore dupes</b> Do not check duplicate qsos at all.</li>
@@ -104,7 +104,7 @@ Contest window has following fields and checkboxes:<br>
 <br><b> Note:</b> pressing <b>ENTER at any time</b> after Call field is filled does the same.</li>
 <li><b>Clear QSO</b> Clear all QSO information.
 <br><b> Note:</b> Pressing 2x ESC key does the same.</li>
-<br><li><b>Clear all</b> Clear all fields. Usefull when starting a new contest to remove saved settings.</li>
+<br><li><b>Clear all</b> Clear all fields. Useful when starting a new contest to remove saved settings.</li>
 </ul>
 <br>
 All settings, including contest name, are saved when closing contest form. When opening cqrlog and contest form again after rest period you can directly continue contest working.
@@ -121,7 +121,7 @@ callsign of least three characters long. Sent/Received number and message are no
 <p>
 Contest numbers and messages are saved in log into their own columns. Use <b>preferences/Visible columns</b> to show them in <b>Qso list</b>.
 <br><br>
-<b>CW macros</b> can be used for sending contest meessages. Look them from help section <a href="h26.html">CW Operation</a>
+<b>CW macros</b> can be used for sending contest messages. Look them from help section <a href="h26.html">CW Operation</a>
 </p>
 <p>
 ADIF exports fields to right tags.<br><br>

--- a/help/firsttime.html
+++ b/help/firsttime.html
@@ -31,7 +31,7 @@
 <p>First start of CQRLOG is important.
 <br>Thanks for opening the help to your web browser during this first run.  Help has many answers to your future questions and you can open it again from many menus of CQRLOG.
  We hope that you at least check now the left frame to see what topics you may find from help if needed.
-</p><p> Then you have to decide where you put your logs. You have three ways to save logs and each of them has it's good and bad sides.
+</p><p> Then you have to decide where you put your logs. You have three ways to save logs and each of them has its good and bad sides.
 <br><br><img src="img/firsts1.png" >
 
 
@@ -49,19 +49,19 @@ This option uses SQL server already installed to your machine during CQRLOG inst
 <br>When using this option CQRLOG tries first to create SQL user with proper privileges to use the SQL server and then set proper values to "Database connection" window.
 <br>CQRLOG will create two scripts to your home folder: <b>create_cqr_user.sh</b> and <b>backup_all_cqr.sh</b>
 <br>The first one creates database user and is normally used only once. It needs your Linux user password to run this script with sudo.
-<br>The second one allows you to make full backup of all CQRLOG logs currently in database by starting this scipt in command-line terminal. 
+<br>The second one allows you to make full backup of all CQRLOG logs currently in database by starting this script in command-line terminal. 
 This script needs program mysqldump and cqrlog database users username and password to access database same way as CQRLOG itself does.
 Backup creates <b>allcqrlogs.sql</b> in <b>/tmp</b> folder. You have to move this file to safe place because most Linuxes do clean up /tmp folder during startup.
 <br>It is also recommended to save <b>~/.config/cqrlog folder with allcqrlogs.sql </b>file. Script tells you how you can restore all logs back.
 <br><br>CQRLOG tries to open most common terminals <b>xterm, gnome-terminal </b>or<b> lxterminal</b> to execute <b>create_cqr_user.sh</b>. If that fails you have to run script manually from your command-line terminal.
 </p>
 <h4>external networked SQL server</h4>
-With this option you have to define values to connect SQL server by yourself. Address, port, user and passord are required to connect to external SQL server.
-<br>SQL user and it's privileges have to be created by SQL server administrator.
+With this option you have to define values to connect SQL server by yourself. Address, port, user and password are required to connect to external SQL server.
+<br>SQL user and its privileges have to be created by SQL server administrator.
 <br>It can exist in your home network or in Internet. When using internet SQL servers it is most recommended to use VPN or SSH tunnel connection for security reasons.
 </p>
 <p><br>
-After any of these options is selected, <b>OK</b> button pressed, and connection to SQL database established, CQRLOG tries to create first empty Log. This can take some time, so plese be patient.
+After any of these options is selected, <b>OK</b> button pressed, and connection to SQL database established, CQRLOG tries to create first empty Log. This can take some time, so please be patient.
 <br>When log is ready you can open it and go to <b>NewQSO/File/Preferences</b> to set all station details and other settings affecting to CQRLOG.
 In case of local and external SQL servers there might already be a log, or logs. Then no new log is created.<br><br><b>NOTE:</b> All settings are log based. You can have other logs with different settings and station information. 
 <br>Once you have got all settings ready you can export them to file. It happens at CQRLOG start in <b>Database connection</b> window with <b>Utils/Export/configuration</b>.

--- a/help/gridmap.html
+++ b/help/gridmap.html
@@ -33,19 +33,19 @@
 <p>Grid map is showing locator squares over a world map. Grids are filled by log information of locator and worked/confirmed qsos. You can adjust the map window size, but note that size change may cause sharpness changes and mouse pointing inaccuracy in some cases.</p>
 <p><img src=img/gm1.png></p>
 <p>At top left you have selectors that you can use to select <strong>band</strong> and <strong>mode</strong> that you can to use as base setting of locator grids marking. Also <strong>All</strong> and <strong>Any</strong> can be selected to show all worked locators in log at same time.
- There is also a checbox <strong>Flw rig</strong> that causes band and mode selectors to follow rigs current settings. If rig is outside of ham bands it will not change map. If mode that rigctld gets from rig is not in listed modes and not added to preferences/user modes selector will turn to <strong>Any</strong>. Wsjt modes will be selected from wsjt program if <strong>wsjt remote</strong> is on.<br>
+ There is also a checkbox <strong>Flw rig</strong> that causes band and mode selectors to follow rigs current settings. If rig is outside of ham bands it will not change map. If mode that rigctld gets from rig is not in listed modes and not added to preferences/user modes selector will turn to <strong>Any</strong>. Wsjt modes will be selected from wsjt program if <strong>wsjt remote</strong> is on.<br>
 </p>
-<p>With checbox <strong>Wkd grid</strong> you can select map view so that only worked grids are drawn. 
+<p>With checkbox <strong>Wkd grid</strong> you can select map view so that only worked grids are drawn. 
 </p>
 <p><img src=img/gm3.png></p>
 <p>With<strong> Save image</strong> button you can save current view to image file.</p>
-<p>Square around main grid show that it is worked. There exists also small dot(s) indicating what subgrid(s) is/are worked. The color of worked gird mark is red as long as qso is not confirmed by qsl/eQSL/LoTW. When qso is confirmed  to your log grid marking turns to green.<br>
+<p>Square around main grid show that it is worked. There exists also small dot(s) indicating what subgrid(s) is/are worked. The color of worked grid mark is red as long as qso is not confirmed by qsl/eQSL/LoTW. When qso is confirmed  to your log grid marking turns to green.<br>
 Status texts on top of map shows main and subgrid counts (left) , log name (middle), and  qsos on selected band and mode / all qsos in log (right)</p>
 </p>
 <p>Mouse pointing and click over any main grid of map shows it zoomed as subgrid map. 
 </p>
 <p><img src=img/gm2.png></p>
-<p>In sub view <strong>Wkd grid</strong> checbox has no effect. Band and mode selectors, as well as <strong>Flw rig</strong> are working in subgrid map. You can save also this subgrid map same way as the main map.<br>
+<p>In sub view <strong>Wkd grid</strong> checkbox has no effect. Band and mode selectors, as well as <strong>Flw rig</strong> are working in subgrid map. You can save also this subgrid map same way as the main map.<br>
 </p>
 <p>Mouse click at any position of subgrid map brings the main map visible again.</p>
 <p align=center><img src=img/line.png></p>

--- a/help/h1.html
+++ b/help/h1.html
@@ -30,13 +30,13 @@
 <p align=center><img src=img/line.png></p>
 <a name=ah0><h2><strong>Starting cqrlog</strong></h2>
 <p>Installing cqrlog from package should create a start up selection to your system startup menu.
-<br>Cqrlog can also be started from command terminal by typing: cqrlog ,follwed with return key.
+<br>Cqrlog can also be started from command terminal by typing: cqrlog ,followed with return key.
 <br>There are some additional startup parameters that you can use with command terminal, or add them to your startup menu parameters of cqrlog.
  Those parameters can be listed in command terminal starting cqrlog as: cqrlog -h , or: cqrlog --help
 <br><br><img src=img/h0.png border=0>
 <br><br>Starting with <b>--remote</b> or <b>-r</b> takes one letter argument <b>J</b>,<b> M</b> or <b>K</b> that is not case sensitive. Letters correspond quick control keys in NewQSO/File to start three remote modes.
 <br>When one of these are assigned cqrlog will jump to selected remote mode 10 seconds after startup is complete.
-<br><br>Starting with <b>--debug</b> takes one number (NR) usually<b> 1</b> to see full debug. Thtere are also some negative numbers in use to limit debug prints to certain functions. Mainly for developer usage.
+<br><br>Starting with <b>--debug</b> takes one number (NR) usually<b> 1</b> to see full debug. There are also some negative numbers in use to limit debug prints to certain functions. Mainly for developer usage.
 
 </p>
 <a name=ah1><h2><strong>Preferences</strong></h2>
@@ -91,7 +91,7 @@
     <br>Fix for this is to give path and filename to your real browser. It does not have to be same as your system default one. You can compare results opening first BandMap window and pressing blue ? (help) button.
     <br>Do it first with cqrlog found browser (xdg-open). Then change your favorite browser path and name (like /usr/bin/firefox) and repeat pressing ? of Band Map.
     <br>If no difference, you do not need to change default (unless you want use different browser than system default with cqrlog).
-    <br><strong>Hint:</strong> If you click Web browser name edit box a file open dialog opens and you can navigate to your browser. If you place cursor on Web browser name edit box, press left button and keep it down, you can paint exisiting text and use delete button to clear it and type new text.
+    <br><strong>Hint:</strong> If you click Web browser name edit box a file open dialog opens and you can navigate to your browser. If you place cursor on Web browser name edit box, press left button and keep it down, you can paint existing text and use delete button to clear it and type new text.
     <br><br>    
     
     <strong>get UTC time from computer time</strong> - CQRLOG will read UTC from the system time.
@@ -134,7 +134,7 @@
     on the local computer only. E.g. if you have two computers in hamshack, both are connected to
     the common database. Now you can choose that TRX control, CW keying interface and position
     of opened windows will be stored only to local computer.
-    You'll be able to have different TRX control configuration, windows postions, number of
+    You'll be able to have different TRX control configuration, windows positions, number of
     opened windows etc. on each computer.
 </div>
 <p align=center><img src=img/line.png></p>
@@ -149,7 +149,7 @@
     grayline map.<br>Locator writing format is forced to "AB12cd" that follows definition  https://en.wikipedia.org/wiki/Maidenhead_Locator_System#Description_of_the_system 
     <br><br>
     If you want to use the export function to export contest logs as .edi file you can fill in your
-    personal data into the filelds in the <strong>General</strong> section. Those are then also 
+    personal data into the fields in the <strong>General</strong> section. Those are then also 
     exported to your contest logs.
 </div>
 <p align=center><img src=img/line.png></p>
@@ -158,10 +158,10 @@
 <div align=justify>
     Here are the default values for a new QSO. Remember, that if the radio interface control is
     active, the default frequency does not appear on the logging screen. The preset RST values
-    will apppear in their corresponding boxes.
+    will appear in their corresponding boxes.
     <br><br>
     The <strong>Change default values</strong> button allows you to change the frequencies available in
-    the drop down menu in the NewQSO window. Very useful if you have favourite frequencies
+    the drop down menu in the NewQSO window. Very useful if you have favorite frequencies
     and don't have the radio connected to the computer.<br>
     The <strong>'Use spacebar to move between fields'</strong> is very interesting and probably the
     most natural way but it works only if you are moving forwards. To move between fields,
@@ -185,7 +185,7 @@
     previous QSO with a station even if he was active from another country with his
     call/prefix. E.g. if you enter OK2CQR, you'll also see previous QSOs with him when he
     was OM/OK2CQR, SP/OK2CQR etc.</br>
-    The <strong>Enable satellite mode</strong> Opens second tab 'Satellte' to NewQSO/DXCC statistic view. There you can select used satellite name,
+    The <strong>Enable satellite mode</strong> Opens second tab 'Satellite' to NewQSO/DXCC statistic view. There you can select used satellite name,
     RX frequency and also propagation mode for logged qso.</br>
     If you enable the <strong>Upload SAT info to AMSAT status page</strong> cqrlog will upload a status info to the AMSAT satellite status page. This only happens for satellite QSOs (i.e. propagation mode is "SAT"). The status page can be found under: <a target="_blank" href="https://www.amsat.org/status/">https://www.amsat.org/status/</a>.<br>
     <strong>User defined web button</strong> defaults to www.qrzcq.com requesting info for currently existing call in NewQSO, but you can define URL address you want and use listed macros if needed.<br><br>
@@ -234,7 +234,7 @@
     is fine.<br><br>
     <strong>Port number</strong> is the number of the port used to communicate with rigctld.
     Default value is 4532. The second radio, has to have a different port e.g. 4533.<br>
-    <br><strong>Extra command line arguments</strong> usefull when you have to specify more parameters to
+    <br><strong>Extra command line arguments</strong> useful when you have to specify more parameters to
     rigctld. E.g. CIV address (--civaddr=ID, where ID is the CIV address).<br><br>
     <strong>Run rigctld when program starts</strong> is usually checked but when rig model #2 <strong>Hamlib Net Rigctld</strong> is used then it is unchecked and disabled because with that rig setting we are trying to connect external rigctld. Either in same PC or in network.
     <br>If rig model #1 <b>Hamlib Dummy</b> is selected <strong>Run rigctld when program starts</strong>  is forced to be checked. This allows testing and simulated operations without rig CAT control.
@@ -251,16 +251,16 @@
      command or several in a queue, rigctld commands may be used or if definition starts with word "<strong>run</strong>" (without quotes) it can be a program or
       script name with full file path for your computer.
       <br><ul> <li>
-    <strong>Note:</strong> Rigctld supports raw command <strong>W</strong>. Parameter for it is the rig cat command in bytes. Prefix<strong> \0x</strong> must be added for Hex values. Usr1 command in picture Sets IC7300 to 60m CW with 500Hz filter and reduces output power to leagal limit with raw command.
+    <strong>Note:</strong> Rigctld supports raw command <strong>W</strong>. Parameter for it is the rig cat command in bytes. Prefix<strong> \0x</strong> must be added for Hex values. Usr1 command in picture Sets IC7300 to 60m CW with 500Hz filter and reduces output power to legal limit with raw command.
     </li> <li>
-    <strong>Note:</strong> To run program or script it's name with full path must be entered. If file is command script then first line of it must tell what it is written for. If it is bash command script it's first line must be
+    <strong>Note:</strong> To run program or script its name with full path must be entered. If file is command script then first line of it must tell what it is written for. If it is bash command script its first line must be
     <strong>#!/bin/bash </strong> if not, button definition must have <strong>run /bin/bash /tmp/my_test.sh</strong> to tell that bash is used to call the script.
     </li> <li>
     <strong>Note:</strong> Several rigctld commands can be written in same button definition. Usr3 command in picture  moves rig to 70MHz and then sets CW mode with 500Hz bandwidth filter.
     </li><br> <li>
     <strong>Note:  There is NO feedback from commands to cqrlog !</strong>
     </li></ul>
-    <strong>Switch only between mode related memories</strong> if this option is cheched, only memories related to
+    <strong>Switch only between mode related memories</strong> if this option is checked, only memories related to
     current
     operating mode will be used. E.g. you are on CW right now, CQRLOG will switch only between memories with CW mode.
     When you switch to
@@ -289,10 +289,10 @@
 Setting up Rotator control is very similar to setting up Rig control. Rotor models 1 and 2 (Dummy, NET rotctld ) are using TCP communication and so the <strong>Device</strong> as well
      as <strong>Rotor serial parameters</strong> do not need settings.<br><br>
 <br>
-<br>If <b>Use rotctld \dump_state info for limits</b> cheked rotctld asks turning limits AzMin and AzMax values from rotctld with command <strong>'+\dump_state'</strong>.
+<br>If <b>Use rotctld \dump_state info for limits</b> checked rotctld asks turning limits AzMin and AzMax values from rotctld with command <strong>'+\dump_state'</strong>.
  That makes user possible to set turning limits other than rotator default turn with
  <strong>Extra command line arguments</strong>. Using string <strong> --set-conf=min_az=10,max_az=355</strong>  you can set rotator so that cqrlog will never turn it below 10deg or over 355deg.
- <br>Using negative value at az_min causes Cqrlog set it's 0degrees "P"-command to given negative value (while still displaying 0). I.E if az_min=-180 Cqrlog will use turning commands from "P-180" to "P180".
+ <br>Using negative value at az_min causes Cqrlog set its 0degrees "P"-command to given negative value (while still displaying 0). I.E if az_min=-180 Cqrlog will use turning commands from "P-180" to "P180".
  <br>Without negative az_min or when checkbox  <b>Use rotctld \dump_state info for limits</b> is not set Cqrlog sends commands in usual range "P0 to "P360".
  </p><p>Some rotators have turn from -180deg-0deg-180deg (south stop), like Hamlib Dummy test rotator.
  <br>Most of rotators have turn 0deg - 360deg.
@@ -302,7 +302,7 @@ Setting up Rotator control is very similar to setting up Rig control. Rotor mode
 </p><p align=center><img src=img/line.png></p>
 <p> 
 <a name="mem"><strong>Add/Modify memory</strong></a><br><br>
-You can define your own favourite frequencis and swich between them directly in New QSO window using ALT+V (Mem down)
+You can define your own favorite frequencies and switch between them directly in New QSO window using ALT+V (Mem down)
 and
 ALT+B (Mem up). These keys are used in N6TR clones to switch between bands.<br>
 You can also switch between memory frequencies with TRXControl's <b>M up</b> and <b>M dwn</b> buttons and set rig frequencies
@@ -325,7 +325,7 @@ user should add digital modes (submode names) exactly as written in this table <
 If mode is missing from <strong>NewQSO/mode</strong> selection list and not added to <strong>User defined digital modes</strong> it may prevent ADIF import causing "wrong mode" error.
 </p><p>
 <strong>Note:</strong><br>
-Cqrlog uses internally modefied mode name. We call it here <strong>CqrMode</strong>. CqrMode is created from ADIF mode and submode with conversion table. CqrMode is mainly ADIF submode if it exist, with some exceptions.
+Cqrlog uses internally modified mode name. We call it here <strong>CqrMode</strong>. CqrMode is created from ADIF mode and submode with conversion table. CqrMode is mainly ADIF submode if it exist, with some exceptions.
 <br>Cqrlog will create four files in ~/.config/cqrlog folder for this use if they do not exist. One is a brief <strong>README_modefiles</strong> explaining three other files purposes.
 <br><br>If files exist they are not overwritten keeping possible user changes there. How ever user must do backups by himself if files are edited from original format.
 These files apply to all logs created. They are not log based.
@@ -352,7 +352,7 @@ These files apply to all logs created. They are not log based.
 <li><strong>exception_mode.txt</strong>
 <br>This file holds submode=mode pairs used to convert incoming mode+submode pair to CqrMode when CqrMode can not use ADIF submode directly.
 <br>For example by ADIF definition mode SSB  has submodes USB and LSB. How ever Cqrlog does not use those as CqrMode, but uses only SSB.
- Then CqrMode is converted as SSB. How ever after exception the mode can not have it's submode back when exporting ADIF from Cqrlog.
+ Then CqrMode is converted as SSB. How ever after exception the mode can not have its submode back when exporting ADIF from Cqrlog.
 <br><br>This file can also have conversion from rigctld given mode to ADIF mode. For example with IC7300 rigctld shows mode PACKETUSB if rig is set to usb and data mode:
 <br> then this file can convert PACKETUSB to PKT that is ADIF standard format.
 <br><br> All pairs must be in uppercase format. User can add or delete mode pairs with text editor when needed.
@@ -395,7 +395,7 @@ Only checked fields are exported. The 'Column' option names columns at header li
 Both options affect only for the HTML export. 
 <br>The SAT mode field is not stored in the database but instead calculated on the fly from frequency and RX frequency and for SAT QSOs only.
 <br>Width setting is ignored if "HTML auto column width" is checked when longest text in column (column name or data) sets the column width.
-<br>Distances are not exported when doing log backup at cqlog closing phase. They will be calculated and exported (if selected) in ADIF, HTML and QSL label printing.
+<br>Distances are not exported when doing log backup at cqrlog closing phase. They will be calculated and exported (if selected) in ADIF, HTML and QSL label printing.
  Calculation of distances requires that preferences/station/locator is set and applied (automatic) to every qso and that at least 4 digit locator
   (in case "ll" is added as 5 and 6th char to get the center of grid) of destination station logged. Sometimes importing logs from other logging program may leave own station locator unset. In this case QSO list/File/Group edit must be used for updating "my locator" field.
 
@@ -403,14 +403,14 @@ Both options affect only for the HTML export.
 <a name=ah11><h2><strong>DX cluster</strong></h2></a>
 <img src=img/h14.png border=0><br><br>
 This dialog allows an easy setup of the DX cluster spot filtering. Check the bands you want
-to display. If you want to supress (ie. filter out) spots for some DX countries, put
+to display. If you want to suppress (ie. filter out) spots for some DX countries, put
 its prefixes in the box below. Use a semicolon as a separator.
 <p>
 <strong>Callsign alert</strong> - allows you to enter callsigns that you are interested in. Eg. some special station for an award etc.<br>
 <strong>Run this command when callsign is spotted:</strong> will run select command when any of callsigns you've enter appears in the cluster.<br>
 E.g. use this if you want to see small window with information:<br><br>
 <i> zenity --info --text='Callsign $CALLSIGN detected at $FREQ $MODE' --title=Info</i><br><br>
-You have to install zenity, first. <i>(Thans to SV2RCK for the tip!)</i>
+You have to install zenity, first. <i>(Thanks to SV2RCK for the tip!)</i>
 <br><br>A variant for the KDE desktop.<br>
 The display duration in seconds (here 5) can be set here. The window closes automatically.
 <br><br><i>kdialog --title=Spot-Info --passivepopup "Callsign $CALLSIGN detected at $FREQ $MODE" 5</i>
@@ -419,12 +419,12 @@ This is also possible with "notify-send". The display duration is set in ms (-t 
 <br><br>
 <i>notify-send -t 5000 "Spot-Info" "Callsign $CALLSIGN detected at $FREQ $MODE"</i>
 <br><br>
-"Kdialog" is installed by default using the 'kdebase-bin' package. For "notify-send" the 'libnotify-bin' package must be installed. <i>(Thans to Wolfgang, DL2KI, for the tip!)</i>
+"Kdialog" is installed by default using the 'kdebase-bin' package. For "notify-send" the 'libnotify-bin' package must be installed. <i>(Thanks to Wolfgang, DL2KI, for the tip!)</i>
 
 
 </p>
 <p>
-<strong>Show country name in the DX cluster spot</strong> - next to every spot, you will se the coutry name of the DX station<br>
+<strong>Show country name in the DX cluster spot</strong> - next to every spot, you will se the country name of the DX station<br>
 <strong>Send these commands to telnet DXCluster when connected</strong> - one or several commands with comma separated can be sent to DXCluster after connect is initialized.
  If your command(s) have space(s) between, like "<strong>acc/spot by_zone 14,15,16 and not (on hf/data or on hf/rtty)</strong>" it is recommended to close each command between double quotes.<br>
 <strong>Connect to DX cluster after program startup</strong> - after log is opened, cqrlog will connect to your default cluster. Please remember that
@@ -473,9 +473,9 @@ converted records appears.<br><br><img src=img/h38.png border=0><br><br>
             file browser to 'show hidden files and folders' to see it.
             <br><br>When creating your own member list files you can use one of Global files as example.
             <br>File name must have extension ".txt" and be a plain text file written with linux editor that ends lines to "\n", in hex #0A (LF character).
-            <br>Editors that use "\r\n", in hex #0D#0A (CR+LF charactes) [Windows style linefeeds] do not produce a working list file.
+            <br>Editors that use "\r\n", in hex #0D#0A (CR+LF characters) [Windows style linefeeds] do not produce a working list file.
             <br>1st line is membership list name, 2nd a short description. Do not put any additional spaces after name and description.
-            <br>It can lead to situaton where Club member list selection does not stay in preferences over cqrlog restart.
+            <br>It can lead to situation where Club member list selection does not stay in preferences over cqrlog restart.
             <br>3rd and following lines are CALLSIGN;membership_number. One pair for a line. No spaces, semicolon as delimiter.  Note ONLY CAPS written callsigns will work.
         </td>
     </tr>
@@ -524,7 +524,7 @@ The lower part contains a dialog allowing the set up of where the resulting info
 corresponding field. The most preferred field is 'Award'. Since this field is used for
 check purposes only, all info (more memberships) are displayed in a single line which can
 be longer than the corresponding field on the logging screen. You can navigate here
-with the cursor but the well formated and color coded results in verbose form are
+with the cursor but the well formatted and color coded results in verbose form are
 displayed in the 'Details' window.<br><br>
 <img src=img/h33.png border=0>
 <br><br>
@@ -552,7 +552,7 @@ When checked, the Band Map will show only spots for the mode or band which the r
 The spots are sorted by frequency, so you will see what is on the band - at a glance.
 No doubt you will prefer this over the DX Cluster window which contains a mess of rolling
 spots, often hard to 'catch'. Finally, if the <strong>'Delete station from band map after
-    QSO'</strong> option is checked, the entry with a worked station disappers from the Band Map.
+    QSO'</strong> option is checked, the entry with a worked station disappears from the Band Map.
 If such a station is spotted again, it will appear again in the Band Map.
 
 <br><br> You can also set width for frequency and call columns. After change clear is needed to get all lines to have even columns.
@@ -706,7 +706,7 @@ There are no known dependencies issues.<br><br>
     At WSJT-X 2.1.0 settings ADIF remote is renamed to "Secondary UDP server (deprecated)" and it is reported to be removed completely in future. Because of that it is now possible to set cqrlog's ADIF port to wsjt-x UDP server port number. WSJT-X 2.1.x UDP frames contain message #12 that
      includes log information in ADIF format and ADIF remote can now parse that from binary data if you do not like to have monitoring properties (using wsjt remote) but want just qso logging (using ADIF remote).
     <br><br>
-    ADIF remote has now better support for QRZ/HamQTH info fetch. If this is not allowed in preferences, or if there is no reponse from Web max waiting time (timeout)  is 5 seconds (You can not remove this property, so be patient. You can not have new qso for logging during 5 seconds!).
+    ADIF remote has now better support for QRZ/HamQTH info fetch. If this is not allowed in preferences, or if there is no response from Web max waiting time (timeout)  is 5 seconds (You can not remove this property, so be patient. You can not have new qso for logging during 5 seconds!).
     <br>While having qso you can write some notes like Name, QTH, Comment to QSO, etc. to NewQSO and it will saved with qso data during next wsjt-x "log qso/OK" event. They will not be overwritten by possible Qrz/HamQth info.
     <br><br>
     <strong>NOTE !!</strong> Wstx- does not send contest -name, -number and -string in ADIF logging datagram. Contest exchanges are placed to regular rst_s and rst_r strings. So cqrlog can not fill proper contest columns when logging is done with ADIF datagram using ADIF remote. 
@@ -715,15 +715,15 @@ There are no known dependencies issues.<br><br>
     <a name=ch3><h2><strong>Exit & Auto backup</strong></h2></a>
     To increase the safety of your log data, CQRLOG is equipped with an <strong>Auto backup</strong>
     option which allows you to export (ADIF) and store the log data in a safe location.
-    The ADIF format was choosen because of its text format. The output file can be compressed
+    The ADIF format was chosen because of its text format. The output file can be compressed
     in tar.gz format.<br><br>
     <img src="img/h102.png"><br><br>
     Of course, the export and compression takes some time, depending on the log size (QSO count).
     If you are not in a hurry, allow the program 2-3 minutes to perform this safety measure.
-    We reccomend you backup your log to your hard drive from there it should be copied to
+    We recommend you backup your log to your hard drive from there it should be copied to
     other media (your server, USB flash, a memory card etc.).<br>Distances are not exported in backup phase. So do not expect to find them from backup file.
     </br></br><img src="img/h119.png"><br><br>
-    Check both "Enable autobackup after program ends" and "Ask before creating a backup" to prevent closing cqrlog accidently. Answering <strong>"Cancel"</strong> to question returns to NewQso without backup.
+    Check both "Enable autobackup after program ends" and "Ask before creating a backup" to prevent closing cqrlog accidentally. Answering <strong>"Cancel"</strong> to question returns to NewQso without backup.
     <a name=ch4><h2><strong>External viewers</strong></h2></a>
     <br>
     <img src="img/h111.png"><br><br>Set up the viewers used for browsing the notes related to a particular callsign.
@@ -732,7 +732,7 @@ There are no known dependencies issues.<br><br>
     To enable reading of all file types, corresponding viewers must be set up properly,
     ie. must be in the system path.<br>
     <br><strong>Note:</strong> Setting html browser here affects only to call attachments and it can be different than system default, or different than selected at preferences/program tab.
-    <br><strong>Hint:</strong> If you click Web browser name edit box a file open dialog opens and you can navigate to your browser. If you place cursor on Web browser name edit box, press left button and keep it down, you can paint exisiting text and use delete button to clear it and type new text.
+    <br><strong>Hint:</strong> If you click Web browser name edit box a file open dialog opens and you can navigate to your browser. If you place cursor on Web browser name edit box, press left button and keep it down, you can paint existing text and use delete button to clear it and type new text.
     <a name=ch5><h2><strong>Callbook support</strong></h2></a>
     CQRLOG supports <a href="http://HamQTH.com">HamQTH</a> and <a href="http://qrz.com">QRZ.com</a>
     callbooks but only access through the XML interface is supported. HamQTH has a free interface,
@@ -791,7 +791,7 @@ There are no known dependencies issues.<br><br>
         <li>check if you have set correct username, password (email, Code)</li>
         <li>export all data from the log to ADIF file</li>
         <li>import this adif file to the website of online log you are going to use
-            (if you are using HamQTH, please wait untill the email about a successful import arrives)
+            (if you are using HamQTH, please wait until the email about a successful import arrives)
         </li>
         <li>open QSO list window, click to <strong>Online log</strong> menu and choose
             <strong>Mark QSO as uploaded to all logs</strong>, CQRLOG marks all QSO as uploaded

--- a/help/h20.html
+++ b/help/h20.html
@@ -301,7 +301,7 @@
     (only if you enable it in the <a href="h1.html#ah4"><strong>Preferences</strong></a>).
     The 'Frequency' and 'Mode' fields are skipped if you have properly set up the
     <a href="h1.html#ah7"><strong>TRX Control</strong></a>.
-    If you omit settting up the TRX Control option or if your radio does not
+    If you omit setting up the TRX Control option or if your radio does not
     allow Computer Aided Control (CAT), the Frequency and Mode fields
     are not skipped and must be filled manually, however you can use the
     pull-down menu to choose a corresponding default frequency in any band
@@ -347,14 +347,14 @@
     <br><br>
     <img src=img/h25.png border=0><br><br>
     <div align=justify>
-    Details window dispays details about new/confirmed zones, IOTA details etc. You can open it from <strong> NewQSo/Window/Details</strong> or with Ctrl-I key.
+    Details window displays details about new/confirmed zones, IOTA details etc. You can open it from <strong> NewQSo/Window/Details</strong> or with Ctrl-I key.
     </div>
     <br><br>
 
-    <strong>German DOK:</strong> When entering a german callsign the field State will switch to DOK. 
-    Here you can enter the german DOK of the station. You can, too, click on the label 'State' or 'DOK'
+    <strong>German DOK:</strong> When entering a German callsign the field State will switch to DOK. 
+    Here you can enter the German DOK of the station. You can, too, click on the label 'State' or 'DOK'
     and the field will toggle between State and DOK. Only letters and numbers are valid 
-    and a maximum length of 12 character due to special DOKs (in german "Sonder-DOK").<br>
+    and a maximum length of 12 character due to special DOKs (in German "Sonder-DOK").<br>
     You can use the Statistic for DOK. You can export or import it via ADIF Files.
     When in Preferences - Callbook support the option HamQTH.com is enabled, the DOK is filled when available.
     QRZ.com does not support DOK.<br><br>
@@ -373,7 +373,7 @@
     If you check <b>Preferences/New QSO/Enable satellite mode</b> you get a new tab where 
     you can enter satellite name, rx frequency and propagation mode.
     There are several propagation modes that you can select, not only "SAT" so this 
-    is usefull also when keeping record of non satellite contacts.<br>
+    is useful also when keeping record of non satellite contacts.<br>
     You can make the DX spot function use the RX frequency of this tab if you enable
     the checkbox "Use RX frequency for DX spots".<br><br>
 
@@ -408,10 +408,10 @@
     mostly for VHF freaks who forget to change the QRA locator in the QTH profile).
     In the next column is the reference call sign (the core of a slashed call, ie.
     KH6/OK2CQR). You can change it using Ctrl-R. The purpose is to provide the possibility
-    of changeing the reference call if a correction of membership needed.
+    of changing the reference call if a correction of membership needed.
     The second column also shows the operator call if it is set to a different call
     than what is configured as station callsign in preferences. You can change the 
-    operator call tempoarily using the key combination ALT-O. The new operator callsign
+    operator call temporarily using the key combination ALT-O. The new operator callsign
     is stored until restart of cqrlog. To manually reset the operator call back to the
     station callsign just set an empty value.
     The number in the right corner denotes the CQRLOG version.
@@ -436,7 +436,7 @@
 
 <a name="ah33"><h2><strong>Digital modes </strong></h2></a>
 CQRLOG employs <em>fldigi</em> by Dave Freese, W1HKJ and <em>WSJT-X</em> by Joe Taylor, K1JT. We believe that these are the
-best digimode softwares available.<br>
+best digimode software available.<br>
 <br>The most important thing is a <a href="h1.html#ch2">proper setup</a> of the remote mode. For <em>fldigi<em> you have 2 different ways to setup remote .<br>
 For <em>wsjt-x</em>, setup is done at same tab of preferences as <em>fldigi<em>. For operating with wsjt-x see: <a href="wsjt.html">Wsjt-x operation</a>
 <br><br> To use <em>fldigi</em>, CQRLOG must be switched to Remote from the menu File -> Remote mode for fldigi(or Ctrl-M).

--- a/help/h21.html
+++ b/help/h21.html
@@ -90,7 +90,7 @@ Callsign alert window allows <b>adding</b>, <b>deleting</b> and <b>editing</b> c
 <img src="img/misc44.png" name="44"  width="380" height="260">
 </img>
 <p>
-There is also checkbox "<b>Allow partialy callsign alert</b>" that allows many different kind of alerting conditions using regular expressions (regexp).
+There is also checkbox "<b>Allow partially callsign alert</b>" that allows many different kind of alerting conditions using regular expressions (regexp).
 <br>As an example from the image of callsign alert window you can see different regexp variations for some alert conditions. 
 <br>In order they will alert as follows:
 <br>
@@ -101,7 +101,7 @@ There is also checkbox "<b>Allow partialy callsign alert</b>" that allows many d
 <li> all calls @2M/all mode</li>
 <li> calls starting with EA @40M/RTTY</li>
 <li> calls starting with VK @all bands/all modes</li>
-<li> calls starting with XF1IM basicly this is whole call, but can have also suffix extensios like /M /P etc all bands/all modes</li>
+<li> calls starting with XF1IM basically this is whole call, but can have also suffix extensions like /M /P etc all bands/all modes</li>
 <li> calls starting with ZL all bands/all modes</li>
 <br>
 For more information how to use regexp delimiters see: <a href=https://en.wikipedia.org/wiki/Regular_expression#POSIX_basic_and_extended>https://en.wikipedia.org/wiki/Regular_expression#POSIX_basic_and_extended</a>
@@ -212,7 +212,7 @@ So any time you like you can make it larger and chat lines are there to check.</
             <ul>
                 <li>Spot filtering set up for the DX Cluster window</li>
                 <li>Additional band map filtering capable of filtering out spots from momentarily unwanted
-                    modes, contries, zones or continents. CQRLOG has another filter allowing you to watch spots
+                    modes, countries, zones or continents. CQRLOG has another filter allowing you to watch spots
                     of special interest, ie. you are waiting for an expedition etc. You can set up another
                     filter showing spots only on the active band (the band which the radio is on) and the
                     actual mode (the mode the radio is on).</li>
@@ -228,8 +228,8 @@ So any time you like you can make it larger and chat lines are there to check.</
                 If the entry becomes older than the set time, it is displayed in a lighter color. Very old
                 entries will disappear, also if you log the station, the corresponding entry disappears
                 from the band map. 
-                <br><br>The entries are always sorted by frequency. Default order is for lowest to higest. This can be reversed with checkbox <b>Reverese order</b>.
-                <br>With normal order and <b>Show active band</b> checked this shows CW spots first (CW is normally at band low edge). Cheking <b>Reverse order</b> will then show SBB spots first.
+                <br><br>The entries are always sorted by frequency. Default order is for lowest to highest. This can be reversed with checkbox <b>Reverse order</b>.
+                <br>With normal order and <b>Show active band</b> checked this shows CW spots first (CW is normally at band low edge). Checking <b>Reverse order</b> will then show SSB spots first.
                 <br><br>When band map form is active new spots are not added. This helps to locate needed
                 line from all spot lines. Form name changes to <b>BM PAUSED!</b> to remind that nothing will be
                  added until focus is moved to any other form by a mouse click.

--- a/help/h22.html
+++ b/help/h22.html
@@ -42,7 +42,7 @@ The QSO list has a dedicated QSL menu item in the upper menu bar.
             <li>Do not send (N)</li>
             <li>Manager direct (MD)</li>
             <li>Manager buro (MB)</li>
-            <li>Confirmad by email (CE)</li>
+            <li>Confirmed by email (CE)</li>
         </ul>
 </ul>
 If you want to send a QSL card, it is better to mark the QSO record with a similar mark

--- a/help/h23.html
+++ b/help/h23.html
@@ -47,7 +47,7 @@ the <b>Callsign</b> box and click the <b>Include</b> radio button. Note, please,
 contacts with members of a particular club or from your own database, you should choose
 the time span (<b>date from-to</b>) to make the <b>Membership</b> option active.
 <br>Selecting <b>Band</b> from bandselector will preset <b>Freq from:</b> and <b>Freq to:</b> as band start and end frequencies (Defined in Preferences/Bands/Frequencies).
-<br><br> Once filter values are selected you can make them reversed by checking chekbox <strong>Reverse filter (NOT)</strong>. I.E. making filter like <strong>mode FT8</strong>
+<br><br> Once filter values are selected you can make them reversed by checking checkbox <strong>Reverse filter (NOT)</strong>. I.E. making filter like <strong>mode FT8</strong>
  will show all FT8 qsos, but if you check <strong>Reverse filter (NOT)</strong> it shows all other mode qsos, but not FT8 ones.
 <br><br>
 Pressing calendar icon is easy way to set date. Double click on selected date closes calendar and sets the date. Pressing ESC closes calendar, but does not set date. Date can also be typed in manually.
@@ -67,7 +67,7 @@ used). Choose a location and file name.<br><br>
 Besides the standard filter function there is a separate menu for filtering QSOs based on contests. 
 To use this please select "Contest filter" from the "Filter"-menu.<br><br>
 <img src="img/h45h.png"><br><br>
-The function autmatically loads the names of all contests that QSO where logged in in the QSO database.
+The function automatically loads the names of all contests that QSO where logged in in the QSO database.
 You can then choose based on the name of the contest which QSOs to show and the export accordingly.
 It is recommended to use individual names for the contests e.g. extend by month and year to be able 
 to distinguish.<br><br>

--- a/help/h24.html
+++ b/help/h24.html
@@ -57,14 +57,14 @@ the QSO list can trigger a DXCC statistics rebuild.
         </td></tr>
     </tbody>
 </table>
-The main difference is that the 'Details' window can ionly be activated (if not activated
+The main difference is that the 'Details' window can only be activated (if not activated
 at program startup, <a href="h1.html#ah4"><strong>see 'Preferences'</strong></a>)
 from the logging screen.
 Statistics <a href="h3.html#ah30"><strong>rebuilding</strong></a> is only possible
 from the QSO list.<br><br>
 The only statistics which should be maintained are the DXCC ones. With the exception of
 the footer of the DXCC detailed presentation, all DXCC scores are based on actual valid
-contries on the current DXCC list, ie. <strong>NO</strong> deleted countries. Other
+countries on the current DXCC list, ie. <strong>NO</strong> deleted countries. Other
 stats are computed while logging.<br><br>
 There are several presentations of DXCC statistics. A summary is displayed in the
 QSO List, just above the table.<br>

--- a/help/h25.html
+++ b/help/h25.html
@@ -45,7 +45,7 @@
     changed to an Edit window. This status is clearly marked with the red message
     <font color=#ff0000>(edit mode)</font> just behind the <em>Call</em> header which
     is also displayed in red. All fields can be edited. When you finish editing, you should
-    save the chages using the ENTER key or by clicking the <em>Save QSO [enter]</em> button,
+    save the changes using the ENTER key or by clicking the <em>Save QSO [enter]</em> button,
     in the same way that you do when you log a new contact.<br></div>
 <p><img src=img/h93.png></p>
 <div align="justify">A QSO record can now be edited directly from the logging screen.

--- a/help/h26.html
+++ b/help/h26.html
@@ -31,7 +31,7 @@
 <h2><strong>CW messages</strong></h2>
     <p>Assuming that your CW interface is properly set up and working,
     you can add and/or edit your CW messages.<br><br>
-    Set up your CW messages via Preferences/CW inteface/CW messages button.
+    Set up your CW messages via Preferences/CW interface/CW messages button.
     <br> You can also access CW messages from the upper menu bar of the New QSO window.
     Click on the 'File' item and select CW Messages.<br><br>
     <img src=img/h96b.png>&nbsp;&nbsp;<img src=img/h96.png><br><br>
@@ -58,11 +58,11 @@
 		<br>
 		<li>%xn  - contest exchange serial number</li>
 		<li>%xm  - contest exchange message</li>
-		<li>%xns - contest exchenge serial number sends 9->N and 0->T</li>
+		<li>%xns - contest exchange serial number sends 9->N and 0->T</li>
 		<li>%xrs - full contest exchange RST+SerialNR+Message sends 9->N and 0->T.<br>
 		(May be used always instead of %rs as if serNR and Message are empty just sends plain report.)</li>
 		</li><li> + or - in macro text will increase/decrease CW speed by 5WPM/one mark. 
-		<br>"TU +++599--- 001" will send 599 with 15WPM higer speed.
+		<br>"TU +++599--- 001" will send 599 with 15WPM higher speed.
 		<br><br>Hamlib keyer has some limitations with this: 
 		<br> 1) Version of Hamlib must be at least Hamlib 4.1~git Last commit 2020-10-20 03:22:59 2020 +0000 SHA=8a769c
 		<br> 2) Do not use space(s) between text and +(or -) rigctld will add them I.E. "TU+++599---001"
@@ -78,7 +78,7 @@
     </p><a name=mk1><br></a> <img src="img/misc8.png" name="8"  width="500" height="85">
    </img>
    <p><strong>Memory keys</strong> form has buttons PgUp and PgDn that are not configurable. They alter CW speed in same way as keyboard keys PgUp and PgDn that some, specially laptop computers, may not even have.
-   <br>When using <strong>Memory keys</strong>-form with mouse, or keyboard, you are able to lauch memories by mouse click or by  <strong>F</strong>-key press from keyboard keys. Same with PgUp and PgDn, both are working, keys and mouse click.
+   <br>When using <strong>Memory keys</strong>-form with mouse, or keyboard, you are able to launch memories by mouse click or by  <strong>F</strong>-key press from keyboard keys. Same with PgUp and PgDn, both are working, keys and mouse click.
    <br>You can select what happens when <strong>Memory keys</strong>-form is active and <strong>ENTER</strong> (also called Return) key is pressed, <strong>repeat last clicked memory</strong> (send focused button text)
    , <strong>ignore it</strong> (do nothing) or <strong>save qso</strong>, by selecting that with ENTER section radio buttons in <strong> CW Messages</strong> definition form.</p>
     <a name=mk2><img src=img/h98.png></a><br>
@@ -89,7 +89,7 @@
         <li><strong>word mode</strong> - a whole word is typed, sending starts after pressing
             of the spacebar
         <li><strong>word mode, first word in letter mode</strong> - a combination of above.
-            The keyer begins in letter mode to avoid unneccessary delays, if you type fast enough
+            The keyer begins in letter mode to avoid unnecessary delays, if you type fast enough
             it switches to word mode
         </li>
     </ul>
@@ -100,14 +100,14 @@
       
       <br><br> <strong>Same warning  </strong>with manual typing in word mode: If your typing speed is faster than cw sending you may hit send buffer limit sooner or later.
       <br><br> <strong>Switching radios </strong>while CW sending is going on can cause unexpected results !
-      <br><strong>Always wait</strong> that CW message has finshed before switching radios as it will also switch CW keyers.
+      <br><strong>Always wait</strong> that CW message has finished before switching radios as it will also switch CW keyers.
       <br><strong>Always wait</strong> that selected radio shows frequency in TRXControl before sending a CW message or start using CW Type.
       <br><br>
 
     The <strong>keying speed</strong> can be changed with PgUp (QRQ) and PgDn (QRS) keys
     in 2 WPM steps when <strong>NewQSO</strong>-form is active. In the <strong>CW type</strong>-form when cursor is in text typing area same PgUP/PgDN keys work. Speed can also be changed with the small arrow
     buttons to the right of the speed display. The actual speed is always displayed in the status line of the <strong>New QSO</strong>-form and in <strong>CWType</strong>-forms speed selector.<br><br>
-    The<strong> ESC </strong>key stops running transmit. This may not be supported in all keyers and rigs and is mainly usefull when using word mode or pasted/dropped text.
+    The<strong> ESC </strong>key stops running transmit. This may not be supported in all keyers and rigs and is mainly useful when using word mode or pasted/dropped text.
     <br>
     With HamLib keyer ESC sends hex byte 0xFF as message. Icom rigs halt CW with this. An empty message with Kenwood rigs should use this to stop sending.
     <br>Be aware that this has tested very little.

--- a/help/h27.html
+++ b/help/h27.html
@@ -64,7 +64,7 @@
 
         <h3><strong>Tables in cqrlogXXX:</strong></h3><br>
 
-        where XXX is numer of the log e.g. cqrlog001 for the first log.<br><br>
+        where XXX is number of the log e.g. cqrlog001 for the first log.<br><br>
         <strong>cqrlog_main</strong><br>
         &nbsp;&nbsp;&nbsp;the main table with all QSO records<br><br>
 

--- a/help/h28.html
+++ b/help/h28.html
@@ -39,14 +39,14 @@ If mode is SSB, FM or AM  then voice messages will be sent. Otherwise CW message
 When F-key is pressed, or button clicked, program will execute a script at ~/.config/cqrlog/voice_keyer/voice_keyer.sh with Fkey name (F1 .. F10) as 1st parameter.
 </br> Script will then do what user wants to happen with that key/button. It can be anything, not just playing a voice recording.
 </p><p>
-Here is a sample of script. Modfy it against your needs:
+Here is a sample of script. Modify it against your needs:
 
 <pre>
 #!/bin/bash
 
 #Comment lines are starting with #
 #this script requires program 'ncat' (also called 'nc') 
-# 'pidof' and player you select (defaut 'mpg123') to be installed.
+# 'pidof' and player you select (default 'mpg123') to be installed.
 
 
 #You can test this script from command line by typing:

--- a/help/h29.html
+++ b/help/h29.html
@@ -37,9 +37,9 @@
      ~/.config/cqrlog/stop.sh</br></p><p>
      They are called when program is up/goes down and rigctld is still running.
      You can do anything with them. </br>
-     If you have PC controlled relay box you can  start  your coffee maker when cqrlog starts and when cqlog is closed
+     If you have PC controlled relay box you can  start  your coffee maker when cqrlog starts and when cqrlog is closed
      switch coffee maker off  :D :D :D</br>
-     If you have rotctld yuo can turn your antenna to start direction.
+     If you have rotctld you can turn your antenna to start direction.
      With rigctld you can power your rig, or/and set your favorite frequency and mode when cqrlog starts.
      </br>At cqrlog closing phase 1000ms (1sec) wait time is added so that script can access to rigctld before it goes down.
      This should be enough to execute a command.<br>

--- a/help/h3.html
+++ b/help/h3.html
@@ -37,9 +37,9 @@
     programs may need a third party conversion utility).
     <br><br>
     Cqrlog now follows ADIF 3.1.0 specification of special UTF8 characters. Mainly they can be found from Name, QTH, Comment and Notes fields. Specification says that when there is special character(s) some adif tags may have suffix _INTL to show this. Like &lt;QTH_INTL:6&gt;Pyhtää
-    <br>If pure ASCII charcters are found the usual tag format is used. Like &lt;QTH:4&gt;Pori
+    <br>If pure ASCII characters are found the usual tag format is used. Like &lt;QTH:4&gt;Pori
     <br>Every time special UTF8 character is found in tags, where specification allows, UTF8 printing routines are used and the _INTL suffix is added.
-    <br>At import side tags with suffix _INTL are read with UTF8 routines. Without _INTL with normal ASCII routines. This makes importing backward compatible with old cqrlog exports that have set tag lenght wrong if there has been special UTF8 characters in tag data.<br><br>
+    <br>At import side tags with suffix _INTL are read with UTF8 routines. Without _INTL with normal ASCII routines. This makes importing backward compatible with old cqrlog exports that have set tag length wrong if there has been special UTF8 characters in tag data.<br><br>
     Go to QSO list (Ctrl-O on the main logging screen or File -> Show QSO list from the menu).
     <br><br>
     <img src="img/h39.png" border="0"><br><br>
@@ -56,9 +56,9 @@
     is so fast that you never notice the progress indicator.<br><br>
     If the ADIF file contains a grid locator (tag MY_GRIDSQUARE) that will be used upon import.
     In the case that this is not present the grid locator from the selected profile will be used.
-    If also that is absent or incorret the default locator from the config will be used.
+    If also that is absent or incorrect the default locator from the config will be used.
     However the user can choose to override a MY_GRIDSQUARE from ADIF file by selecting the checkbox.
-    In this case MY_GRIDSQUARE from the ADIF file is overriden by the locator from the selected profile 
+    In this case MY_GRIDSQUARE from the ADIF file is overridden by the locator from the selected profile 
     or if no profile is selected the default locator from the config is used.<br><br>
     <img src="img/h42.png" border="0"> <img src="img/h42b.png" border="0"><p>
     The  window now shows the import completion, the number of imported records and
@@ -109,7 +109,7 @@
     This function can be used to export contest logs in .edi file format. This export requires a 
     suitable filter to be set. Generally only one band per file is allowed. Also make sure that the
     fields like exchange sent/received are set properly before exporting. If you choose this export
-    you will see the follwing window.
+    you will see the following window.
     <br><br>
     <img src=img/h45f.png><br><br>
     You can set the filename to export to as well as some meta data describing the equipment you
@@ -122,23 +122,23 @@
     </p>
     <p align=center><img src=img/line.png></p>
     <p><a name=ah28><strong>Cabrillo export</strong></a><br><br>
-    This dialog can be used to export contest logs in Carbillo format. Cabrillo is very compilcated to export as
+    This dialog can be used to export contest logs in Cabrillo format. Cabrillo is very complicated to export as
     almost all contests have their own QSO line layout and score counting. That's why Export has no score counting, but it offers
     some statistics from exported qsos to help manual counting of claimed score.<br><br>
     For export  <b>Qso list/filter/create</b> or <b>Qso list/filter/Contest filter </b>has to be set to select qsos to be exported.<br>
     If you used <b>Qso list/filter/Contest filter </b> you can press button <b>Frm Flt</b> to get contest name from filtered result.
     <br><br>QSO-line header follows most used layout and can not be modified, except <b>width of callsign space</b> that affects both calls (my&amp;wkd).
-    <br><b>Use UpCase letters for all QSO records</b> is defaut checked and converts QSO lines to upper case. Mainly changes exchange messages if they have been written with low case letters. This setting can be saved to log settings file.<br>
-    Info sent and rcvd can be modified using selections. Some contests do not use <b>reports, they can be omitted from checbox.</b><br>
+    <br><b>Use UpCase letters for all QSO records</b> is default checked and converts QSO lines to upper case. Mainly changes exchange messages if they have been written with low case letters. This setting can be saved to log settings file.<br>
+    Info sent and rcvd can be modified using selections. Some contests do not use <b>reports, they can be omitted from checkbox.</b><br>
     Exchange1 and Exchange2 can contain data by  selected by selectors with <b>given space width</b> 1-99. If empty they are ignored.<br>
-    <B>TX count</b> is the transmitter count at the end of line. It can also be empty and so ingnored<br>
+    <B>TX count</b> is the transmitter count at the end of line. It can also be empty and so ignored<br>
     Many template layouts to study can be found from <b> http://www.contestlogchecker.com/cabrillo-templates.html</b>
     <br><br>
     With <b>Count pfx</b> user can get statistic count from qsos to certain country. Type in callsign prefix of country. If export thinks prefix is wrong
      it clears column when moved away from it. Then try again. Example: VA is not ok, but VA1 will turn accepted as VE.
     <br><br>
-    Export remebers last used settings (by used log). You can also save and load settings for different contests using <b>save and load buttons</b>.
-    <br>At bottom of form there is prograss indicator and after export there is some statistics and possible error message shown. You can also open resulted Cabrillo file with defined text editor (preferences/external viewers) using button <b>"Open resulted file".</b>
+    Export remembers last used settings (by used log). You can also save and load settings for different contests using <b>save and load buttons</b>.
+    <br>At bottom of form there is progress indicator and after export there is some statistics and possible error message shown. You can also open resulted Cabrillo file with defined text editor (preferences/external viewers) using button <b>"Open resulted file".</b>
     <br>If red error text is displayed after export you can open error log by clicking the red error text line.
     <br><br>
     As cabrillo export output is very basic you may need to edit exported file afterwards with text editor to suit your purposes!
@@ -156,7 +156,7 @@
             <td valign="top"><img src="img/note.png"></td>
             <td style="width: 100%; text-align: justify; background-color: rgb(204, 255, 255);">
                 <strong><font color="blue">Note:</font></strong> Very often Cqrlog version update requires just file /usr/bin/cqrlog change to latest version. If your package manager does not support latest version and you have well running old version in use just copy folder ~/.config/cqrlog with all files and subfolders to safe place as backup. Copy also 
-                /usr/bin/cqrlog to same place. Then download the tgz file "Complete application directory for other distributions", extract file /usr/bin/cqrlog from there and copy it to your /usr/bin folder (you need to use root priveleges I.E sudo for that).
+                /usr/bin/cqrlog to same place. Then download the tgz file "Complete application directory for other distributions", extract file /usr/bin/cqrlog from there and copy it to your /usr/bin folder (you need to use root privileges I.E sudo for that).
                 If everything works you have latest version. If not, just copy back your saved folder ~/.config/cqrlog and the old /usr/bin/cqrlog.
             </td>
         </tr>
@@ -186,7 +186,7 @@
             <td valign="top"><img src="img/note.png"></td>
             <td style="width: 100%; text-align: justify; background-color: rgb(204, 255, 255);">
                 <strong><font color="blue">Note:</font></strong> While opening your new country files
-                [see 3.], you dont need to open a particular file. The 'Open' button starts a procedure
+                [see 3.], you don't need to open a particular file. The 'Open' button starts a procedure
                 which reads ALL files in the /ctyfiles folder.
             </td>
         </tr>
@@ -345,7 +345,7 @@ High Speed Club</pre>
     &nbsp;&nbsp;6Y5XG;331;1951-05;-<br>
     &nbsp;&nbsp;7J1AEF;1297;1976-06;-<br><br>
     ie. a <strong>single</strong> call, membership number and datelimits from-to, separated by
-    a semicolon ';', per line. See above the two optins: 6O2NG with membership number 533 was
+    a semicolon ';', per line. See above the two options: 6O2NG with membership number 533 was
     a member of the club from April, 1957 to March, 2005. 6Y5XG with number 331 started his
     membership May, 1951 and is still a member. The dash instead of a date (separated from
     the begin date by a semicolon) denotes that the membership is still active. A dash can

--- a/help/h30.html
+++ b/help/h30.html
@@ -37,8 +37,8 @@
 </img>
 <p>
 TRX Control window Shows current frequency and buttons allow change of Band, mode, memory and rig. Additional selections are User defined buttons, Power buttons, Vfo A and B buttons and memory information field.
-<br>When pressing band selection button rig moves to that band using predefined frequency of currently active mode. Default frequencies and User buttons can be defined in <a href="h1.html#ah7">preferecences/TRX control</a>.
-<br><br>You can select rig vfo with buttons <b>A</b> and <b>B</b> but there is no feedback what vfo is currenty used as Icom brand rigs do not support "Get_vfo" command.
+<br>When pressing band selection button rig moves to that band using predefined frequency of currently active mode. Default frequencies and User buttons can be defined in <a href="h1.html#ah7">preferences/TRX control</a>.
+<br><br>You can select rig vfo with buttons <b>A</b> and <b>B</b> but there is no feedback what vfo is currently used as Icom brand rigs do not support "Get_vfo" command.
 </p><a name="m4"></a><p>If <b>M_up</b> or <b>M_dwn</b> are pressed or memory is selected by double click of memory list, the information text will show up to <b>Mem Info</b> field. If frequency is changed manually after that info text will disappear.
 <br>If memory does not have info text (max 25chr) just <b>x of y</b> is displayed where x refers to memory order in Add/Modify memory list and y total amount of memories.
 <b>None</b> (in red) indicates that there are no memory lines.
@@ -50,15 +50,15 @@ TRX Control window Shows current frequency and buttons allow change of Band, mod
 Keeping both keys pressed the step is 1MHz.
 <br>If you use mouse wheel the rig frequency is changed while turning. There is no need to press enter then. Just move mouse cursor away from frequency display.
 
-<br><br><b>NOTE!!!</b> <br>Check <b>pereferences/TRXcontrol/Switch only between mode related memories</b><br>Cqrlog TRXcontrol memories are categorized by mode (groups). CW, SSB(=AM+USB+LSB+FM), RTTY(=RTTY+DATA+PKTLSB+PKTUSB+PKTFM)[no mode selector for PKT*  but you may "M wri" them anyway]. 
+<br><br><b>NOTE!!!</b> <br>Check <b>preferences/TRXcontrol/Switch only between mode related memories</b><br>Cqrlog TRXcontrol memories are categorized by mode (groups). CW, SSB(=AM+USB+LSB+FM), RTTY(=RTTY+DATA+PKTLSB+PKTUSB+PKTFM)[no mode selector for PKT*  but you may "M wri" them anyway]. 
 So do not wonder if you get smaller amount of memories than in your list when pressing <b>M_up</b> and <b>M_dwn</b> with "Show mode related" checked.
 <br><br>
 <img src="img/h122.png" name="9"  width="393" height="367">
  <img src="img/h121.png" name="10"  width="373" height="367">
 </img>
 <br/>
-<br>You can set rig by double click of an memory row in <b>Open  memory list</b>. Similar action happen also in <b>Add/Modify memories</b>. The differense is that you can keep
- <b>Open memory list</b> open while loggeing qsos etc. Where as <b>Add/Modify memories</b>, when open, blocks other functionality.
+<br>You can set rig by double click of an memory row in <b>Open  memory list</b>. Similar action happen also in <b>Add/Modify memories</b>. The difference is that you can keep
+ <b>Open memory list</b> open while logging qsos etc. Where as <b>Add/Modify memories</b>, when open, blocks other functionality.
  <br>While <b>Add/Modify memories</b> is open you can use buttons in right frame. Texts of buttons are quite self explaining.
  <br>Deleting a memory line, or all lines, do not have any further warning questions (Are you sure?). In case you deleted something wrong just close window with  <b>Cancel</b>. No changes are recorded then.
 <br>Closing <b>Add/Modify memories</b> is done with buttons <b>OK</b> or <b>Cancel</b>. Closing <b> Open memory list</b> window must be done using <b>x</b> at top right corner of window.
@@ -81,8 +81,7 @@ Window shows current position of rotor with <b>numerical display, Short and Long
 <br>Small numbers on top of bar display shows current rotor limits. Usually this is 0..360, but may be also -180..180 depending on rotor model, or other user defined limits.
 <br>Direction drive buttons run rotor until stop button is pressed or maximum 15sec time limit is reached.
 <br><br> When a call is entered to <b>NewQSO</b> callsign field and cursor is moved away from that field <b>DXCC info</b> part gets filled against call prefix and/or locator grid,
- then, when <b>DXCC/AZIM</b> shows a value, it is possible to press <b>Short Path</b> or <b>Long Path buttons</b> and your ro
- tor will turn your antenna to that direction.
+ then, when <b>DXCC/AZIM</b> shows a value, it is possible to press <b>Short Path</b> or <b>Long Path buttons</b> and your rotor will turn your antenna to that direction.
 <br><br>It is also possible to set new direction by a click on <b>Azimuth display</b>, type a new direction value and press <b>Enter</b> or use  <b>mouse wheel</b> to select degrees.
 <br>One wheel step is one degree. If you keep <b>Shift key</b> pressed while turning mouse wheel the step will be 10 degrees. If <b> Ctrl key</b> is pressed instead step will be 100 degrees.
 <br>If you have used mouse wheel it is enough to move mouse away from Azimuth reading to get rotor turning. No enter keypress is needed then.

--- a/help/h31.html
+++ b/help/h31.html
@@ -42,7 +42,7 @@
     <li>Frequency</li>
     <li>Callsign</li>
     <li>Mode</li>
-    <li>Singnal streght</li>
+    <li>Signal strength</li>
     <li>Is DX Lotw or/and Eqsl user</li>
     <li>DX status against your log: New county, new Band, new Mode</li>
     </ul>

--- a/help/h32.html
+++ b/help/h32.html
@@ -34,7 +34,7 @@
 <p>
  Grayline map has speed button at top right corner that opens a popup menu containing:
    <ul>
-   <li> <b>Connect to RBN</b> If autoconnect is not seleceted, see: <a href="h1.html#ch6">RBN support</a>, the connect and disconnect to RBN can be done here.</li>
+   <li> <b>Connect to RBN</b> If autoconnect is not selected, see: <a href="h1.html#ch6">RBN support</a>, the connect and disconnect to RBN can be done here.</li>
    <li> <b>Link to RBNMonitor</b> This is alternative to RBN connection and will use same connection as RBN monitor window has (if connected).</li>
    <li> <b>Show statusbar</b> Shows connection or linking state</li>
    <li> <b>Show ShortPath</b> By default Grayline map will show straight line from your station (from your locator defined) to station you enter to NewQSO/callsign. 

--- a/help/h34.html
+++ b/help/h34.html
@@ -40,11 +40,11 @@
 
     <br><h3>eQSL upload</h3></p>
     <p>
-    You find eQSL up and donwload from <b>QSO list/QSL</b> menu.<br>
+    You find eQSL up and download from <b>QSO list/QSL</b> menu.<br>
     <div align=justify><strong>Select the QSO records</strong> you want to confirm.
     Either whole log, or just files that have never been uploaded (that is the normal operation).
     <br>Be sure that<b> QTH Nickname </b> is the same you defined at eQSL website setup.
-   <br>Now click the <b>Upload</b> button. A message will appear to inform you about ulpload progress.<br>
+   <br>Now click the <b>Upload</b> button. A message will appear to inform you about upload progress.<br>
     From message you will see what is the adif file that were used for upload. It is saved and can be used afterwards if needed.
     <br> You see also how many records were added to eQSL.
     </p>
@@ -56,7 +56,7 @@
     <br>
     <img src="img/eqsl2.png"><br><br>
     Set the <b>date after</b> to request QSL records. This is normally good to keep in current year for daily use.
-    It keep the download and porcessing fast. Every now and then set te date more back to past to see possible late confirms.
+    It keep the download and processing fast. Every now and then set the date more back to past to see possible late confirms.
     <br>Be sure that<b> QTH Nickname </b> is the same you defined at eQSL website setup.
     If you press <b>Download  data from eQSL website</b> a progress
     indicator is displayed in <b>Progress</b> window.

--- a/help/h5.html
+++ b/help/h5.html
@@ -48,7 +48,7 @@
                 check the port settings - ttyS* or ttyUSB* number and <strong>all</strong>
                 communication parameters.
             </li>
-            <li><strong>Is the poll rate set too fast?</strong> Try a lower setting (higher number). Your qsos usually lasts longer than 5 seconds so even ẃith value 5000 the right frequency is there before you save your qso.</li>
+            <li><strong>Is the poll rate set too fast?</strong> Try a lower setting (higher number). Your qsos usually last longer than 5 seconds so even ẃith value 5000 the right frequency is there before you save your qso.</li>
         </ul>
         <br>
         <p align=center><img src=img/line.png></p>
@@ -82,9 +82,9 @@ Error: ssl_none</pre>
     <p align=center><img src=img/line.png></p>
     <a name="ah41"><em><strong>CQRLOG is very slow or does not run at all</strong></em>
         <ul>
-            <p align="justify">The accompanying problem is an abonormally high CPU load. The problem
+            <p align="justify">The accompanying problem is an abnormally high CPU load. The problem
                 is instant polling of a non-existent (not responding) radio. Your radio setup is
-                probably incorrect. Try to downoad a default cqrlog.cfg from the CQRLOG web site
+                probably incorrect. Try to download a default cqrlog.cfg from the CQRLOG web site
                 (www.cqrlog.com) and copy it into your /cqrlog/log_data folder. Backup your old
                 cqrlog.cfg before if you want. The default cqrlog.cfg redirects all polling to the
                 hamlib dummy radio (model=1] and the high CPU load should return to its

--- a/help/h7.html
+++ b/help/h7.html
@@ -67,7 +67,7 @@
     <br><br>
     <div align=justify><strong>1. Select the QSO records</strong> you want to confirm.
 
-        A suitable choice is a filter for date, QSL received etc. But be aware that QSO with propagtion mode "RPT - repeater" are filtered, due to the LoTW rule that repeater QSO doesn't count.<br><br>
+        A suitable choice is a filter for date, QSL received etc. But be aware that QSO with propagation mode "RPT - repeater" are filtered, due to the LoTW rule that repeater QSO doesn't count.<br><br>
         Now, there are two possibilities:
         <blockquote>
             <strong>I. Export the selected records</strong> to a local ADIF file. This is useful
@@ -95,7 +95,7 @@ website by pressing the Upload button</pre>
                 Now click the <em>Upload</em> button. A message<br>
 <pre>Uploading file ...
 Size: xxxxx
-Uploading was succesful<br></pre>
+Uploading was successful<br></pre>
         </blockquote>
         This procedure can be checked in the following way: in the /cqrlog/lotw folder there should
         appear two new files - an ADIF file named date_time.adi (where date and time corresponding

--- a/help/index_right.html
+++ b/help/index_right.html
@@ -122,7 +122,7 @@ and
                 <img src="img/exc.png"></td>
             <td bgcolor=ffffcc valign="top" align="justify"><strong><font color="red">WARNING!</font></strong>
                 cwdaemon use may result in <strong>sloppy CW at speeds above 30 WPM</strong>.
-                Use Winkey (by K1EL) if possible or your <strong>kernel must be modified to minimalize the
+                Use Winkey (by K1EL) if possible or your <strong>kernel must be modified to minimize the
                     latency</strong>. Tickless, high resolution timer and 1000 Hz sampling rate must be used.
                 Recommended for very experienced linux users only!
             </td>

--- a/help/qslimperr.html
+++ b/help/qslimperr.html
@@ -32,7 +32,7 @@
 Sometimes you find some "QSO not found" errors in LoTW or eQSL download. There are some reasons for that.<br>
 <ul>
 <li>QSO did not complete and you did not log that, but the opponent station thinks it is completed.</li>
-<li>You forgot to set remote on and logged qso only to your digital mode program. (You find qso from it's log)
+<li>You forgot to set remote on and logged qso only to your digital mode program. (You find qso from its log)
 <li>People type in their old paper logs to computer and upload them to LoTW/eQSL. QSO is ok but it is somewhere in your earlier paper logs.</li>
 <li>QSO may be an SWL report waiting to confirm via eQSL</li>
 </ul><br>
@@ -57,7 +57,7 @@ If you do not want to import all error qsos, or want to send a confirmation to e
 LoTW error file looks very similar, but has some text more for every qso record.
 <br><br>When you edit file do not touch the header of the file. Lines from 1 to 8 where header ends with "EOH" (End Of Header).
 <br>You can remove qso records that you do not want to import to your log by removing all record's lines. For example here remove the F-21716 qso means
- to remove lines 10 - 23. Adif tag &lt;APP_CQRLOG_ERROR:XXX specifies error label data lenght but it is actually not used for anything.
+ to remove lines 10 - 23. Adif tag &lt;APP_CQRLOG_ERROR:XXX specifies error label data length but it is actually not used for anything.
  <br>There are also other comments starting with &lt;APP_CQRLOG_NOTE that are just for information.
  <br><br><b>NOTE:</b>RST sent/rcvd are swapped to be ready for import to your log. I.E. senders RST_sent is placed to (your) RST_rcvd already.
  <br>(This concerns mainly eQSL as LoTW does not handle RSTs)
@@ -68,7 +68,7 @@ Cqrlog fixes error record if adif tag APP_EQSL_SWL is found.<br>
 CONTEST_ID is changed to talk about "SWL" instead of "Qso". Then all imported SWL cards from this error file can be found fast by selecting Contest filter "SWL_was_not_found_in_log!"
 <br>RST_SENT is swapped to RST_RCVD as SWLs do report how heard you in RST_SENT tag.
 <br>RST_SENT is replaced as "SWL". This is your "report" for swl.
-<br>SWLs should report who they heard you working with. They should use QSOMSG adif tag. This is swapped to tag COMMENT to show up in "Comment for qso" in cqrlog. Without this informaton you can concider that swl report is not valid.
+<br>SWLs should report who they heard you working with. They should use QSOMSG adif tag. This is swapped to tag COMMENT to show up in "Comment for qso" in cqrlog. Without this information you can consider that swl report is not valid.
 <br><br>If you want to upload a confirmation for SWL  after importing error file to cqrlog change "eQSL qsl sent" value with QSL list/File/Group edit from Y to N to cause upload to eQSL. This might be handy if you want to check several swl cards before uploading. Be careful not to touch "LoTW qsl sent" value as LoTW does not support SWLs. 
 <br><br>Same way, if you want to confirm an old paper log qso now added to cqrlog on next upload/"Export only QSOs which has never been uploaded"
 just change the eQSL and/or LoTW qsl set from value Y to N</p> 

--- a/help/wkdgrid.html
+++ b/help/wkdgrid.html
@@ -15,7 +15,7 @@
 </img>
 <br/>Worked grids map gives graphical view of locators worked in addition of cqrlog's own text based information. As for JT-mode workers this map us useful also for V-,U-,SHF workers who are collecting locator grids.<br/>
 <br/>Map shows worked grids on selected band and mode, or all bands and modes. Or you can select ”Follow rig” and then map follows band and mode that rig is sending to cqrlog via rigctld.<br/>
-<br/>Confirmed main grids show up as green, unconfirmed as red. Subgrids show up with dots inside main grid with coresponding colors. You can click any main grid to zoom it. Again colors tell you about confirmation.</p>
+<br/>Confirmed main grids show up as green, unconfirmed as red. Subgrids show up with dots inside main grid with corresponding colors. You can click any main grid to zoom it. Again colors tell you about confirmation.</p>
 <p ><img src="img/wkdgrid10.png" name="10" width="549" height="339">
 </img>
 <br/>Clicking again on zoomed main grid brings back whole map.

--- a/help/wsjt.html
+++ b/help/wsjt.html
@@ -41,7 +41,7 @@
     </ul>
 <p>From New QSO / File select 'Remote mode for wsjt'</p>
 <img src="img/wsjt2.png" name="2" width="144" height="238" border="0"/>
-<p> Remote mode for WSJT-X-communication is made via UDP dtatgrams that and is supported from WSJT-X 1.5.0 program upwards.<br/>
+<p> Remote mode for WSJT-X-communication is made via UDP datagrams that and is supported from WSJT-X 1.5.0 program upwards.<br/>
 Cqrlog supports WSJT-X UDP remote mode since version 1.9.1 
 </p>
 <img src="img/wsjt18.png" name="18" width="144" height="137" border="0"/>
@@ -90,28 +90,28 @@ In some cases your TX may be shut down after you have first tried to answer some
 </img></p><p>
 If you do not want any information texts, just alerts, you can check <b>nTxt</b> to prevent text updates and minimize window size horizontal or drop it completely down with (<b>_</b>) while alerts and follow are still working.
 </br></br>
-Selecting <b>DX</b> checkbox cqrlog fiters away all calls that are from same continent as you are. This works both in Cq monitor and MAP mode<br>
+Selecting <b>DX</b> checkbox cqrlog filters away all calls that are from same continent as you are. This works both in Cq monitor and MAP mode<br>
 
 
 
 </p><p><img src="img/wsjt21.png" name="21" width="363" height="282">
 </img></p>
 Checking <b>“flw”</b> new part of monitor opens. This will make easier to follow a DX who does not stay on same frequency, but jumps around answering to callers.
-</br>Type in a callsing. The callsign is checked to be written in upcase letters and spaces are trimmed away. Pressing RETURN at the end of typing turns <strong>Follow</strong> button ON (green).
+</br>Type in a callsign. The callsign is checked to be written in upcase letters and spaces are trimmed away. Pressing RETURN at the end of typing turns <strong>Follow</strong> button ON (green).
 You can also toggle  <b>Follow</b> button ON and OFF by mouse clicks (turns green/red) 
 </br>When <b>Follow</b> turns ON then during next decoding periods follow line (at right side of follow call edit)
 shows decoded lines where that <b>followed callsign is the originating (2nd) callsign</b> and the line is <b>not CQ</b> or not <b>to YOUR Call</b>(destination). That box uses same font and size as CQ-monitor.
 </br>You can also paint any call from WSJT-X main window or CQ-monitor, drag it over Follow callsign field, and drop it there. Follow callsign field can have previous call (it is erased) or empty.
  Dropping also activates <b>Follow button</b> ON (turns green).
 </br></br>Line contains:  <b>decoding_period_time</b> | <b>snr</b>  | <b>delta_frequency</b>  | <b>the_message</b>.  
- </br>Alerts are not connected  to this line. Follow and flw states and callsing are saved over program restart.
+ </br>Alerts are not connected  to this line. Follow and flw states and callsign are saved over program restart.
  </br>Line color turns silver gray from default color (black) when corresponding response period is over.
  </br>This will make easier to follow a DX who does not stay same frequency and jumps around answering to callers.
  </br>Double click on followed line loads Std messages to wsjt-x (but does not fire TX). This works with Wsjt-x 1.9.0-rc3 and up. 
  </br>
  </br>CQ-monitor has known problem of color printing (richmemo unit) that causes CPU load to grow slowly during online hours. For so far solution for this  has not been found.
  </br>
- </br>How ever you can drop CPU load by just setting NewQSO/File/remote mode for wsjt to OFF and then immediately back to ON. This releases previously used memory and CPU load returns to normal and is a very fast fix that can be done during a reciving period.
+ </br>How ever you can drop CPU load by just setting NewQSO/File/remote mode for wsjt to OFF and then immediately back to ON. This releases previously used memory and CPU load returns to normal and is a very fast fix that can be done during a receiving period.
  </br>
  </br>CQ-monitor has now 30 lines (if “no history” unchecked). Automatic scrollbars are visible if needed.
 
@@ -122,7 +122,7 @@ shows decoded lines where that <b>followed callsign is the originating (2nd) cal
 	<li/> mode symbol. Same that wsjt-x uses.</br>
 	<li/> callsign with color and low/Upcase coding.</br>
 	<li/> locator grid with color and low/Upcase coding </br>
-	<li/> caller’s country name (cut to 15chrs) Overlayed with “<font color="#ff0066"><b>CQ:xx</b></font>”
+	<li/> caller’s country name (cut to 15chrs) Overlaid with “<font color="#ff0066"><b>CQ:xx</b></font>”
 	 and <font color="#ff0066"><b>different color</b></font> if station is calling directed CQ like: CQ DX, AS, AF, OC, NA, SA .. or CQ CALLSIGN DX.<br/>
 	<font color="#ff0066"><b>This is set as warning for you </b></font> to check that you are in directed area before answering to his/her CQ.
 	<br/>I.E. <font color="#ff0066"><b>In case of CQ DX you should be in DIFFERENT CONTINENT as the CQ caller</b></font>
@@ -134,7 +134,7 @@ shows decoded lines where that <b>followed callsign is the originating (2nd) cal
 	<li/> information of DXCC status compared to your logged qsos.</br>
 </ul></p>
 <p>If you want to see a bit more in country name you may try to create this script and run it from console. Remember to set execute bit (chmod +x) to script file to get it running. This script will fix some long country names and change comma-space combinations
- to dot (as CQ-monitor cuts contry name if it sees comma). That way you will see a bit more info in 15chr long country name of CQ-monitor.
+ to dot (as CQ-monitor cuts country name if it sees comma). That way you will see a bit more info in 15chr long country name of CQ-monitor.
 <pre>
 --------------cut here---------------------------------------------------------
 #/bin/sh
@@ -222,22 +222,22 @@ How ever if alerts were <strong>on</strong> they stay <strong>on</strong>. Excep
 </p><p><strong>dB</strong> selection shows station snr report, like it shows up in Band Activity of wsjt-x.
 </br><strong>ColorBackCQs </strong> selection work so that all <strong>CQs</strong> are printed (colored) <strong>back to Wsjt-x</strong> Band Activity window and <strong>rest of the traffic</strong> will appear to Wsjt-x <strong>band map</strong>.
 </p>
-If you have Wsjt-x devel version 1.9.0-rc3 r8592 (or higher) <strong>color</strong>ing is sent <strong>back</strong> to Wsjt-x with same choosed colours as CQ-monitor uses. 
+If you have Wsjt-x devel version 1.9.0-rc3 r8592 (or higher) <strong>color</strong>ing is sent <strong>back</strong> to Wsjt-x with same chosen colours as CQ-monitor uses. 
 How ever there are some limitations compared to CQ-monitor:
 </br><li><strong>color back</strong> can not change lower case letters of Band Activity line in case call or locator is worked. Just font color is changed</li>
 <li><strong>color back</strong> can not print locator with 2 colors in case main grid is worked, but subgrid(numerical part) is not. In that case locator will have maingrid color and yellow background.</li>
 <li><strong>color back</strong> will paint both "CQ" and cq-direction with "CQ ext" color if CQ is not directed to you.</li>
 </br>
-With older versions of wsjt-x this causes unkonwn command error and then <b>nTxt</b> should not be checked until you get newer version of Wsjt-x.
+With older versions of wsjt-x this causes unknown command error and then <b>nTxt</b> should not be checked until you get newer version of Wsjt-x.
 </br></p><p>
 <img src="img/wsjt34.png" name="34" width="353" height="282">
 </img>
 <img src="img/wsjt33.png" name="33" width="353" height="282">
 </img></p><p>
-If you are able to use <strong>color back</strong> feature you may want to change some Wsjt-x color settings and maybe check "CQ only" checbox at Main window. Selecting also font to some of "mono"+ "bold" ones from "Configuration/General/Decoded Text Font" could make a better view.</p>
+If you are able to use <strong>color back</strong> feature you may want to change some Wsjt-x color settings and maybe check "CQ only" checkbox at Main window. Selecting also font to some of "mono"+ "bold" ones from "Configuration/General/Decoded Text Font" could make a better view.</p>
 <p>
 <ul><strong>A word of warning:</strong></ul>  In current Wsjt-x devel version 1.9.0-rc3 r8592 selecting <strong>CQ only</strong> will <strong>disable Generating of Std messages</strong> by double click either <strong>followed</strong> message line or Wsjt-x <strong>map's non-cq lines</strong>.
-</br>This <strong>does not</strong> happen if <strong>CQ only</strong> is <strong>uncheked</strong>. Unchecking it after not working double click does not help if Band Activiy window does not contain that line from which  <strong>Wsjt map</strong> or <strong>follow</strong> line was created.
+</br>This <strong>does not</strong> happen if <strong>CQ only</strong> is <strong>unchecked</strong>. Unchecking it after not working double click does not help if Band Activity window does not contain that line from which  <strong>Wsjt map</strong> or <strong>follow</strong> line was created.
 </br>That is because Wsjt-x must found equal line from Band activity and UDP command that produces Std General messages creation. 
 </br> This may change in future devel versions or in official release of 1.9.0, but at the moment you should be aware of that.</p>
 <p><strong>Hint:</strong> If you have had <strong>CQ only</strong> checked and you want to load Std message from just appeared line from <strong>Wsjt map</strong> or <strong>follow line</strong> uncheck <strong>CQ only immediately</strong> during time that entry is not grayed (ongoing period).
@@ -249,7 +249,7 @@ If you are able to use <strong>color back</strong> feature you may want to chang
 </br>Pressing this button will send a FreeTextMessage to WSJT-X containing "TU HISNAME 73" Where HISNAME is text from NewQSO/Name field. This will not start TX.
 </br>FreeTextMessage length is limited to 13 characters. "Tu " and " 73" will take 6 of them. So name can be only 7 char long. If it is longer it is not sent to WSJT-X and button disappears after pressing to indicate that name is too long.
 </br>Button disappears also on next decode when NewQSO/Name becomes empty. If you do not like to use generated FreeTextMessage you can double click WSJT-X's button <strong>TX5</strong> to get back  standard "CALL MYCALL 73" message.
-</br>This button is made just for testing reply-UDP messages as new WSJT-X will use more of these kind of messages, like callsing coloring in Band activity window by external request.
+</br>This button is made just for testing reply-UDP messages as new WSJT-X will use more of these kind of messages, like callsign coloring in Band activity window by external request.
 </p>
 <h3><a name="w2"></a>Colors &amp; fonts</h3>
 <p>
@@ -343,7 +343,7 @@ text found from monitor line <br/>
 # // 'call'= text fits to the
 callsign<br/>
 # // create files you want to be played<br/>
-# scirpt
+# script
 is seeking names with '.wav' suffix! Change if needed <br/>
 #select
 audio card(if needed) and play alert message</p>


### PR DESCRIPTION
This PR fixes some small errors in the help files.
I didn't replace the lower case "qsl", "qso", "qth" with upper case because it would double the size of this diff for little gain.

I reverted an automatic fix by `codespell` in `help/sql_console.html` where it would replace "releas" with "release" because that's the actual field name in `src/dData.lfm`
```
CREATE TABLE version (
            major INTEGER DEFAULT 0,
            minor INTEGER DEFAULT 9,
            releas INTEGER DEFAULT 4
);
```

`codespell` could be run also on the source files making it to ignore some words like "releas" but there is still the risk of breaking the code. For example the following command lists all the word that would be changed if you run it add a `--write-changes` option (and `--interactive=2` to let you choose when there is more than one choice):
`codespell --ignore-words-list=ans,dout,release,ro,ser,te --skip=./ctyfiles/*,./members/*,./zipcodes/* --summary`
however there are probably more words to ignore and directories to skip.