### PR TITLE
Fix build with FPC 3.2.4

### DIFF
--- a/src/lnet/lib/lcommon.pp
+++ b/src/lnet/lib/lcommon.pp
@@ -461,7 +461,11 @@ end;
 
 function TZSeconds: Integer; inline;
 begin
+{$IF FPC_FULLVERSION > 30202}
+  Result := unix.TZSeconds;
+{$ELSE}
   Result := unixutil.TZSeconds;
+{$ENDIF}
 end;
 
 {$ENDIF}

--- a/src/lnet/lib/sys/osunits.inc
+++ b/src/lnet/lib/sys/osunits.inc
@@ -4,6 +4,9 @@
 
 {$ifdef UNIX}
   BaseUnix, NetDB,
+  {$IF FPC_FULLVERSION > 30202}
+    Unix,
+  {$ENDIF}
 {$endif}
 
 {$ifdef NETWARE}


### PR DESCRIPTION
FPC 3.2.4-rc1 is now available. TZSeconds has been moved from the 'UnixUtil' unit to 'Unix'.