### PR TITLE
Modernize the AppStream metadata

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ install:
 	install -d -v         $(sharedir)/pixmaps/cqrlog
 	install -d -v         $(sharedir)/icons/cqrlog
 	install -d -v         $(sharedir)/applications
-	install -d -v         $(sharedir)/appdata
+	install -d -v         $(sharedir)/metainfo
 	install -d -v         $(sharedir)/man/man1
 	install    -v -m 0755 src/cqrlog $(bindir)
 	install    -v -m 0755 tools/cqrlog-apparmor-fix $(datadir)/cqrlog-apparmor-fix
@@ -65,7 +65,7 @@ install:
 #	install    -v -m 0644 images/icon/256x256/*   $(datadir)/images/icon/256x256/
 #	install    -v -m 0644 images/*   $(datadir)/images/
 	install    -v -m 0644 tools/cqrlog.desktop $(sharedir)/applications/cqrlog.desktop
-	install    -v -m 0644 tools/cqrlog.appdata.xml $(sharedir)/appdata/cqrlog.appdata.xml
+	install    -v -m 0644 tools/com.cqrlog.cqrlog.appdata.xml $(sharedir)/metainfo/com.cqrlog.cqrlog.appdata.xml
 	install    -v -m 0644 images/icon/32x32/cqrlog.png $(sharedir)/pixmaps/cqrlog/cqrlog.png
 	install    -v -m 0644 images/icon/128x128/cqrlog.png $(sharedir)/icons/cqrlog.png
 	install    -v -m 0644 src/changelog.html $(datadir)/changelog.html

--- a/tools/com.cqrlog.cqrlog.appdata.xml
+++ b/tools/com.cqrlog.cqrlog.appdata.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Copyright 2017 Daniel Rusek <mail@asciiwolf.com> -->
 <component type="desktop">
-  <id>cqrlog.desktop</id>
+  <id>com.cqrlog.cqrlog</id>
   <project_license>GPL-2.0</project_license>
   <metadata_license>CC0-1.0</metadata_license>
   <name>CQRLOG</name>
+  <developer_name>Petr Hlozek</developer_name>
   <summary>Advanced logging program for hamradio operators</summary>
   <description>
     <p>
@@ -16,8 +16,12 @@
     </p>
   </description>
   <url type="homepage">https://www.cqrlog.com/</url>
+  <launchable type="desktop-id">cqrlog.desktop</launchable>
   <screenshots>
-    <screenshot type="default">https://camo.githubusercontent.com/4b8b103448e282e79faa249cc2a3a26e5cfcc25b/68747470733a2f2f6371726c6f672e636f6d2f696d616765732f75736572732f6f6b326371722e706e67</screenshot>
+    <screenshot type="default">
+      <image>https://camo.githubusercontent.com/44596096b3e7dbb320d6cbca9ea6bbe3bc66494aa6c3cb0bbcf3b3dd270d587f/68747470733a2f2f6371726c6f672e636f6d2f696d616765732f75736572732f6f6b326371722e706e67</image>
+    </screenshot>
   </screenshots>
-  <update_contact>mail@asciiwolf.com</update_contact>
+  <content_rating type="oars-1.1" />
+  <update_contact>petr@petrhlozek.cz</update_contact>
 </component>


### PR DESCRIPTION
This PR makes the CQRLOG AppStream metadata more modern and accepted by current parsers.

Important changes:
- Remove my _copyright_ comment.
- Use proper rDNS AppStream app id.
- Add _launchable_ tag that matches the desktop file name.
- Install the metadata into _metainfo_ directory instead of a deprecated _appdata_ one.
- Add _developer_name_ tag that is required nowadays.
- Add _content_rating_ that is also required by some parsers nowadays.
- Fix screenshot url and wrap it into a proper _image_ tag.
- Fix the _update_contact_ tag to contain actual developer e-mail instead of mine.

@ok2cqr Feel free to review and merge. :-)

Here is another example of a modern AppStream metadata file: https://github.com/gqrx-sdr/gqrx/blob/master/dk.gqrx.gqrx.appdata.xml