### PR TITLE
Allow installation to /usr/local or ~/.local

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -31,6 +31,7 @@ Legend:
   - cabrillo export (Saku, OH1KH)
   - docker build fixes (Dawid, SQ6EMM)
   - microwave band fixes (Dawid, SQ6EMM)
+  - fix QSO list display when using dark theme (George, N3GB)
   
 2.5.2 (2021-02-12)
   # some code refactoring

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,7 @@ Legend:
 --------------------
 2.6.0 (2022-05-29)
   #some code refactoring
+  #Easier to install into /usr/local or ~/.local (N3GB)
   + new button "URL" to row below "Comment to callsign" (Saku, OH1KH)  
   + many improvements to working with WSJTX (Saku, OH1KH)
   + Clear RIT after saving QSO cleats also XIT (Saku, OH1KH)

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,12 @@
 CC=lazbuild
 ST=strip
-datadir  = $(DESTDIR)/usr/share/cqrlog
-bindir   = $(DESTDIR)/usr/bin
-sharedir = $(DESTDIR)/usr/share
+# Set default path header for installation. Can be changed by
+#  environment variable or CLI
+DESTDIR  = /usr
+#
+datadir  = $(DESTDIR)/share/cqrlog
+bindir   = $(DESTDIR)/bin
+sharedir = $(DESTDIR)/share
 tmpdir   = /tmp
 
 cqrlog: src/cqrlog.lpi
@@ -18,8 +22,8 @@ clean:
 	rm -rf src/backup
 	rm -f -v src/richmemo/*.o src/richmemo/*.ppu src/richmemo/gtk2/*.ppu src/richmemo/gtk2/*.o
 	rm -f -v tools/adif_hash_generator tools/adif_hash_generator.lpi tools/adif_hash_generator.lps
-	rm -rf /tmp/.lazarus
-	
+	rm -rf $(tmpdir)/.lazarus
+
 install:
 	install -d -v         $(bindir)
 	install -d -v         $(datadir)
@@ -82,4 +86,3 @@ cqrlog_qt5: src/cqrlog.lpi
 cqrlog_qt5_debug: src/cqrlog.lpi
 	$(CC) --ws=qt5 --pcp=$(tmpdir)/.lazarus src/cqrlog.lpi
 	gzip tools/cqrlog.1 -c > tools/cqrlog.1.gz
-	

--- a/src/changelog.html
+++ b/src/changelog.html
@@ -9,6 +9,7 @@
     <hr>
     <br>
     <ul style="list-style: square;text-align:left; color: green;" >
+    <li>QSO list: Fix display of #QSOs and #DXCC cfmd when using dark theme</li>
     <li>eQSL download: Fixed the stuck up caused by eQSL starting to add one more empty line at the end of downloaded file</li>
     <li>Contest: Inform remote mode 'on' when saving manual entered qso. Multimode contests like<br>
 	NAC (CW,Phone,MGM) it may happen that remote is left on when jump from FT8 to CW/Phone.<br>

--- a/src/fMain.lfm
+++ b/src/fMain.lfm
@@ -344,7 +344,6 @@ object frmMain: TfrmMain
       Anchors = [akLeft, akBottom]
       BorderSpacing.Left = 10
       Caption = '10000'
-      Font.Color = clBlack
       Font.Style = [fsBold]
       Layout = tlBottom
       ParentColor = False
@@ -410,7 +409,6 @@ object frmMain: TfrmMain
       AutoSize = False
       BorderSpacing.Right = 10
       Caption = '150'
-      Font.Color = clBlack
       Font.Style = [fsBold]
       Layout = tlBottom
       ParentColor = False


### PR DESCRIPTION
Make it easier to install cqrlog into /usr/local (or elsewhere) with correct sub-directories.

Also fixes QSOlist display for dark themes